### PR TITLE
fix: Add start_date_limit to historical

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,8 +51,11 @@
 - Eliminate tensorflow import warnings from `import loop`
 - Allow `uel` uel to move `round_results[_preds]` from `sfm.model` to `uel.preds` for post run use
 
-## v0.8.6 on 5th of June, 2025
+## v0.8.6 on 6th of June, 2025
 - Generalize `reports.results_df` to work with any experiment using `get_historical_klines`
 - Use `x` for axis label in `reports.confusion_matrix_plus`
 - Add liquidity-based signals to `get_historical_klines`
 - Add `start_date_limit` to `get_historical_klines` for limiting the start date of the data
+
+## v0.8.7 on 6th of June, 2025
+- Add `start_date_limit` as an input parameter to `historical.get_historical_klines`

--- a/loop/data.py
+++ b/loop/data.py
@@ -40,20 +40,26 @@ class HistoricalData:
 
         self.data_columns = self.data.columns
 
-    def get_historical_klines(self, n_rows: int = None, kline_size: int = 1) -> None:
+    def get_historical_klines(self,
+                              n_rows: int = None,
+                              kline_size: int = 1,
+                              start_date_limit: str = None) -> None:
         
         '''Get historical klines data from Binance API
 
         Args:
             n_rows (int): Number of rows to be pulled
             kline_size (int): Size of the kline in seconds
+            start_date_limit (str): The start date of the klines data
 
         Returns:
             self.data (pl.DataFrame)
     
         '''
 
-        self.data = get_klines_data(n_rows=n_rows, kline_size=kline_size)
+        self.data = get_klines_data(n_rows=n_rows,
+                                    kline_size=kline_size,
+                                    start_date_limit=start_date_limit)
 
         self.data_columns = self.data.columns
 

--- a/loop/utils/get_klines_data.py
+++ b/loop/utils/get_klines_data.py
@@ -5,7 +5,7 @@ from typing import Optional
 
 def get_klines_data(n_rows: Optional[int] = None,
                     kline_size: int = 1,
-                    start_date: str = None,
+                    start_date_limit: str = None,
                     show_summary: bool = False) -> pl.DataFrame:
     
     '''Get 1 second klines data based on Binance raw trades data. Returns either 
@@ -14,7 +14,7 @@ def get_klines_data(n_rows: Optional[int] = None,
     Args:
         n_rows (int | None): if not None, fetch this many latest rows instead.
         kline_size (int): the size of the kline in seconds.
-        start_date (str): the start date of the klines data.
+        start_date_limit (str): the start date of the klines data.
         show_summary (bool): if a summary for data is printed out.
 
     Returns:
@@ -34,8 +34,8 @@ def get_klines_data(n_rows: Optional[int] = None,
     else:
         limit = ''
 
-    if start_date is not None:
-        start_date_limit = f"WHERE datetime >= toDateTime('{start_date}') "
+    if start_date_limit is not None:
+        start_date_limit = f"WHERE datetime >= toDateTime('{start_date_limit}') "
     else:
         start_date_limit = ''
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='loop',
-    version='0.8.6',
+    version='0.8.7',
     packages=find_packages(),
     install_requires=[
         "pandas>=2.0.0",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added an optional start date limit parameter when retrieving historical klines data, allowing users to specify the earliest date for data retrieval.
- **Documentation**
	- Updated the changelog to reflect the new version and document the addition of the start date limit parameter.
- **Chores**
	- Bumped the package version to 0.8.7.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->