### PR TITLE
Stop publishing the coverage badge data branch

### DIFF
--- a/.github/workflows/pr_checks_tests.yml
+++ b/.github/workflows/pr_checks_tests.yml
@@ -55,6 +55,7 @@ jobs:
           mv .coverage coverage-artifacts/coverage.db
 
       - name: Upload coverage artifact
+        if: github.event_name == 'pull_request'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: coverage-data
@@ -83,34 +84,6 @@ jobs:
         run: mv coverage-artifacts/coverage.db .coverage
 
       - name: Publish coverage comment
-        uses: py-cov-action/python-coverage-comment-action@4c2eefcda8b94596768855a80ac94edc61aba669 # v3
-        with:
-          GITHUB_TOKEN: ${{ github.token }}
-
-  publish_coverage_badge_data:
-    name: Publish Coverage Badge Data
-    if: github.event_name == 'push'
-    needs: pr_checks_tests
-    runs-on: ubuntu-latest
-    permissions:
-      actions: read
-      contents: write
-
-    steps:
-      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
-        with:
-          persist-credentials: true
-
-      - name: Download coverage artifact
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
-        with:
-          name: coverage-data
-          path: coverage-artifacts
-
-      - name: Restore coverage data
-        run: mv coverage-artifacts/coverage.db .coverage
-
-      - name: Publish coverage badge data
         uses: py-cov-action/python-coverage-comment-action@4c2eefcda8b94596768855a80ac94edc61aba669 # v3
         with:
           GITHUB_TOKEN: ${{ github.token }}

--- a/README.md
+++ b/README.md
@@ -16,8 +16,7 @@
 <br />
 <div align="center">
   <a href="https://www.bestpractices.dev/projects/11898"><img src="https://www.bestpractices.dev/projects/11898/badge" alt="OpenSSF Best Practices" /></a>
-  <a href="https://scorecard.dev/viewer/?uri=github.com/Vaquum/Limen"><img src="https://api.scorecard.dev/projects/github.com/Vaquum/Limen/badge" alt="OpenSSF Scorecard" /></a>
-  <a href="https://github.com/Vaquum/Limen/tree/python-coverage-comment-action-data"><img src="https://raw.githubusercontent.com/Vaquum/Limen/python-coverage-comment-action-data/badge.svg" alt="Coverage" /></a>
+  <a href="https://scorecard.dev/viewer/?uri=github.com/Vaquum/Limen"><img src="https://img.shields.io/ossf-scorecard/github.com/Vaquum/Limen?label=openssf+scorecard&amp;style=flat" alt="OpenSSF Scorecard" /></a>
 </div>
 
 <hr />


### PR DESCRIPTION
## Summary
- stop publishing coverage badge data into the `python-coverage-comment-action-data` branch
- keep PR coverage comments intact
- remove the README coverage badge that depended on that generated branch and switch Scorecard to the stable shields endpoint

## Why
The generated coverage data branch does not contain `docs-site/`, so Cloudflare’s Git-based docs Worker can try to build that branch and fail with `root directory not found`. Removing the branch-writing coverage job prevents this class of failure from recurring from GitHub Actions.

## Testing
- `git diff --check`
- verified there are no remaining references to `python-coverage-comment-action-data` in the repo