### PR TITLE
docs: Create Making-Pull-Requests.md with PR guidelines

### DIFF
--- a/docs/Developer/Making-Pull-Requests.md
+++ b/docs/Developer/Making-Pull-Requests.md
@@ -8,7 +8,7 @@ We have PR reviews for every PR, but the responsibility is with the author of th
 
 Every PR must minimally involve successfully going through the following steps: 
 
-- [ ] I have reviewed full diff in “Files changed”)
+- [ ] I have reviewed full diff in “Files changed”
 - [ ] I left no unnecessary files in the changes
 - [ ] I ran `python tests/run.py` locally without errors (where applicable)
 - [ ] I updated `/docs` (if behavior/API/config/user/etc changed)


### PR DESCRIPTION
Added guidelines for making pull requests, including self-review and checklist items.

Before requesting for review, make sure to to look through the below carefully.

## What does this PR change?

_(A short description of the change)_

## Checklist

- [ ] I have successfully run `python tests/run.py`
- [ ] I have updated `/docs` (if applicable)
- [ ] All functions have docstrings in line with [Writing Docstrings](https://github.com/Vaquum/Limen/blob/main/docs/Developer/Writing-Docstrings.md)
- [ ] I have updated `CHANGELOG.md` (if applicable)
- [ ] I've added tests (if applicable)
- [ ] I've used an LLM to validate changes 
- [ ] I have removed examples, and other extranous comments added by LLMs
- [ ] I've added "Closes #x" where x is underlying ticket id
