### PR TITLE
[codex] switch Limen spot data to complete TDW view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -648,3 +648,7 @@
 - Remove legacy non-core dependencies (`matplotlib`, `seaborn`, `streamlit`, `plotly`, `ipython`, `mcp`, and `playwright`) from `pyproject.toml`
 - Replace temp-file based `Log.read_from_file()` loading with in-memory CSV parsing while preserving duplicate-header cleanup
 - Add regression coverage for file-backed log loading and whitespace trimming in `tests.run`
+
+## v1.53.0 on 13th of April, 2026
+
+- Switch Limen spot raw-trade and kline queries from `tdw.binance_trades` to `tdw.binance_trades_complete` so `HistoricalData` sees the daily overlay view while preserving finalized monthly history

--- a/limen/data/_internal/generic_endpoints.py
+++ b/limen/data/_internal/generic_endpoints.py
@@ -149,7 +149,7 @@ def query_klines_data(n_rows: int | None = None,
         db_table = 'FROM tdw.binance_futures_trades '
         id_col = 'futures_trade_id'
     else:
-        db_table = 'FROM tdw.binance_trades '
+        db_table = 'FROM tdw.binance_trades_complete '
         id_col = 'trade_id'
 
     query = (

--- a/limen/data/historical_data.py
+++ b/limen/data/historical_data.py
@@ -124,7 +124,7 @@ class HistoricalData:
         '''
 
         self.data = query_raw_data(
-            table_name='binance_trades',
+            table_name='binance_trades_complete',
             id_col='trade_id',
             select_cols=['trade_id', 'timestamp', 'price', 'quantity', 'is_buyer_maker'],
             month_year=month_year,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaquum_limen"
-version = "1.52.0"
+version = "1.53.0"
 description = "Bitcoin-first research and trading platform."
 readme = "README.md"
 authors = [


### PR DESCRIPTION
## What changed

- switch `HistoricalData.get_spot_trades()` from `tdw.binance_trades` to `tdw.binance_trades_complete`
- switch spot kline aggregation queries to `tdw.binance_trades_complete`
- bump the package version to `1.53.0`
- add a changelog entry for the spot-data source switch

## Why

Limen currently stops at the finalized monthly TDW table, which means it cannot see the open-month daily overlay. The new `tdw.binance_trades_complete` view preserves the finalized monthly history while extending coverage into the current open month.

## Validation

I benchmarked Limen-equivalent query shapes against both sources with the same ClickHouse path and only the table name changed.

- raw March day-level fingerprints: exact match, median `1.4562s` vs `1.4701s` (`+0.95%`)
- latest 10k raw trades on March 12, 2026: exact match, median `0.4702s` vs `0.5308s` (`+12.89%`)
- hourly klines on March 12, 2026: identical aside from machine-precision floating-point noise in `maker_volume`, median `1.5618s` vs `1.5885s` (`+1.71%`)
- hourly klines for March 10-16, 2026: same result pattern, median `1.6217s` vs `1.6111s` (`-0.65%`)
- five-minute klines on March 12, 2026: same result pattern, median `1.3344s` vs `1.3617s` (`+2.05%`)
- April 10, 2026 open-month hourly klines: monthly source returned `0` rows, complete view returned `24` hourly bars as expected

Repo-local check run for this PR:

- `python3 -m py_compile limen/data/historical_data.py limen/data/_internal/generic_endpoints.py`

## Notes

- futures paths are unchanged
- spot agg-trades paths are unchanged
