### PR TITLE
docs: update README intro copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 
 *Manifest-driven Bitcoin alpha research engine that turns market data into searchable signals, backtested outcomes, and decoder cohorts.*
 
-Limen unifies parameter search across machine learning and rule-based strategies, with built-in analytics that show not just what works, but why it works. Evolves from Talos, the hyperparameter optimization framework for TensorFlow and Keras cited in over 1,000 scientific papers with zero breaking bugs in six years.
+Limen unifies parameter search across machine learning and rule-based strategies, with built-in analytics that show not just what works, but why it works. It evolves from Talos, the hyperparameter optimization framework for TensorFlow and Keras cited in over 1,000 scientific papers with zero breaking bugs in six years.
 
 ## What Limen Is Not
 

--- a/README.md
+++ b/README.md
@@ -21,11 +21,13 @@
 
 <hr />
 
-# Limen
+<a id="limen"></a>
 
-Limen is a manifest-driven Bitcoin alpha research engine. It turns market data into searchable experiments, benchmark-style analytics, backtest results, and decoder cohorts.
+# Limen — The Research Engine
 
-Limen brings data preparation, feature construction, target shaping, parameter search, and post-run analysis into one Python workflow. It supports both machine learning and rule-based research, but it stays focused on signal research rather than decisioning or execution.
+*Manifest-driven Bitcoin alpha research engine that turns market data into searchable signals, backtested outcomes, and decoder cohorts.*
+
+Limen unifies parameter search across machine learning and rule-based strategies, with built-in analytics that show not just what works, but why it works. Evolves from Talos, the hyperparameter optimization framework for TensorFlow and Keras cited in over 1,000 scientific papers with zero breaking bugs in six years.
 
 ## What Limen Is Not
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   <br />
 </div>
 <br />
-<div align="center"><strong>Vaquum Limen turns Bitcoin market data into searchable alpha, backtested signals, and decoder cohorts.</strong></div>
+<div align="center"><strong>Vaquum Limen turns Bitcoin market data into searchable signals, backtested outcomes, and decoder cohorts.</strong></div>
 
 <div align="center">
   <a href="#limen">Limen</a> •

--- a/docs-site/product-docs.json
+++ b/docs-site/product-docs.json
@@ -1,7 +1,7 @@
 {
   "productId": "limen",
   "productName": "Limen",
-  "tagline": "Bitcoin market data into searchable alpha, backtested signals, and decoder cohorts.",
+  "tagline": "Bitcoin market data into searchable signals, backtested outcomes, and decoder cohorts.",
   "versionLabel": "latest",
   "basePath": "/limen/",
   "navSections": [


### PR DESCRIPTION
## Summary
- update the README intro heading and opening copy to the latest Limen positioning
- preserve the existing top navigation by keeping a stable `limen` anchor
- leave the current badges and capabilities list unchanged

## Testing
- not run (README-only change)