### PR TITLE
feat: Fix huge-space legacy ParamSpace sampling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -717,3 +717,9 @@ Note: add all new changelog entries to the bottom of this file.
 
 - Align inline and post-run confusion mean-return metrics to the same immediate-next-execution-row contract used by snapshot backtests for completed-bar pipelines
 - Make post-run snapshot backtests raise explicitly on unsupported multiclass logged outputs while keeping the existing binary and directional-regression contracts
+
+## v2.3.5 on 19th of April, 2026
+
+- Fix legacy `ParamSpace` sampling for huge discrete spaces so `n_permutations < total_space` no longer overflows when `total_space > sys.maxsize`
+- Preserve exact legacy `random.sample(range(N), k)` ordering and downstream RNG-state semantics in the huge-space fallback path
+- Add regression coverage for stdlib-equivalent range sampling, large-space reproducibility, prefix stability, and exhaustion behavior on the legacy `ParamSpace` path

--- a/limen/utils/param_space.py
+++ b/limen/utils/param_space.py
@@ -44,7 +44,7 @@ def sample_range_exact(
             )
         )
 
-    if population_size <= setsize:
+    if population_size <= setsize and population_size <= sys.maxsize:
         return rng.sample(range(population_size), sample_size)
 
     bits = population_size.bit_length()

--- a/limen/utils/param_space.py
+++ b/limen/utils/param_space.py
@@ -69,9 +69,12 @@ class ParamSpace:
 
     Args:
         params (dict): Dictionary of parameter names and their possible values.
-        n_permutations (int): Number of parameter combinations to sample. Uses
-            exact `random.sample(range(N), k)` semantics even when `N` exceeds
-            the stdlib wrapper's `Py_ssize_t` limit.
+        n_permutations (int): Number of parameter combinations to sample. When
+            this is smaller than the total parameter space, sampling uses exact
+            `random.sample(range(N), k)` semantics, including when `N` exceeds
+            the stdlib wrapper's `Py_ssize_t` limit. When this is greater than
+            or equal to the total parameter space, all combinations are
+            enumerated instead of sampled.
     '''
 
     def __init__(self, params: dict, n_permutations: int) -> None:

--- a/limen/utils/param_space.py
+++ b/limen/utils/param_space.py
@@ -1,14 +1,77 @@
+import math
 import random
+import sys
+from typing import Any
+
 import polars as pl
+
+
+SAMPLE_SELECTION_MIN_SIZE = 21
+SAMPLE_SELECTION_TIPPING_POINT = 5
+SAMPLE_SELECTION_LOG_BASE = 4
+SAMPLE_SELECTION_MULTIPLIER = 3
+
+
+def sample_range_exact(
+    rng: Any,
+    population_size: int,
+    sample_size: int,
+) -> list[int]:
+
+    '''
+    Sample ordered indices with exact `random.sample(range(N), k)` semantics.
+
+    Args:
+        rng (Any): Random provider with `sample()` and `getrandbits()`
+        population_size (int): Size of the conceptual `range(N)` population
+        sample_size (int): Number of unique ordered indices to draw
+
+    Returns:
+        list[int]: Ordered sampled indices matching stdlib range-sampling behavior
+    '''
+
+    # Mirror CPython Lib/random.py for range(N) sampling so huge-space ParamSpace
+    # keeps legacy random.sample semantics even when the wrapper overflows.
+    if not 0 <= sample_size <= population_size:
+        raise ValueError('Sample larger than population or is negative')
+
+    setsize = SAMPLE_SELECTION_MIN_SIZE
+    if sample_size > SAMPLE_SELECTION_TIPPING_POINT:
+        setsize += SAMPLE_SELECTION_LOG_BASE ** math.ceil(
+            math.log(
+                sample_size * SAMPLE_SELECTION_MULTIPLIER,
+                SAMPLE_SELECTION_LOG_BASE,
+            )
+        )
+
+    if population_size <= setsize:
+        return rng.sample(range(population_size), sample_size)
+
+    bits = population_size.bit_length()
+    get_bits = rng.getrandbits
+    seen: set[int] = set()
+    ordered_indices: list[int] = []
+
+    for _ in range(sample_size):
+        index = get_bits(bits)
+        while index >= population_size or index in seen:
+            index = get_bits(bits)
+        seen.add(index)
+        ordered_indices.append(index)
+
+    return ordered_indices
+
 
 class ParamSpace:
 
     '''
-    Create parameter space manager for hyperparameter sampling.
+    Create a legacy parameter space manager for hyperparameter sampling.
 
     Args:
         params (dict): Dictionary of parameter names and their possible values.
-        n_permutations (int): Number of parameter combinations to sample.
+        n_permutations (int): Number of parameter combinations to sample. Uses
+            exact `random.sample(range(N), k)` semantics even when `N` exceeds
+            the stdlib wrapper's `Py_ssize_t` limit.
     '''
 
     def __init__(self, params: dict, n_permutations: int) -> None:
@@ -23,8 +86,10 @@ class ParamSpace:
         # Generate n_permutations unique random indices
         if n_permutations >= self.total_space:
             indices = list(range(self.total_space))
-        else:
+        elif self.total_space <= sys.maxsize:
             indices = random.sample(range(self.total_space), n_permutations)
+        else:
+            indices = sample_range_exact(random, self.total_space, n_permutations)
 
         # Convert indices to parameter combinations
         combos = [self._index_to_combo(idx) for idx in indices]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaquum_limen"
-version = "2.3.4"
+version = "2.3.5"
 description = "Bitcoin-first research and trading platform."
 readme = "README.md"
 authors = [

--- a/tests/run.py
+++ b/tests/run.py
@@ -19,6 +19,14 @@ from tests.test_account_conviction import test_account_conviction
 from tests.test_backtest_conviction import test_backtest_conviction
 from tests.test_klines_data_maker_fields import test_klines_data_maker_fields
 from tests.test_large_param_space import test_large_param_space
+from tests.test_param_space import test_param_space_large_space_no_longer_overflows_and_is_reproducible
+from tests.test_param_space import test_param_space_large_space_sequences_match_for_both_generation_modes
+from tests.test_param_space import test_param_space_enumerates_full_space_and_returns_none_when_exhausted
+from tests.test_param_space import test_param_space_small_legacy_sequence_is_unchanged
+from tests.test_param_space import test_sample_range_exact_handles_edge_cases
+from tests.test_param_space import test_sample_range_exact_matches_stdlib_and_preserves_rng_state
+from tests.test_param_space import test_sample_range_exact_preserves_prefix_for_huge_ranges
+from tests.test_param_space import test_sample_range_exact_retries_rejected_and_duplicate_draws_in_order
 from tests.test_bars import test_volume_bars_basic
 from tests.test_bars import test_trade_bars_basic
 from tests.test_bars import test_liquidity_bars_basic
@@ -638,6 +646,14 @@ tests = [
     test_budget_set_state_missing_key,
     test_worst_first_maximize_false,
     test_large_param_space,
+    test_sample_range_exact_matches_stdlib_and_preserves_rng_state,
+    test_sample_range_exact_retries_rejected_and_duplicate_draws_in_order,
+    test_sample_range_exact_handles_edge_cases,
+    test_sample_range_exact_preserves_prefix_for_huge_ranges,
+    test_param_space_small_legacy_sequence_is_unchanged,
+    test_param_space_enumerates_full_space_and_returns_none_when_exhausted,
+    test_param_space_large_space_no_longer_overflows_and_is_reproducible,
+    test_param_space_large_space_sequences_match_for_both_generation_modes,
     test_klines_data_maker_fields,
     test_volume_bars_basic,
     test_trade_bars_basic,

--- a/tests/run.py
+++ b/tests/run.py
@@ -27,6 +27,7 @@ from tests.test_param_space import test_sample_range_exact_handles_edge_cases
 from tests.test_param_space import test_sample_range_exact_matches_stdlib_and_preserves_rng_state
 from tests.test_param_space import test_sample_range_exact_preserves_prefix_for_huge_ranges
 from tests.test_param_space import test_sample_range_exact_retries_rejected_and_duplicate_draws_in_order
+from tests.test_param_space import test_sample_range_exact_skips_small_range_fallback_above_sys_maxsize
 from tests.test_bars import test_volume_bars_basic
 from tests.test_bars import test_trade_bars_basic
 from tests.test_bars import test_liquidity_bars_basic
@@ -649,6 +650,7 @@ tests = [
     test_sample_range_exact_matches_stdlib_and_preserves_rng_state,
     test_sample_range_exact_retries_rejected_and_duplicate_draws_in_order,
     test_sample_range_exact_handles_edge_cases,
+    test_sample_range_exact_skips_small_range_fallback_above_sys_maxsize,
     test_sample_range_exact_preserves_prefix_for_huge_ranges,
     test_param_space_small_legacy_sequence_is_unchanged,
     test_param_space_enumerates_full_space_and_returns_none_when_exhausted,

--- a/tests/test_param_space.py
+++ b/tests/test_param_space.py
@@ -66,7 +66,7 @@ def test_sample_range_exact_matches_stdlib_and_preserves_rng_state():
 def test_sample_range_exact_retries_rejected_and_duplicate_draws_in_order():
     class StubRandom:
         def __init__(self) -> None:
-            self.values = iter([130, 7, 7, 9])
+            self.values = iter([127, 7, 7, 9])
 
         def getrandbits(self, _bits: int) -> int:
             return next(self.values)

--- a/tests/test_param_space.py
+++ b/tests/test_param_space.py
@@ -1,0 +1,197 @@
+import random
+
+import pytest
+
+from limen.utils.param_space import ParamSpace
+from limen.utils.param_space import sample_range_exact
+
+
+HUGE_SPACE_FIRST_INDICES = [
+    2053695854357871005,
+    4517457392071889495,
+    2574020394472462046,
+    1890702223848595625,
+    586287033698423193,
+]
+
+
+def _build_huge_params(dimensions: int = 19) -> dict[str, list[int]]:
+    return {f'p{i}': list(range(10)) for i in range(dimensions)}
+
+
+def _collect_generated_params(
+    seed: int,
+    params: dict[str, list[int]],
+    n_permutations: int,
+    count: int,
+    *,
+    random_search: bool,
+) -> list[dict]:
+    previous_state = random.getstate()
+    try:
+        random.seed(seed)
+        param_space = ParamSpace(params, n_permutations)
+        return [
+            param_space.generate(random_search=random_search)
+            for _ in range(count)
+        ]
+    finally:
+        random.setstate(previous_state)
+
+
+def test_sample_range_exact_matches_stdlib_and_preserves_rng_state():
+    cases = [
+        (0, 0),
+        (1, 0),
+        (1, 1),
+        (10, 10),
+        (30, 5),
+        (100, 10),
+        (1_000, 50),
+        (1_000_000, 500),
+    ]
+
+    for seed in range(10):
+        for population_size, sample_size in cases:
+            exact_rng = random.Random(seed)
+            stdlib_rng = random.Random(seed)
+
+            exact_sample = sample_range_exact(exact_rng, population_size, sample_size)
+            stdlib_sample = stdlib_rng.sample(range(population_size), sample_size)
+
+            assert exact_sample == stdlib_sample
+            assert exact_rng.randrange(1_000_000_000) == stdlib_rng.randrange(1_000_000_000)
+
+
+def test_sample_range_exact_retries_rejected_and_duplicate_draws_in_order():
+    class StubRandom:
+        def __init__(self) -> None:
+            self.values = iter([130, 7, 7, 9])
+
+        def getrandbits(self, _bits: int) -> int:
+            return next(self.values)
+
+        def sample(self, _population, _sample_size: int) -> list[int]:
+            raise AssertionError('small-range fallback should not be used')
+
+    assert sample_range_exact(StubRandom(), 100, 2) == [7, 9]
+
+
+def test_sample_range_exact_handles_edge_cases():
+    assert sample_range_exact(random.Random(1), 0, 0) == []
+    assert sample_range_exact(random.Random(2), 10**19, 0) == []
+
+    with pytest.raises(ValueError, match='Sample larger than population or is negative'):
+        sample_range_exact(random.Random(3), 5, 6)
+
+
+def test_sample_range_exact_preserves_prefix_for_huge_ranges():
+    full_sample = sample_range_exact(random.Random(42), 10**19, 50)
+    prefix_sample = sample_range_exact(random.Random(42), 10**19, 10)
+
+    assert full_sample[:10] == prefix_sample
+    assert prefix_sample[:5] == HUGE_SPACE_FIRST_INDICES
+
+
+def test_param_space_small_legacy_sequence_is_unchanged():
+    params = {'a': [0, 1], 'b': [10, 20]}
+    expected_sequence = [
+        {'a': 1, 'b': 10},
+        {'a': 1, 'b': 20},
+        {'a': 0, 'b': 10},
+    ]
+
+    assert _collect_generated_params(
+        seed=123,
+        params=params,
+        n_permutations=3,
+        count=3,
+        random_search=True,
+    ) == expected_sequence
+
+
+def test_param_space_enumerates_full_space_and_returns_none_when_exhausted():
+    params = {'a': [0, 1], 'b': [10, 20]}
+    previous_state = random.getstate()
+
+    try:
+        random.seed(999)
+        param_space = ParamSpace(params, 10)
+    finally:
+        random.setstate(previous_state)
+
+    assert param_space.n_permutations == 4
+
+    generated = [
+        param_space.generate(random_search=False),
+        param_space.generate(random_search=False),
+        param_space.generate(random_search=False),
+        param_space.generate(random_search=False),
+    ]
+    assert generated == [
+        {'a': 0, 'b': 10},
+        {'a': 1, 'b': 10},
+        {'a': 0, 'b': 20},
+        {'a': 1, 'b': 20},
+    ]
+    assert param_space.generate(random_search=False) is None
+
+
+def test_param_space_large_space_no_longer_overflows_and_is_reproducible():
+    params = _build_huge_params()
+    larger_params = _build_huge_params(25)
+    previous_state = random.getstate()
+
+    try:
+        random.seed(42)
+        first = ParamSpace(params, 10_000)
+
+        random.seed(42)
+        second = ParamSpace(params, 10_000)
+
+        random.seed(7)
+        larger = ParamSpace(larger_params, 64)
+    finally:
+        random.setstate(previous_state)
+
+    assert first.n_permutations == 10_000
+    assert second.n_permutations == 10_000
+    assert larger.n_permutations == 64
+    assert first.df_params.head(5).rows() == second.df_params.head(5).rows()
+    assert set(larger.generate(random_search=False).keys()) == set(larger_params.keys())
+
+
+def test_param_space_large_space_sequences_match_for_both_generation_modes():
+    params = _build_huge_params()
+
+    sequential_first = _collect_generated_params(
+        seed=42,
+        params=params,
+        n_permutations=128,
+        count=12,
+        random_search=False,
+    )
+    sequential_second = _collect_generated_params(
+        seed=42,
+        params=params,
+        n_permutations=128,
+        count=12,
+        random_search=False,
+    )
+    random_first = _collect_generated_params(
+        seed=42,
+        params=params,
+        n_permutations=128,
+        count=12,
+        random_search=True,
+    )
+    random_second = _collect_generated_params(
+        seed=42,
+        params=params,
+        n_permutations=128,
+        count=12,
+        random_search=True,
+    )
+
+    assert sequential_first == sequential_second
+    assert random_first == random_second

--- a/tests/test_param_space.py
+++ b/tests/test_param_space.py
@@ -85,6 +85,24 @@ def test_sample_range_exact_handles_edge_cases():
         sample_range_exact(random.Random(3), 5, 6)
 
 
+def test_sample_range_exact_skips_small_range_fallback_above_sys_maxsize(monkeypatch):
+    class StubRandom:
+        def __init__(self) -> None:
+            self.values = iter(range(50))
+
+        def getrandbits(self, _bits: int) -> int:
+            return next(self.values)
+
+        def sample(self, _population, _sample_size: int) -> list[int]:
+            raise AssertionError('range fallback should not be used above sys.maxsize')
+
+    import limen.utils.param_space as param_space_module
+
+    monkeypatch.setattr(param_space_module.sys, 'maxsize', 50)
+
+    assert sample_range_exact(StubRandom(), 100, 50) == list(range(50))
+
+
 def test_sample_range_exact_preserves_prefix_for_huge_ranges():
     full_sample = sample_range_exact(random.Random(42), 10**19, 50)
     prefix_sample = sample_range_exact(random.Random(42), 10**19, 10)

--- a/tests/test_param_space.py
+++ b/tests/test_param_space.py
@@ -85,7 +85,7 @@ def test_sample_range_exact_handles_edge_cases():
         sample_range_exact(random.Random(3), 5, 6)
 
 
-def test_sample_range_exact_skips_small_range_fallback_above_sys_maxsize(monkeypatch):
+def test_sample_range_exact_skips_small_range_fallback_above_sys_maxsize():
     class StubRandom:
         def __init__(self) -> None:
             self.values = iter(range(50))
@@ -98,9 +98,12 @@ def test_sample_range_exact_skips_small_range_fallback_above_sys_maxsize(monkeyp
 
     import limen.utils.param_space as param_space_module
 
-    monkeypatch.setattr(param_space_module.sys, 'maxsize', 50)
-
-    assert sample_range_exact(StubRandom(), 100, 50) == list(range(50))
+    previous_maxsize = param_space_module.sys.maxsize
+    try:
+        param_space_module.sys.maxsize = 50
+        assert sample_range_exact(StubRandom(), 100, 50) == list(range(50))
+    finally:
+        param_space_module.sys.maxsize = previous_maxsize
 
 
 def test_sample_range_exact_preserves_prefix_for_huge_ranges():


### PR DESCRIPTION
## Summary

Fixes the legacy `ParamSpace` overflow path from [#450](https://github.com/Vaquum/Limen/issues/450) without changing the existing small-space behavior.

This keeps the current `random.sample(range(N), k)` path untouched for representable populations and only swaps in an exact stdlib-equivalent helper when `total_space > sys.maxsize` and the wrapper would otherwise overflow.

## What Changed

- add `sample_range_exact()` in `limen/utils/param_space.py` to mirror CPython's ordered selection-branch semantics for `random.sample(range(N), k)`
- switch `ParamSpace` to use that helper only in the true overflow regime
- harden the helper so its small-range fallback cannot reintroduce the same overflow above `sys.maxsize`
- add focused regression tests for:
  - stdlib-equivalent sampled output and downstream RNG state
  - rejection and dedup behavior in the huge-range helper
  - prefix stability for huge ranges
  - unchanged small legacy `ParamSpace` sequencing
  - no-overflow reproducibility for `19 x 10` and operational coverage beyond that
  - enumerate-all behavior and exhaustion to `None`
  - the guarded no-fallback-above-`sys.maxsize` edge case
- bump the patch version to `2.3.5` and add a changelog entry
- fold the issue comment clarifications back into the issue body so the contract is canonical in one place

## Why

The old implementation failed on extremely large discrete spaces because `random.sample(range(total_space), n_permutations)` eventually trips the `Py_ssize_t` limit in the stdlib wrapper.

The important part here is that legacy `ParamSpace` is sensitive not just to uniqueness, but to:

- selection order
- seeded reproducibility
- downstream RNG state after pool construction
- partial-run prefix identity

So this PR fixes the overflow by preserving those semantics, not by introducing a different sampler.

## Validation

- `source .venv-codex/bin/activate && pytest -q tests/test_param_space.py tests/test_large_param_space.py`
- `source .venv-codex/bin/activate && python -m coverage run -m pytest -q tests/test_param_space.py tests/test_large_param_space.py && python -m coverage report --include='limen/utils/param_space.py'`
- `source .venv-codex/bin/activate && ruff check limen/utils/param_space.py tests/test_param_space.py tests/run.py`
- `source .venv-codex/bin/activate && LIMEN_COVERAGE_RUN=1 python -m coverage run -m tests.run && python -m coverage report --fail-under=92`