### PR TITLE
ci: publish releases to pypi

### DIFF
--- a/.github/workflows/pr_publish_pypi.yml
+++ b/.github/workflows/pr_publish_pypi.yml
@@ -1,0 +1,56 @@
+name: Publish Package to PyPI
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build_distribution:
+    name: Build Distribution
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout released tag
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.release.tag_name }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Install build tooling
+        run: python -m pip install --upgrade build
+
+      - name: Build package distributions
+        run: python -m build
+
+      - name: Upload distributions
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+
+  publish_to_pypi:
+    name: Publish Distribution to PyPI
+    needs: build_distribution
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Download distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: ${{ secrets.PYPI_USERNAME }}
+          password: ${{ secrets.PYPI_PASSWORD }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ tabpfn = ["tabpfn>=6"]
 
 [project.urls]
 Homepage = "https://vaquum.fi"
+Documentation = "https://docs.vaquum.fi/limen/"
 Repository = "https://github.com/vaquum/limen"
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
## What changed
- add a release-triggered GitHub Actions workflow that builds the package from the published release tag and publishes the distributions to PyPI using the existing `PYPI_USERNAME` and `PYPI_PASSWORD` secrets
- add the Limen docs URL to `[project.urls]` in `pyproject.toml` so PyPI can render a Documentation project link

## Why
Releases were being created without a matching package publication step, which meant shipping a GitHub release did not automatically update the PyPI package. This wires package publication directly to the release event so the published release and the published package stay in sync.

## Impact
Every published GitHub release will now build the package from its release tag and upload the resulting distributions to PyPI. The package metadata will also expose the docs site as a first-class project link.

## Validation
- built the package locally with `python -m build` in an isolated virtualenv
- confirmed the new workflow is scoped to `release.published`
- confirmed only `pyproject.toml` and the new workflow file are included in this change

## Notes
This PR intentionally leaves the existing `project.license` deprecation warning untouched because it predates this change and is unrelated to the PyPI release flow.