### PR TITLE
test: Correctness and efficiency of lazy evaluation of polars datafra…

### DIFF
--- a/loop/tests/run.py
+++ b/loop/tests/run.py
@@ -13,6 +13,10 @@ from loop.tests.test_moving_average_correction_model import test_moving_average_
 from loop.tests.test_account_conviction import test_account_conviction
 from loop.tests.test_backtest_conviction import test_backtest_conviction
 from loop.tests.test_klines_data_maker_fields import test_klines_data_maker_fields
+from loop.tests.test_polars_lazy_evaluation import (
+    test_polars_lazy_evaluation_correctness,
+    test_polars_lazy_evaluation_performance,
+)
 
 tests = [
     test_klines_data_maker_fields,
@@ -25,6 +29,8 @@ tests = [
     #test_moving_average_correction,
     test_account_conviction,
     test_backtest_conviction,
+    test_polars_lazy_evaluation_correctness,
+    test_polars_lazy_evaluation_performance,
 ]
 
 setup_cleanup_handlers()

--- a/loop/tests/test_polars_lazy_evaluation.py
+++ b/loop/tests/test_polars_lazy_evaluation.py
@@ -1,0 +1,105 @@
+import timeit
+import polars as pl
+
+from loop.indicators import roc, atr, ppo, wilder_rsi
+from loop.features import vwap, kline_imbalance
+from loop.tests.utils.get_data import get_klines_data
+
+
+def test_polars_lazy_evaluation_correctness():
+
+    data = get_klines_data()
+
+    transformations = {
+        'indicators': [
+            (roc, {'period': 12}),
+            (atr, {}),
+            (ppo, {}),
+            (wilder_rsi, {}),
+        ],
+        'features': [
+            (vwap, {}),
+            (kline_imbalance, {})
+        ],
+        'filters': [
+            ~pl.col('roc_12').is_null(),
+            ~pl.col('wilder_rsi_14').is_null()
+        ]
+    }
+
+    imperative_result = _imperative_evaluation(data.clone())
+    declarative_result = _lazy_evaluation(data.clone(), transformations)
+
+    assert imperative_result.shape == declarative_result.shape
+    assert set(imperative_result.columns) == set(declarative_result.columns)
+    assert imperative_result.equals(declarative_result)
+
+
+def test_polars_lazy_evaluation_performance():
+
+    data = get_klines_data()
+
+    transformations = {
+        'indicators': [
+            (roc, {'period': 12}),
+            (atr, {}),
+            (ppo, {}),
+            (wilder_rsi, {}),
+        ],
+        'features': [
+            (vwap, {}),
+            (kline_imbalance, {})
+        ],
+        'filters': [
+            ~pl.col('roc_12').is_null(),
+            ~pl.col('wilder_rsi_14').is_null()
+        ]
+    }
+
+    num_iter = 3
+    imperative_time = timeit.timeit(
+        lambda: _imperative_evaluation(data.clone()),
+        number=num_iter
+    ) / num_iter
+
+    declarative_time = timeit.timeit(
+        lambda: _lazy_evaluation(data.clone(), transformations),
+        number=num_iter
+    ) / num_iter
+
+    assert imperative_time > declarative_time * 1.25
+
+
+def _lazy_evaluation(data, config):
+
+    lazy_data = data.lazy()
+
+    if 'indicators' in config:
+        for func, params in config['indicators']:
+            lazy_data = lazy_data.pipe(func, **params)
+
+    if 'features' in config:
+        for func, params in config['features']:
+            lazy_data = lazy_data.pipe(func, **params)
+
+    if 'filters' in config and config['filters']:
+        combined_filter = config['filters'][0]
+        for filter_expr in config['filters'][1:]:
+            combined_filter = combined_filter & filter_expr
+        lazy_data = lazy_data.filter(combined_filter)
+
+    return lazy_data.collect()
+
+def _imperative_evaluation(data):
+
+    data = roc(data, period=12)
+    data = atr(data)
+    data = ppo(data)
+    data = wilder_rsi(data)
+    data = vwap(data)
+    data = kline_imbalance(data)
+
+    return data.filter(
+        ~pl.col('roc_12').is_null() &
+        ~pl.col('wilder_rsi_14').is_null()
+    )


### PR DESCRIPTION
Adds a test for validating correctness and performance benefits of lazy evaluation of multiple polars dataframe transformation

_(A short description of the change)_

## Checklist

- [x] I have successfully run `python loop/tests/run.py`
- [ ] I have updated `/docs` (if applicable)
- [ ] All functions have docstrings in line with [Writing Docstrings](https://github.com/Vaquum/Loop/blob/main/docs/Developer/Writing-Docstrings.md)
- [ ] I have updated `CHANGELOG.md` (if applicable)
- [x] I've added tests (if applicable)
- [ ] I've used an LLM to validate changes 
- [ ] I have removed examples, and other extranous comments added by LLMs
- [ ] I've added "Closes #x" where x is underlying ticket id


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a new test suite validating Polars lazy evaluation for both correctness and performance.
  * Ensures data parity with the imperative path (matching shapes, columns, and values).
  * Benchmarks average runtimes over multiple iterations and enforces at least a 25% speedup for the lazy path.
  * Integrated into the test runner to execute with the existing suite.
  * No changes to production behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->