### PR TITLE
Clean HistoricalData docs wording

### DIFF
--- a/docs/Experiment-Manifest.md
+++ b/docs/Experiment-Manifest.md
@@ -141,7 +141,7 @@ Configure the test data source used when `LOOP_ENV='test'`.
 If `LOOP_ENV='test'` but no test data source is configured, Limen falls back to the production data source.
 
 That is why foundational SFDs can run locally with no explicit `data=` and still use the configured test data source by default when one is defined.
-To get deterministic, file-backed local behavior, configure `set_test_data_source()` with a pinned local fixture.
+To keep local runs lightweight, configure `set_test_data_source()` with explicit `kline_size` and `n_rows`.
 
 ## Pipeline Configuration
 

--- a/docs/Historical-Data.md
+++ b/docs/Historical-Data.md
@@ -1,6 +1,6 @@
 # Historical Data
 
-`HistoricalData` is Limen's stateful file-backed data surface. It now has exactly three public retrieval methods:
+`HistoricalData` is Limen's stateful file-backed data surface. It has exactly three public retrieval methods:
 
 - `get_spot_klines()`
 - `get_binance_file()`
@@ -19,21 +19,21 @@ data = historical.get_spot_klines(kline_size=3600, start_date_limit='2025-01-01'
 assert data is historical.data
 ```
 
-`HistoricalData` stays stateful for manifest compatibility, but the public methods now also return the loaded frame directly.
+`HistoricalData` stays stateful for manifest compatibility, and the public methods also return the loaded frame directly.
 
 ## Current Surface
 
 | Method | Backend | Returns | Typical use |
 |---|---|---|---|
-| `get_spot_klines()` | latest Hugging Face BTCUSDT 1m parquet snapshot | BTCUSDT spot klines as `pl.DataFrame` | most common experiment input |
+| `get_spot_klines()` | Hugging Face BTCUSDT 1m parquet dataset | BTCUSDT spot klines as `pl.DataFrame` | most common experiment input |
 | `get_binance_file()` | direct Binance ZIP/CSV archive | normalized Binance file contents as `pl.DataFrame` | source-native Binance trade files |
 | `get_any_file()` | local path or URL (`.parquet`, `.csv`, `.zip`) | loaded file contents as `pl.DataFrame` | test fixtures, local research files, remote datasets |
 
 ## `get_spot_klines()`
 
-`get_spot_klines()` now reads from the BTCUSDT 1-minute dataset published at [vaquum/binance_btcusdt_1m_klines](https://huggingface.co/datasets/vaquum/binance_btcusdt_1m_klines).
+`get_spot_klines()` reads from the BTCUSDT 1-minute dataset published at [vaquum/binance_btcusdt_1m_klines](https://huggingface.co/datasets/vaquum/binance_btcusdt_1m_klines).
 
-By default it resolves the latest snapshot automatically, then aggregates upward from the file when you request a larger interval.
+By default it reads that dataset and aggregates upward when you request a larger interval.
 
 ```python
 from limen.data import HistoricalData
@@ -49,7 +49,6 @@ Important rules:
 
 - sub-1-minute klines are not supported
 - `kline_size` must be a multiple of the source file interval
-- the current Hugging Face dataset does not include `median` or `iqr`, so those columns are not returned
 
 Returned columns:
 
@@ -106,7 +105,7 @@ It is the right choice for:
 
 ## Manifest Integration
 
-Most manifest-driven experiments should now use:
+Most manifest-driven experiments should use:
 
 - `HistoricalData.get_spot_klines` for production data
 - `HistoricalData.get_spot_klines` with a smaller `n_rows` and coarser `kline_size` for lightweight test runs

--- a/docs/Universal-Experiment-Loop.md
+++ b/docs/Universal-Experiment-Loop.md
@@ -22,7 +22,7 @@ The standard run path is the right starting point for most readers. The advanced
 
 ## First Real Run
 
-This is the most reliable local example because it uses the repo test CSV through the new file-backed ingestion path.
+This is the most reliable local example because it uses the file-backed spot-kline path with explicit `kline_size` and `n_rows`.
 
 ```python
 import limen
@@ -52,7 +52,7 @@ uel.experiment_confusion_metrics
 uel.experiment_backtest_results
 ```
 
-On a live local run over the file-backed test data, that produced:
+On a live local run over that file-backed input, that produced:
 
 - `uel.experiment_log` with one row per round
 - `uel.experiment_confusion_metrics` with one row per round

--- a/limen/data/README.md
+++ b/limen/data/README.md
@@ -45,7 +45,7 @@ data/
 ## Things to know
 
 - `HistoricalData` is stateful. Each `get_*` call mutates `self.data` and `self.data_columns`, and also returns the resulting `pl.DataFrame`.
-- `get_spot_klines()` is now file-backed and resolves the latest Hugging Face BTCUSDT 1-minute snapshot by default.
+- `get_spot_klines()` reads the Hugging Face BTCUSDT 1-minute dataset by default.
 - `get_binance_file()` normalizes millisecond timestamps automatically when the source file stores them as large integers.
 - `get_any_file()` is the generic loader for local paths and URLs.
 


### PR DESCRIPTION
## Summary
- remove time-bound and migration-story wording from HistoricalData docs
- keep the docs focused on the stable public contract
- fix the UEL example description to match the actual file-backed spot-kline path

## Validation
- docs-only change
- reviewed targeted wording changes locally