### PR TITLE
Move mean return metrics to confusion side

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -687,13 +687,19 @@ Note: add all new changelog entries to the bottom of this file.
 - Add cross-timescale state features: `trend_coherence` and `volatility_term_structure`
 - Add documentation and full behavioral test coverage for the new OHLCV feature families
 
+## v2.3.1 on 19th of April, 2026
+
+- Move TP/FP/TN/FN mean return metrics off the snapshot backtest surface and onto the confusion/benchmark side
+- Add inline `confusion_tp_mean_return_pct`, `confusion_fp_mean_return_pct`, `confusion_tn_mean_return_pct`, and `confusion_fn_mean_return_pct`
+- Add `aligned_return_pct` support to post-run confusion metrics so the same next-bar aligned one-bar return view is available after a run
+- Restore `backtest_snapshot()` and inline snapshot backtests to price-only inputs with no label plumbing through the backtest helper
+
 ## v2.3.0 on 18th of April, 2026
 
 - Change snapshot backtests to execute predictions on the next tradable bar by default, with `execution_lag_bars=0` available for legacy same-row behavior
 - Change snapshot `trade_*` metrics to run-level by default, add explicit `bar_*` metrics, and retain `trades_count_mode='bars'` for legacy-style bar metrics
 - Apply the new snapshot defaults explicitly to experiment backtest summaries and SFD inline backtest metrics so the behavior change is intentional and visible in outputs
-- Add confusion-bucket mean return columns (`tp/fp/tn/fn_mean_return_pct`) to snapshot backtest summaries when aligned `actuals` are available
-- Populate inline snapshot confusion-bucket return metrics from the aligned test labels, with regression SFDs passing directional actuals explicitly
+- Add confusion-bucket mean return diagnostics for aligned next-bar returns
 - Align regression experiment/log snapshot backtests with the same directional binary convention as inline reference-architecture backtests
 - Add `mean_kelly_pct` to snapshot backtest summaries using the active trade/bar return distribution with breakeven observations kept in the Kelly sample
 - Add direct snapshot tests to the canonical `python -m tests.run` path and extend docs for the updated snapshot semantics

--- a/docs/Backtest.md
+++ b/docs/Backtest.md
@@ -63,10 +63,6 @@ Snapshot backtests produce:
 - `bar_expectancy_pct`
 - `bar_return_mean_win_pct`
 - `bar_return_mean_loss_pct`
-- `tp_mean_return_pct`
-- `fp_mean_return_pct`
-- `tn_mean_return_pct`
-- `fn_mean_return_pct`
 - `mean_kelly_pct`
 - `bars_total`
 - `sharpe_per_bar`
@@ -79,11 +75,7 @@ Snapshot backtests produce:
 
 By default, `trade_*` fields are computed per consecutive `1`-run, which matches the economic idea of one held trade. The `bar_*` fields are always the in-market bar statistics. This is a behavioral change from the earlier bar-level `trade_*` defaults, so old experiment backtest tables are not directly comparable under the same column names. If you need the legacy bar-level `trade_*` behavior, call `backtest_snapshot(..., trades_count_mode='bars')`.
 
-When `actuals` are present in the input table, or when `actual_col` points to an equivalent label column, snapshot also reports `tp_mean_return_pct`, `fp_mean_return_pct`, `tn_mean_return_pct`, and `fn_mean_return_pct`. These are the mean aligned one-bar returns for each confusion bucket after applying `execution_lag_bars`, before run-level holding logic and transaction costs. If your labels already describe the future execution bar, this alignment is correct. If your labels are coincident with the feature bar instead, the confusion-bucket return columns will refer to a different bar than the label.
-
-For inline SFD backtests, Limen now passes the already-aligned test labels straight through to snapshot. Binary SFDs use `y_test` as-is, while regression SFDs pass an explicit directional `actuals` series derived from `y_test > 0`.
-
-For experiment/log backtests, Limen applies the same directional convention to regression rounds before calling snapshot, so post-run `backtest_*` columns stay aligned with the inline reference-architecture path.
+Confusion-conditioned return means now live on the confusion side rather than the backtest side. Inline experiment rows expose them as `confusion_tp_mean_return_pct`, `confusion_fp_mean_return_pct`, `confusion_tn_mean_return_pct`, and `confusion_fn_mean_return_pct`. Post-run, use `uel._log.experiment_confusion_metrics('aligned_return_pct')` when you want the same next-bar aligned one-bar return view in the benchmark layer.
 
 `mean_kelly_pct` is estimated from the active return distribution used by the snapshot mode: per held trade by default, or per in-market bar when `trades_count_mode='bars'`. It is the full-Kelly fraction, keeps breakeven observations in the empirical sample, and remains `NaN` when the sample does not contain both winners and losers.
 

--- a/docs/Log.md
+++ b/docs/Log.md
@@ -106,7 +106,7 @@ This table combines:
 - positive-rate diagnostics
 - precision and recall
 - TP and FP counts
-- mean and median of `x` within TP and FP
+- mean and median of `x` within TP, FP, TN, and FN
 - TP-versus-FP separation through Cohen's d and KS
 
 The same summary is exposed directly on UEL as:
@@ -145,6 +145,14 @@ Good questions to ask:
 - are `tp_x_mean` and `tp_x_median` materially better than `fp_x_mean` and `fp_x_median`?
 - is `tp_fp_cohen_d` stable enough to suggest real separation rather than noise?
 
+For aligned next-bar return diagnostics specifically, use:
+
+```python
+conf_ret = uel._log.experiment_confusion_metrics('aligned_return_pct')
+```
+
+This keeps the TP/FP/TN/FN mean-return view on the confusion side instead of mixing it into the snapshot backtest table. Inline experiment rows expose the same idea as `confusion_tp_mean_return_pct`, `confusion_fp_mean_return_pct`, `confusion_tn_mean_return_pct`, and `confusion_fn_mean_return_pct`.
+
 This is exactly why benchmark and backtest are separate in Limen: a round can look statistically interesting before it proves itself economically.
 
 ## Backtest Surface
@@ -176,10 +184,6 @@ The current summary columns are:
 - `bar_expectancy_pct`
 - `bar_return_mean_win_pct`
 - `bar_return_mean_loss_pct`
-- `tp_mean_return_pct`
-- `fp_mean_return_pct`
-- `tn_mean_return_pct`
-- `fn_mean_return_pct`
 - `mean_kelly_pct`
 - `bars_total`
 - `sharpe_per_bar`
@@ -190,7 +194,7 @@ The current summary columns are:
 - `cost_round_trip_bps`
 - `execution_lag_bars`
 
-Use this table to compare the trading-economics side of rounds after you have already inspected the benchmark layer.
+Use this table to compare the trading-economics side of rounds after you have already inspected the benchmark layer. TP/FP/TN/FN-conditioned mean returns are now benchmark/confusion diagnostics rather than backtest outputs.
 
 The snapshot defaults behind this table now execute on the next tradable bar and compute `trade_*` fields per held run. That means historical backtest tables produced before this change are not directly comparable under the same `trade_*` column names.
 

--- a/limen/backtest/backtest_snapshot.py
+++ b/limen/backtest/backtest_snapshot.py
@@ -34,6 +34,7 @@ def backtest_snapshot(df: pd.DataFrame,
     - `trade_*` metrics are computed from completed 1-runs by default.
     - Set `trades_count_mode='bars'` to reproduce the legacy bar-level `trade_*` fields.
     - `bar_*` metrics are always computed from in-market bars.
+    - Confusion-conditioned return means live on the confusion side, not in snapshot outputs.
     - `mean_kelly_pct` reports the full-Kelly fraction for the active return
       distribution, keeping zero-return observations in the sample denominator.
 
@@ -50,10 +51,6 @@ def backtest_snapshot(df: pd.DataFrame,
         'bar_expectancy_pct',
         'bar_return_mean_win_pct',
         'bar_return_mean_loss_pct',
-        'tp_mean_return_pct',
-        'fp_mean_return_pct',
-        'tn_mean_return_pct',
-        'fn_mean_return_pct',
         'mean_kelly_pct',
         'bars_total',
         'sharpe_per_bar',
@@ -71,6 +68,7 @@ def backtest_snapshot(df: pd.DataFrame,
     if execution_lag_bars < 0:
         raise ValueError('execution_lag_bars must be >= 0')
 
+    _ = actual_col  # kept for call-site compatibility after confusion returns moved out of snapshot
     df = df.copy()
 
     pred = pd.to_numeric(df[pred_col], errors='coerce').fillna(0).astype(int).clip(0, 1)
@@ -143,24 +141,6 @@ def backtest_snapshot(df: pd.DataFrame,
         bar_return_mean_win_pct = np.nan
         bar_return_mean_loss_pct = np.nan
 
-    actual = pd.to_numeric(df[actual_col], errors='coerce') if actual_col in df else None
-    if actual is not None:
-        aligned_bar_return = (dpx / open_px).replace([np.inf, -np.inf], np.nan)
-        valid_actual = tradable & actual.isin([0, 1]) & aligned_bar_return.notna()
-        m_tp = valid_actual & (pred == 1) & (actual == 1)
-        m_fp = valid_actual & (pred == 1) & (actual == 0)
-        m_tn = valid_actual & (pred == 0) & (actual == 0)
-        m_fn = valid_actual & (pred == 0) & (actual == 1)
-        tp_mean_return_pct = float(aligned_bar_return.loc[m_tp].mean() * 100.0) if m_tp.any() else np.nan
-        fp_mean_return_pct = float(aligned_bar_return.loc[m_fp].mean() * 100.0) if m_fp.any() else np.nan
-        tn_mean_return_pct = float(aligned_bar_return.loc[m_tn].mean() * 100.0) if m_tn.any() else np.nan
-        fn_mean_return_pct = float(aligned_bar_return.loc[m_fn].mean() * 100.0) if m_fn.any() else np.nan
-    else:
-        tp_mean_return_pct = np.nan
-        fp_mean_return_pct = np.nan
-        tn_mean_return_pct = np.nan
-        fn_mean_return_pct = np.nan
-
     if trade_runs_count:
         run_ids = entries.cumsum()
         trade_returns = ((1.0 + R_net[pos]).groupby(run_ids[pos]).prod() - 1.0)
@@ -209,10 +189,6 @@ def backtest_snapshot(df: pd.DataFrame,
         'bar_expectancy_pct': round(bar_expectancy_pct, 3),
         'bar_return_mean_win_pct': round(bar_return_mean_win_pct, 1),
         'bar_return_mean_loss_pct': round(bar_return_mean_loss_pct, 1),
-        'tp_mean_return_pct': round(tp_mean_return_pct, 3),
-        'fp_mean_return_pct': round(fp_mean_return_pct, 3),
-        'tn_mean_return_pct': round(tn_mean_return_pct, 3),
-        'fn_mean_return_pct': round(fn_mean_return_pct, 3),
         'mean_kelly_pct': round(mean_kelly_pct, 3),
         'bars_total': int(bars_total),
         'sharpe_per_bar': round(sharpe_per_bar, 2),

--- a/limen/log/README.md
+++ b/limen/log/README.md
@@ -49,6 +49,7 @@ log/
 - Manifest-aware logs reconstruct the test window with the same bar-formation logic used during the run.
 - The package root re-exports helper functions, but the `Log` class itself lives in `limen.log.log`.
 - A good mental model is that `Log` is the bridge between raw experiment output and higher-level selection decisions.
+- `permutation_confusion_metrics(x='aligned_return_pct')` is the confusion-side path for next-bar TP/FP/TN/FN mean-return analysis.
 
 ## Read next
 

--- a/limen/log/_experiment_backtest_results.py
+++ b/limen/log/_experiment_backtest_results.py
@@ -8,25 +8,20 @@ from limen.backtest.backtest_snapshot import backtest_snapshot
 def _prepare_snapshot_backtest_input(df: pd.DataFrame) -> pd.DataFrame:
 
     '''
-    Normalize experiment backtest inputs to the binary snapshot contract.
+    Normalize experiment backtest predictions to the binary snapshot contract.
 
-    Binary SFDs already log 0/1 predictions and actuals. Regression SFDs log
-    continuous values, so for snapshot backtests we convert both sides to the
-    same directional convention used by the inline reference-architecture path.
+    Binary SFDs already log 0/1 predictions. Regression SFDs log continuous
+    values, so for snapshot backtests we convert predictions to the same
+    directional convention used by the inline reference-architecture path.
     '''
 
-    if 'actuals' not in df:
-        return df
-
-    actuals = pd.to_numeric(df['actuals'], errors='coerce')
-    valid_actuals = actuals.dropna()
-    if not valid_actuals.empty and valid_actuals.isin([0, 1]).all():
+    predictions = pd.to_numeric(df['predictions'], errors='coerce')
+    valid_predictions = predictions.dropna()
+    if not valid_predictions.empty and valid_predictions.isin([0, 1]).all():
         return df
 
     normalized = df.copy()
-    predictions = pd.to_numeric(normalized['predictions'], errors='coerce')
     normalized['predictions'] = (predictions > 0).astype(int)
-    normalized['actuals'] = (actuals > 0).astype(int)
 
     return normalized
 
@@ -46,8 +41,6 @@ def _experiment_backtest_results(self: Any, disable_progress_bar: bool = False) 
                       'trade_return_mean_win_pct', 'trade_return_mean_loss_pct',
                       'bar_win_rate_pct', 'bar_expectancy_pct',
                       'bar_return_mean_win_pct', 'bar_return_mean_loss_pct',
-                      'tp_mean_return_pct', 'fp_mean_return_pct',
-                      'tn_mean_return_pct', 'fn_mean_return_pct',
                       'mean_kelly_pct', 'bars_total', 'sharpe_per_bar',
                       'bars_in_market_pct', 'bars_in_market_count',
                       'trades_count', 'trade_runs_count', 'cost_round_trip_bps',

--- a/limen/log/_permutation_confusion_metrics.py
+++ b/limen/log/_permutation_confusion_metrics.py
@@ -4,6 +4,20 @@ from typing import Any
 from collections.abc import Sequence
 from math import sqrt
 
+ALIGNED_RETURN_PCT_COL = 'aligned_return_pct'
+
+
+def _build_aligned_return_pct(df: pd.DataFrame, execution_lag_bars: int) -> pd.Series:
+
+    open_px = pd.to_numeric(df['open'], errors='coerce')
+    dpx = pd.to_numeric(df['price_change'], errors='coerce')
+
+    if execution_lag_bars > 0:
+        open_px = open_px.shift(-execution_lag_bars)
+        dpx = dpx.shift(-execution_lag_bars)
+
+    return (dpx / open_px).replace([np.inf, -np.inf], np.nan) * 100.0
+
 
 def _permutation_confusion_metrics(self: Any,
                                   x: str,
@@ -15,29 +29,38 @@ def _permutation_confusion_metrics(self: Any,
                                   threshold: float = 0.5,
                                   outlier_quantiles: Sequence[float] = (0.01, 0.99),
                                   outlier_mode: str = 'filter',
+                                  execution_lag_bars: int = 1,
                                   id_cols: dict[str, Any] | None = None) -> pd.DataFrame:
     '''
     Compute a single-row trimmed report for long-only evaluation: precision,
     recall, signal rates, counts and payoffs, and TP–FP separation.
 
     Args:
-        x (str): Column summarized within TP/FP/TN/FN (e.g., predicted_probability or P&L)
+        x (str): Column summarized within TP/FP/TN/FN (e.g., predicted_probability,
+            P&L, or the special value 'aligned_return_pct')
         pred_col (str): Binary predictions column
         actual_col (str): Binary actuals column
         proba_col (str | None): Probabilities to binarize via `threshold` (overrides `pred_col`)
         threshold (float): Decision threshold for `proba_col`
         outlier_quantiles (Sequence[float]): (lo, hi) for x outlier handling
         outlier_mode (str): 'filter' to drop outside bounds or 'winsor' to clip
+        execution_lag_bars (int): Prediction-to-execution lag used when x='aligned_return_pct'
         id_cols (dict[str, Any] | None): Optional identifiers to prepend (e.g., params)
 
     Returns:
         pd.DataFrame: One-row table with columns 'x_name', 'n_kept', 'pred_pos_rate_pct',
                       'actual_pos_rate_pct', 'precision_pct', 'recall_pct', 'pred_pos_count',
                       'tp_count', 'fp_count', 'tp_x_mean', 'tp_x_median', 'fp_x_mean', 'fp_x_median',
-                      'pred_pos_x_mean', 'pred_pos_x_median', 'tp_fp_cohen_d', 'tp_fp_ks'
+                      'tn_x_mean', 'tn_x_median', 'fn_x_mean', 'fn_x_median', 'pred_pos_x_mean',
+                      'pred_pos_x_median', 'tp_fp_cohen_d', 'tp_fp_ks'
     '''
 
     df = self.permutation_prediction_performance(round_id)
+
+    if x == ALIGNED_RETURN_PCT_COL:
+        df = df.copy()
+        df[x] = _build_aligned_return_pct(df, execution_lag_bars)
+        df = df[df[x].notna()].copy()
 
     # Optional: binarize from probabilities
     if proba_col is not None:
@@ -147,6 +170,10 @@ def _permutation_confusion_metrics(self: Any,
         'fp_x_mean': float(fp['mean']),
         'tp_x_median': float(tp['median']),
         'fp_x_median': float(fp['median']),
+        'tn_x_mean': float(tn['mean']),
+        'tn_x_median': float(tn['median']),
+        'fn_x_mean': float(fn['mean']),
+        'fn_x_median': float(fn['median']),
         'pred_pos_count': int(pred_pos_count),
         'pred_pos_x_mean': float(pred_pos_mean_x),
         'pred_pos_x_median': float(pred_pos_median_x),
@@ -156,5 +183,11 @@ def _permutation_confusion_metrics(self: Any,
         'tp_fp_ks': float(tp_fp_ks),
         'x_name': x,
         'n_kept': int(n),
+        **({
+            'tp_mean_return_pct': float(tp['mean']),
+            'fp_mean_return_pct': float(fp['mean']),
+            'tn_mean_return_pct': float(tn['mean']),
+            'fn_mean_return_pct': float(fn['mean']),
+            'execution_lag_bars': int(execution_lag_bars),
+        } if x == ALIGNED_RETURN_PCT_COL else {}),
     }])
-

--- a/limen/sfd/reference_architecture/base.py
+++ b/limen/sfd/reference_architecture/base.py
@@ -100,10 +100,76 @@ class ReferenceModel(ABC):
             'confusion_recall': recall,
         }
 
+    def _compute_confusion_return_metrics(self,
+                                          preds: np.ndarray,
+                                          y_test: np.ndarray,
+                                          data: dict,
+                                          execution_lag_bars: int = 1) -> dict:
+
+        '''
+        Compute confusion-conditioned aligned one-bar returns if price data is available.
+
+        Args:
+            preds (np.ndarray): Binary predictions (0 or 1)
+            y_test (np.ndarray): Binary true labels (0 or 1)
+            data (dict): Data dictionary, optionally containing 'price_data_for_backtest'
+            execution_lag_bars (int): Number of bars between prediction row and execution row
+
+        Returns:
+            dict: Confusion return metrics with 'confusion_' prefix, or empty dict if no price data
+        '''
+
+        if 'price_data_for_backtest' not in data:
+            return {}
+
+        price_df = data['price_data_for_backtest']
+
+        if isinstance(price_df, pd.DataFrame):
+            price_pd = price_df
+        elif hasattr(price_df, 'to_pandas'):
+            price_pd = price_df.to_pandas()
+        else:
+            return {}
+
+        preds = np.asarray(preds).astype(int)
+        y_test = np.asarray(y_test).astype(int)
+
+        if len(price_pd) != len(preds):
+            raise ValueError(
+                'price_data_for_backtest must align one-to-one with predictions'
+            )
+        if len(y_test) != len(preds):
+            raise ValueError(
+                'y_test must align one-to-one with predictions'
+            )
+
+        open_px = pd.to_numeric(price_pd['open'], errors='coerce')
+        close_px = pd.to_numeric(price_pd['close'], errors='coerce')
+        dpx = close_px - open_px
+
+        if execution_lag_bars > 0:
+            open_px = open_px.shift(-execution_lag_bars)
+            dpx = dpx.shift(-execution_lag_bars)
+
+        aligned_return_pct = ((dpx / open_px).replace([np.inf, -np.inf], np.nan) * 100.0)
+        valid = open_px.notna() & dpx.notna() & (open_px != 0) & aligned_return_pct.notna()
+
+        actual = pd.Series(y_test)
+        pred = pd.Series(preds)
+
+        def _mean(mask: pd.Series) -> float:
+            return round(float(aligned_return_pct.loc[mask].mean()), 3) if mask.any() else np.nan
+
+        return {
+            'confusion_tp_mean_return_pct': _mean(valid & (pred == 1) & (actual == 1)),
+            'confusion_fp_mean_return_pct': _mean(valid & (pred == 1) & (actual == 0)),
+            'confusion_tn_mean_return_pct': _mean(valid & (pred == 0) & (actual == 0)),
+            'confusion_fn_mean_return_pct': _mean(valid & (pred == 0) & (actual == 1)),
+        }
+
     def _compute_backtest(self,
                           preds: np.ndarray,
-                          data: dict,
-                          actuals: np.ndarray | pd.Series | None = None) -> dict:
+                          data: dict) -> dict:
 
         '''
         Compute backtest metrics if price_data_for_backtest is available.
@@ -111,10 +177,6 @@ class ReferenceModel(ABC):
         Args:
             preds (np.ndarray): Binary predictions (0 or 1)
             data (dict): Data dictionary, optionally containing 'price_data_for_backtest'
-            actuals (np.ndarray | pd.Series | None): Optional aligned binary actuals
-                for the same prediction rows. When provided, snapshot confusion-bucket
-                return metrics are populated from these labels without additional
-                shifting.
 
         Returns:
             dict: Backtest metrics with 'backtest_' prefix, or empty dict if no price data
@@ -144,22 +206,6 @@ class ReferenceModel(ABC):
             'close': price_pd['close'].values,
             'price_change': (price_pd['close'] - price_pd['open']).values,
         })
-
-        if actuals is not None:
-            actuals = pd.to_numeric(
-                pd.Series(actuals),
-                errors='coerce',
-            ).to_numpy()
-            if len(actuals) != len(preds):
-                raise ValueError(
-                    'actuals must align one-to-one with predictions'
-                )
-            if np.isnan(actuals).any():
-                raise ValueError(
-                    'actuals must be numeric and contain no NaN values'
-                )
-            actuals = actuals.astype(int)
-            bt_input['actuals'] = actuals
 
         bt_result = backtest_snapshot(
             bt_input,

--- a/limen/sfd/reference_architecture/logreg_binary.py
+++ b/limen/sfd/reference_architecture/logreg_binary.py
@@ -74,7 +74,8 @@ class LogRegBinary(ReferenceModel):
 
         if inline_metrics:
             results.update(self._compute_confusion(preds, data['y_test']))
-            results.update(self._compute_backtest(preds, data, actuals=data['y_test']))
+            results.update(self._compute_confusion_return_metrics(preds, data['y_test'], data))
+            results.update(self._compute_backtest(preds, data))
 
         return results
 

--- a/limen/sfd/reference_architecture/random_binary.py
+++ b/limen/sfd/reference_architecture/random_binary.py
@@ -77,7 +77,8 @@ class RandomBinary(ReferenceModel):
 
         if inline_metrics:
             results.update(self._compute_confusion(preds, data['y_test']))
-            results.update(self._compute_backtest(preds, data, actuals=data['y_test']))
+            results.update(self._compute_confusion_return_metrics(preds, data['y_test'], data))
+            results.update(self._compute_backtest(preds, data))
 
         return results
 

--- a/limen/sfd/reference_architecture/tabpfn_binary.py
+++ b/limen/sfd/reference_architecture/tabpfn_binary.py
@@ -136,7 +136,8 @@ class TabPFNBinary(ReferenceModel):
 
         if inline_metrics:
             results.update(self._compute_confusion(preds, data['y_test']))
-            results.update(self._compute_backtest(preds, data, actuals=data['y_test']))
+            results.update(self._compute_confusion_return_metrics(preds, data['y_test'], data))
+            results.update(self._compute_backtest(preds, data))
 
         return results
 

--- a/limen/sfd/reference_architecture/xgboost_regressor.py
+++ b/limen/sfd/reference_architecture/xgboost_regressor.py
@@ -86,13 +86,8 @@ class XGBoostRegressor(ReferenceModel):
             pred_direction = (preds > 0).astype(int)
             actual_direction = (y_test > 0).astype(int)
             results.update(self._compute_confusion(pred_direction, actual_direction))
-            results.update(
-                self._compute_backtest(
-                    pred_direction,
-                    data,
-                    actuals=actual_direction,
-                )
-            )
+            results.update(self._compute_confusion_return_metrics(pred_direction, actual_direction, data))
+            results.update(self._compute_backtest(pred_direction, data))
 
         return results
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaquum_limen"
-version = "2.3.0"
+version = "2.3.1"
 description = "Bitcoin-first research and trading platform."
 readme = "README.md"
 authors = [

--- a/tests/run.py
+++ b/tests/run.py
@@ -234,12 +234,14 @@ from tests.test_reference_architecture import test_random_binary_train_evaluate_
 from tests.test_reference_architecture import test_tabpfn_train_evaluate_end_to_end
 from tests.test_reference_architecture import test_train_with_validation_data
 from tests.test_reference_architecture import test_train_without_validation_data
-from tests.test_reference_architecture import test_logreg_inline_backtest_passes_binary_actuals_to_snapshot as test_logreg_inline_backtest_passes_binary_actuals_to_snapshot_with_fixture
-from tests.test_reference_architecture import test_xgboost_inline_backtest_passes_directional_actuals_to_snapshot as test_xgboost_inline_backtest_passes_directional_actuals_to_snapshot_with_fixture
+from tests.test_reference_architecture import test_logreg_inline_backtest_does_not_pass_actuals_to_snapshot as test_logreg_inline_backtest_does_not_pass_actuals_to_snapshot_with_fixture
+from tests.test_reference_architecture import test_xgboost_inline_backtest_does_not_pass_actuals_to_snapshot as test_xgboost_inline_backtest_does_not_pass_actuals_to_snapshot_with_fixture
 from tests.test_reference_architecture import test_compute_backtest_requires_aligned_lengths
-from tests.test_reference_backtest_alignment import test_random_binary_inline_backtest_passes_binary_actuals_to_snapshot
-from tests.test_reference_backtest_alignment import test_xgboost_inline_backtest_passes_directional_actuals_and_kwargs
-from tests.test_reference_backtest_alignment import test_compute_backtest_rejects_nan_actuals
+from tests.test_reference_architecture import test_compute_confusion_return_metrics_aligns_next_bar_returns
+from tests.test_reference_architecture import test_compute_confusion_return_metrics_requires_aligned_lengths
+from tests.test_reference_backtest_alignment import test_random_binary_inline_backtest_does_not_pass_actuals_to_snapshot
+from tests.test_reference_backtest_alignment import test_xgboost_inline_backtest_uses_directional_predictions_without_actuals
+from tests.test_reference_backtest_alignment import test_compute_confusion_return_metrics_uses_directional_actuals
 from tests.test_manifest_prepare_data import test_price_data_for_backtest_has_ohlc_columns
 from tests.test_manifest_prepare_data import test_price_data_for_backtest_row_count_matches_test
 from tests.test_manifest_prepare_data import test_price_data_for_backtest_datetime_alignment
@@ -252,8 +254,6 @@ from tests.test_backtest_snapshot import test_snapshot_defaults_to_next_bar_exec
 from tests.test_backtest_snapshot import test_snapshot_can_reproduce_legacy_same_row_execution
 from tests.test_backtest_snapshot import test_snapshot_trade_metrics_are_run_level_by_default
 from tests.test_backtest_snapshot import test_snapshot_bar_mode_preserves_legacy_trade_metrics
-from tests.test_backtest_snapshot import test_snapshot_confusion_bucket_mean_returns_cover_all_quadrants
-from tests.test_backtest_snapshot import test_snapshot_confusion_bucket_respects_actual_col
 from tests.test_backtest_snapshot import test_snapshot_mean_kelly_pct_uses_trade_runs_by_default
 from tests.test_backtest_snapshot import test_snapshot_mean_kelly_pct_keeps_breakevens_in_denominator
 from tests.test_backtest_snapshot import test_snapshot_handles_empty_input
@@ -465,20 +465,20 @@ from tests.test_trainer import test_validate_metrics_ignores_metadata_fields_and
 from tests.test_trainer import test_validate_metrics_reports_missing_permutations_and_large_deterministic_mismatches
 
 
-def test_logreg_inline_backtest_passes_binary_actuals_to_snapshot() -> None:
+def test_logreg_inline_backtest_does_not_pass_actuals_to_snapshot() -> None:
 
     monkeypatch = pytest.MonkeyPatch()
     try:
-        test_logreg_inline_backtest_passes_binary_actuals_to_snapshot_with_fixture(monkeypatch)
+        test_logreg_inline_backtest_does_not_pass_actuals_to_snapshot_with_fixture(monkeypatch)
     finally:
         monkeypatch.undo()
 
 
-def test_xgboost_inline_backtest_passes_directional_actuals_to_snapshot() -> None:
+def test_xgboost_inline_backtest_does_not_pass_actuals_to_snapshot() -> None:
 
     monkeypatch = pytest.MonkeyPatch()
     try:
-        test_xgboost_inline_backtest_passes_directional_actuals_to_snapshot_with_fixture(monkeypatch)
+        test_xgboost_inline_backtest_does_not_pass_actuals_to_snapshot_with_fixture(monkeypatch)
     finally:
         monkeypatch.undo()
 
@@ -707,12 +707,14 @@ tests = [
     test_tabpfn_train_evaluate_end_to_end,
     test_train_with_validation_data,
     test_train_without_validation_data,
-    test_logreg_inline_backtest_passes_binary_actuals_to_snapshot,
-    test_random_binary_inline_backtest_passes_binary_actuals_to_snapshot,
-    test_xgboost_inline_backtest_passes_directional_actuals_to_snapshot,
-    test_xgboost_inline_backtest_passes_directional_actuals_and_kwargs,
+    test_logreg_inline_backtest_does_not_pass_actuals_to_snapshot,
+    test_random_binary_inline_backtest_does_not_pass_actuals_to_snapshot,
+    test_xgboost_inline_backtest_does_not_pass_actuals_to_snapshot,
+    test_xgboost_inline_backtest_uses_directional_predictions_without_actuals,
     test_compute_backtest_requires_aligned_lengths,
-    test_compute_backtest_rejects_nan_actuals,
+    test_compute_confusion_return_metrics_aligns_next_bar_returns,
+    test_compute_confusion_return_metrics_requires_aligned_lengths,
+    test_compute_confusion_return_metrics_uses_directional_actuals,
     test_price_data_for_backtest_has_ohlc_columns,
     test_price_data_for_backtest_row_count_matches_test,
     test_price_data_for_backtest_datetime_alignment,
@@ -725,8 +727,6 @@ tests = [
     test_snapshot_can_reproduce_legacy_same_row_execution,
     test_snapshot_trade_metrics_are_run_level_by_default,
     test_snapshot_bar_mode_preserves_legacy_trade_metrics,
-    test_snapshot_confusion_bucket_mean_returns_cover_all_quadrants,
-    test_snapshot_confusion_bucket_respects_actual_col,
     test_snapshot_mean_kelly_pct_uses_trade_runs_by_default,
     test_snapshot_mean_kelly_pct_keeps_breakevens_in_denominator,
     test_snapshot_handles_empty_input,

--- a/tests/test_backtest_snapshot.py
+++ b/tests/test_backtest_snapshot.py
@@ -10,7 +10,6 @@ def _make_snapshot_input() -> pd.DataFrame:
 
     return pd.DataFrame({
         'predictions': [1, 1, 0],
-        'actuals': [1, 0, 0],
         'open': [100.0, 120.0, 108.0],
         'close': [120.0, 108.0, 108.0],
         'price_change': [20.0, -12.0, 0.0],
@@ -21,7 +20,6 @@ def test_snapshot_defaults_to_next_bar_execution() -> None:
 
     data = pd.DataFrame({
         'predictions': [1, 0],
-        'actuals': [1, 0],
         'open': [100.0, 200.0],
         'close': [150.0, 210.0],
         'price_change': [50.0, 10.0],
@@ -35,7 +33,6 @@ def test_snapshot_defaults_to_next_bar_execution() -> None:
     assert result['bars_in_market_pct'] == 100.0
     assert result['trade_runs_count'] == 1
     assert result['total_return_net_pct'] == 5.0
-    assert result['tp_mean_return_pct'] == 5.0
     assert math.isnan(result['sharpe_per_bar'])
 
 
@@ -43,7 +40,6 @@ def test_snapshot_can_reproduce_legacy_same_row_execution() -> None:
 
     data = pd.DataFrame({
         'predictions': [1, 0],
-        'actuals': [1, 0],
         'open': [100.0, 200.0],
         'close': [150.0, 210.0],
         'price_change': [50.0, 10.0],
@@ -80,10 +76,6 @@ def test_snapshot_trade_metrics_are_run_level_by_default() -> None:
     assert result['bar_expectancy_pct'] == 5.0
     assert result['bar_return_mean_win_pct'] == 20.0
     assert result['bar_return_mean_loss_pct'] == -10.0
-    assert result['tp_mean_return_pct'] == 20.0
-    assert result['fp_mean_return_pct'] == -10.0
-    assert result['tn_mean_return_pct'] == 0.0
-    assert math.isnan(result['fn_mean_return_pct'])
 
 
 def test_snapshot_bar_mode_preserves_legacy_trade_metrics() -> None:
@@ -103,59 +95,10 @@ def test_snapshot_bar_mode_preserves_legacy_trade_metrics() -> None:
     assert result['trade_return_mean_win_pct'] == 20.0
     assert result['trade_return_mean_loss_pct'] == -10.0
 
-
-def test_snapshot_confusion_bucket_mean_returns_cover_all_quadrants() -> None:
-
-    data = pd.DataFrame({
-        'predictions': [1, 1, 0, 0],
-        'actuals': [1, 0, 0, 1],
-        'open': [100.0, 100.0, 100.0, 100.0],
-        'close': [110.0, 90.0, 95.0, 105.0],
-        'price_change': [10.0, -10.0, -5.0, 5.0],
-    })
-
-    result = backtest_snapshot(
-        data,
-        fee_bps=0.0,
-        slip_bps=0.0,
-        execution_lag_bars=0,
-    ).iloc[0]
-
-    assert result['tp_mean_return_pct'] == 10.0
-    assert result['fp_mean_return_pct'] == -10.0
-    assert result['tn_mean_return_pct'] == -5.0
-    assert result['fn_mean_return_pct'] == 5.0
-
-
-def test_snapshot_confusion_bucket_respects_actual_col() -> None:
-
-    data = pd.DataFrame({
-        'predictions': [1, 0],
-        'labels': [1, 0],
-        'open': [100.0, 100.0],
-        'close': [110.0, 90.0],
-        'price_change': [10.0, -10.0],
-    })
-
-    result = backtest_snapshot(
-        data,
-        actual_col='labels',
-        fee_bps=0.0,
-        slip_bps=0.0,
-        execution_lag_bars=0,
-    ).iloc[0]
-
-    assert result['tp_mean_return_pct'] == 10.0
-    assert result['tn_mean_return_pct'] == -10.0
-    assert math.isnan(result['fp_mean_return_pct'])
-    assert math.isnan(result['fn_mean_return_pct'])
-
-
 def test_snapshot_mean_kelly_pct_uses_trade_runs_by_default() -> None:
 
     data = pd.DataFrame({
         'predictions': [1, 0, 1, 0],
-        'actuals': [1, 0, 0, 1],
         'open': [100.0, 100.0, 100.0, 100.0],
         'close': [120.0, 100.0, 90.0, 100.0],
         'price_change': [20.0, 0.0, -10.0, 0.0],
@@ -175,7 +118,6 @@ def test_snapshot_mean_kelly_pct_keeps_breakevens_in_denominator() -> None:
 
     data = pd.DataFrame({
         'predictions': [1, 0, 1, 0, 1],
-        'actuals': [1, 0, 0, 0, 0],
         'open': [100.0, 100.0, 100.0, 100.0, 100.0],
         'close': [120.0, 100.0, 90.0, 100.0, 100.0],
         'price_change': [20.0, 0.0, -10.0, 0.0, 0.0],
@@ -196,7 +138,6 @@ def test_snapshot_handles_empty_input() -> None:
 
     data = pd.DataFrame({
         'predictions': [],
-        'actuals': [],
         'open': [],
         'close': [],
         'price_change': [],

--- a/tests/test_inline_metrics.py
+++ b/tests/test_inline_metrics.py
@@ -39,6 +39,10 @@ def test_inline_and_post_experiment_metrics() -> None:
         assert col in log_cols, f"Missing inline confusion column: {col}"
         assert uel.experiment_log[col].null_count() == 0, f"Null values in {col}"
 
+    for col in ['confusion_tp_mean_return_pct', 'confusion_fp_mean_return_pct',
+                'confusion_tn_mean_return_pct', 'confusion_fn_mean_return_pct']:
+        assert col in log_cols, f"Missing inline confusion return column: {col}"
+
     for col in ['backtest_trade_win_rate_pct', 'backtest_max_drawdown_pct',
                 'backtest_total_return_net_pct', 'backtest_sharpe_per_bar',
                 'backtest_execution_lag_bars']:

--- a/tests/test_metrics_and_log_helpers.py
+++ b/tests/test_metrics_and_log_helpers.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 from sklearn.metrics import accuracy_score, precision_score, recall_score
 
 from limen.log._experiment_backtest_results import _experiment_backtest_results
+from limen.log._permutation_confusion_metrics import _permutation_confusion_metrics
 from limen.log._permutation_prediction_performance import _permutation_prediction_performance
 from limen.metrics.balanced_metric import balanced_metric
 from limen.metrics.multiclass_metrics import multiclass_metrics
@@ -121,7 +122,7 @@ def test_experiment_backtest_results_directionalizes_regression_rounds() -> None
 
         captured['df'] = df.copy()
         captured['kwargs'] = kwargs
-        return pd.DataFrame([{'tp_mean_return_pct': 1.0}])
+        return pd.DataFrame([{'trade_win_rate_pct': 1.0}])
 
     with patch(
         'limen.log._experiment_backtest_results.backtest_snapshot',
@@ -132,11 +133,37 @@ def test_experiment_backtest_results_directionalizes_regression_rounds() -> None
             disable_progress_bar=True,
         )
 
-    assert result.iloc[0]['tp_mean_return_pct'] == 1.0
+    assert result.iloc[0]['trade_win_rate_pct'] == 1.0
     assert captured['df']['predictions'].tolist() == [1, 0, 1]
-    assert captured['df']['actuals'].tolist() == [1, 0, 0]
     assert captured['kwargs']['execution_lag_bars'] == 1
     assert captured['kwargs']['trades_count_mode'] == 'runs'
+
+
+def test_permutation_confusion_metrics_supports_aligned_return_pct() -> None:
+
+    class _DummyConfusionLog:
+
+        def permutation_prediction_performance(self, round_id: int) -> pd.DataFrame:
+            assert round_id == 0
+            return pd.DataFrame({
+                'predictions': [1, 1, 0, 0, 0],
+                'actuals': [1, 0, 0, 1, 0],
+                'open': [100.0, 100.0, 100.0, 100.0, 100.0],
+                'close': [100.0, 110.0, 90.0, 95.0, 105.0],
+                'price_change': [0.0, 10.0, -10.0, -5.0, 5.0],
+            })
+
+    perf = _permutation_confusion_metrics(
+        _DummyConfusionLog(),
+        x='aligned_return_pct',
+        round_id=0,
+        outlier_quantiles=(0.0, 1.0),
+    )
+
+    assert perf.iloc[0]['tp_mean_return_pct'] == 10.0
+    assert perf.iloc[0]['fp_mean_return_pct'] == -10.0
+    assert perf.iloc[0]['tn_mean_return_pct'] == -5.0
+    assert perf.iloc[0]['fn_mean_return_pct'] == 5.0
 
 
 def test_multiclass_metrics_returns_expected_rounded_summary() -> None:

--- a/tests/test_reference_architecture.py
+++ b/tests/test_reference_architecture.py
@@ -149,7 +149,7 @@ def test_train_without_validation_data():
     assert 'rmse' in results
 
 
-def test_logreg_inline_backtest_passes_binary_actuals_to_snapshot(monkeypatch):
+def test_logreg_inline_backtest_does_not_pass_actuals_to_snapshot(monkeypatch):
 
     captured = {}
 
@@ -157,7 +157,7 @@ def test_logreg_inline_backtest_passes_binary_actuals_to_snapshot(monkeypatch):
 
         captured['df'] = df.copy()
         captured['kwargs'] = kwargs
-        return pd.DataFrame([{'tp_mean_return_pct': 1.0}])
+        return pd.DataFrame([{'trade_win_rate_pct': 1.0}])
 
     monkeypatch.setattr(
         'limen.sfd.reference_architecture.base.backtest_snapshot',
@@ -168,23 +168,19 @@ def test_logreg_inline_backtest_passes_binary_actuals_to_snapshot(monkeypatch):
     model = LogRegBinary().train(data, solver='lbfgs', max_iter=200)
     model.evaluate(data)
 
-    assert 'actuals' in captured['df'].columns
-    np.testing.assert_array_equal(
-        captured['df']['actuals'].to_numpy(),
-        np.asarray(data['y_test']).astype(int),
-    )
+    assert 'actuals' not in captured['df'].columns
     assert captured['kwargs']['execution_lag_bars'] == 1
     assert captured['kwargs']['trades_count_mode'] == 'runs'
 
 
-def test_xgboost_inline_backtest_passes_directional_actuals_to_snapshot(monkeypatch):
+def test_xgboost_inline_backtest_does_not_pass_actuals_to_snapshot(monkeypatch):
 
     captured = {}
 
     def _fake_backtest_snapshot(df, **kwargs):
 
         captured['df'] = df.copy()
-        return pd.DataFrame([{'tp_mean_return_pct': 1.0}])
+        return pd.DataFrame([{'trade_win_rate_pct': 1.0}])
 
     monkeypatch.setattr(
         'limen.sfd.reference_architecture.base.backtest_snapshot',
@@ -200,11 +196,7 @@ def test_xgboost_inline_backtest_passes_directional_actuals_to_snapshot(monkeypa
     )
     model.evaluate(data)
 
-    assert 'actuals' in captured['df'].columns
-    np.testing.assert_array_equal(
-        captured['df']['actuals'].to_numpy(),
-        (np.asarray(data['y_test']) > 0).astype(int),
-    )
+    assert 'actuals' not in captured['df'].columns
 
 
 def test_compute_backtest_requires_aligned_lengths():
@@ -221,12 +213,51 @@ def test_compute_backtest_requires_aligned_lengths():
         model._compute_backtest(
             np.array([1, 0]),
             data,
-            actuals=np.array([1, 0]),
         )
 
-    with pytest.raises(ValueError, match='actuals'):
-        model._compute_backtest(
-            np.array([1]),
+def test_compute_confusion_return_metrics_aligns_next_bar_returns() -> None:
+
+    model = LogRegBinary()
+    data = {
+        'price_data_for_backtest': pd.DataFrame({
+            'open': [100.0, 200.0, 100.0, 50.0],
+            'close': [150.0, 210.0, 90.0, 55.0],
+        }),
+    }
+
+    result = model._compute_confusion_return_metrics(
+        np.array([1, 1, 0, 0]),
+        np.array([1, 0, 0, 1]),
+        data,
+        execution_lag_bars=0,
+    )
+
+    assert result['confusion_tp_mean_return_pct'] == 50.0
+    assert result['confusion_fp_mean_return_pct'] == 5.0
+    assert result['confusion_tn_mean_return_pct'] == -10.0
+    assert result['confusion_fn_mean_return_pct'] == 10.0
+
+
+def test_compute_confusion_return_metrics_requires_aligned_lengths() -> None:
+
+    model = LogRegBinary()
+    data = {
+        'price_data_for_backtest': pd.DataFrame({
+            'open': [100.0],
+            'close': [110.0],
+        }),
+    }
+
+    with pytest.raises(ValueError, match='price_data_for_backtest'):
+        model._compute_confusion_return_metrics(
+            np.array([1, 0]),
+            np.array([1, 0]),
             data,
-            actuals=np.array([1, 0]),
+        )
+
+    with pytest.raises(ValueError, match='y_test'):
+        model._compute_confusion_return_metrics(
+            np.array([1]),
+            np.array([1, 0]),
+            data,
         )

--- a/tests/test_reference_backtest_alignment.py
+++ b/tests/test_reference_backtest_alignment.py
@@ -1,10 +1,9 @@
+import math
 from unittest.mock import patch
 
 import numpy as np
 import pandas as pd
-import pytest
 
-from limen.sfd.reference_architecture import LogRegBinary
 from limen.sfd.reference_architecture import RandomBinary
 from limen.sfd.reference_architecture import XGBoostRegressor
 from tests.test_reference_architecture import _make_data
@@ -15,14 +14,14 @@ def _assert_snapshot_kwargs(captured: dict) -> None:
     assert captured['kwargs']['trades_count_mode'] == 'runs'
 
 
-def test_random_binary_inline_backtest_passes_binary_actuals_to_snapshot() -> None:
+def test_random_binary_inline_backtest_does_not_pass_actuals_to_snapshot() -> None:
 
     captured = {}
 
     def _fake_backtest_snapshot(df: pd.DataFrame, **kwargs) -> pd.DataFrame:
         captured['df'] = df.copy()
         captured['kwargs'] = kwargs
-        return pd.DataFrame([{'tp_mean_return_pct': 1.0}])
+        return pd.DataFrame([{'trade_win_rate_pct': 1.0}])
 
     with patch(
         'limen.sfd.reference_architecture.base.backtest_snapshot',
@@ -32,22 +31,18 @@ def test_random_binary_inline_backtest_passes_binary_actuals_to_snapshot() -> No
         model = RandomBinary().train(data, random_weights=0.5)
         model.evaluate(data)
 
-    assert 'actuals' in captured['df'].columns
-    np.testing.assert_array_equal(
-        captured['df']['actuals'].to_numpy(),
-        np.asarray(data['y_test']).astype(int),
-    )
+    assert 'actuals' not in captured['df'].columns
     _assert_snapshot_kwargs(captured)
 
 
-def test_xgboost_inline_backtest_passes_directional_actuals_and_kwargs() -> None:
+def test_xgboost_inline_backtest_uses_directional_predictions_without_actuals() -> None:
 
     captured = {}
 
     def _fake_backtest_snapshot(df: pd.DataFrame, **kwargs) -> pd.DataFrame:
         captured['df'] = df.copy()
         captured['kwargs'] = kwargs
-        return pd.DataFrame([{'tp_mean_return_pct': 1.0}])
+        return pd.DataFrame([{'trade_win_rate_pct': 1.0}])
 
     with patch(
         'limen.sfd.reference_architecture.base.backtest_snapshot',
@@ -62,27 +57,28 @@ def test_xgboost_inline_backtest_passes_directional_actuals_and_kwargs() -> None
         )
         model.evaluate(data)
 
-    assert 'actuals' in captured['df'].columns
-    np.testing.assert_array_equal(
-        captured['df']['actuals'].to_numpy(),
-        (np.asarray(data['y_test']) > 0).astype(int),
-    )
+    assert 'actuals' not in captured['df'].columns
     _assert_snapshot_kwargs(captured)
 
 
-def test_compute_backtest_rejects_nan_actuals() -> None:
+def test_compute_confusion_return_metrics_uses_directional_actuals() -> None:
 
-    model = LogRegBinary()
+    model = XGBoostRegressor()
     data = {
         'price_data_for_backtest': pd.DataFrame({
-            'open': [100.0, 101.0],
-            'close': [110.0, 111.0],
+            'open': [100.0, 100.0, 100.0],
+            'close': [101.0, 99.0, 102.0],
         }),
     }
 
-    with pytest.raises(ValueError, match='actuals must be numeric and contain no NaN values'):
-        model._compute_backtest(
-            np.array([1, 0]),
-            data,
-            actuals=np.array([1.0, np.nan]),
-        )
+    result = model._compute_confusion_return_metrics(
+        np.array([1, 0, 1]),
+        np.array([1, 0, 1]),
+        data,
+        execution_lag_bars=0,
+    )
+
+    assert result['confusion_tp_mean_return_pct'] == 1.5
+    assert result['confusion_tn_mean_return_pct'] == -1.0
+    assert math.isnan(result['confusion_fp_mean_return_pct'])
+    assert math.isnan(result['confusion_fn_mean_return_pct'])


### PR DESCRIPTION
## Summary
- move the TP/FP/TN/FN mean-return fields off the snapshot backtest surface and onto the confusion side where they semantically belong
- restore `backtest_snapshot()` and inline snapshot backtests to price-only inputs with no `actuals` plumbing
- add aligned next-bar confusion-return support post-run through `experiment_confusion_metrics('aligned_return_pct')` and inline through `confusion_*_mean_return_pct`

## Scope Note
- this PR is intentionally limited to the confusion/backtest metric boundary
- it does **not** change `experiment_core` or mainline log/resume behavior
- it keeps the latest merged snapshot execution-lag and run-level trade semantics intact

## Implementation Notes
- inline experiment rows now expose `confusion_tp_mean_return_pct`, `confusion_fp_mean_return_pct`, `confusion_tn_mean_return_pct`, and `confusion_fn_mean_return_pct`
- post-run confusion analysis now supports `aligned_return_pct`, including `tp/fp/tn/fn_mean_return_pct` aliases on that surface
- `experiment_backtest_results()` keeps the trading metrics only; confusion-conditioned return means are no longer emitted from the backtest table

## Testing
- `uv run --with pytest pytest tests/test_backtest_snapshot.py tests/test_reference_architecture.py tests/test_reference_backtest_alignment.py tests/test_metrics_and_log_helpers.py tests/test_inline_metrics.py -q`
- `uv run --with ruff ruff check tests/run.py limen/backtest/backtest_snapshot.py limen/log/_experiment_backtest_results.py limen/log/_permutation_confusion_metrics.py limen/sfd/reference_architecture/base.py limen/sfd/reference_architecture/logreg_binary.py limen/sfd/reference_architecture/random_binary.py limen/sfd/reference_architecture/tabpfn_binary.py limen/sfd/reference_architecture/xgboost_regressor.py tests/test_backtest_snapshot.py tests/test_reference_architecture.py tests/test_reference_backtest_alignment.py tests/test_metrics_and_log_helpers.py tests/test_inline_metrics.py`
- `uv run --with pytest --with coverage coverage run -m tests.run`
- `uv run --with coverage coverage report` (`TOTAL 93%`)