### PR TITLE
feat: Add Kelly and confusion mean return metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -701,3 +701,8 @@ Note: add all new changelog entries to the bottom of this file.
 ## v2.3.1 on 19th of April, 2026
 
 - Revert v2.3.0 snapshot backtest alignment and trade metric changes in full, restoring the pre-v2.3.0 behavior and output surface
+
+## v2.3.2 on 19th of April, 2026
+
+- Add `mean_kelly_pct` back to snapshot backtests without changing the restored legacy execution semantics
+- Add TP/FP/TN/FN mean return percentage columns to the existing confusion metrics surfaces, both inline and post-run, using the existing aligned `open` and `price_change` data

--- a/limen/backtest/backtest_snapshot.py
+++ b/limen/backtest/backtest_snapshot.py
@@ -34,6 +34,7 @@ def backtest_snapshot(df: pd.DataFrame,
         'total_return_net_pct',
         'trade_return_mean_win_pct',
         'trade_return_mean_loss_pct',
+        'mean_kelly_pct',
         'bars_total',
         'sharpe_per_bar',
         'bars_in_market_pct',
@@ -95,6 +96,25 @@ def backtest_snapshot(df: pd.DataFrame,
         trade_win_rate_pct = trade_expectancy_pct = _trade_return_mean_pct = np.nan
         trade_return_mean_win_pct = trade_return_mean_loss_pct = np.nan
 
+    if trades_count_mode == 'runs':
+        entries = pos & (~pos.shift(1, fill_value=False))
+        run_ids = entries.cumsum()
+        kelly_returns = ((1.0 + R_net[pos]).groupby(run_ids[pos]).prod() - 1.0) if int(entries.sum()) else pd.Series(dtype=float)
+    else:
+        kelly_returns = R_net[pos]
+
+    kelly_wins = kelly_returns[kelly_returns > 0]
+    kelly_losses = kelly_returns[kelly_returns < 0]
+    if kelly_wins.size and kelly_losses.size:
+        win_rate = float(kelly_wins.size / kelly_returns.size)
+        loss_rate = float(kelly_losses.size / kelly_returns.size)
+        avg_win = float(kelly_wins.mean())
+        avg_loss = abs(float(kelly_losses.mean()))
+        payout_ratio = avg_win / avg_loss if avg_loss > 0 else np.nan
+        mean_kelly_pct = float((win_rate - (loss_rate / payout_ratio)) * 100.0) if payout_ratio > 0 else np.nan
+    else:
+        mean_kelly_pct = np.nan
+
     mu = float(R_net.mean())
     sd = float(R_net.std(ddof=1))
 
@@ -108,6 +128,7 @@ def backtest_snapshot(df: pd.DataFrame,
         'total_return_net_pct': round(total_return_net_pct, 1),
         'trade_return_mean_win_pct': round(trade_return_mean_win_pct, 1),
         'trade_return_mean_loss_pct': round(trade_return_mean_loss_pct, 1),
+        'mean_kelly_pct': round(mean_kelly_pct, 3),
         'bars_total': int(bars_total),
         'sharpe_per_bar': round(sharpe_per_bar, 2),
         'bars_in_market_pct': round(bars_in_market_pct, 1),
@@ -116,4 +137,3 @@ def backtest_snapshot(df: pd.DataFrame,
     }])
 
     return data
-

--- a/limen/log/_permutation_confusion_metrics.py
+++ b/limen/log/_permutation_confusion_metrics.py
@@ -5,6 +5,53 @@ from collections.abc import Sequence
 from math import sqrt
 
 
+def _confusion_mean_return_pct(pred: pd.Series,
+                               actual: pd.Series,
+                               open_px: pd.Series,
+                               price_change: pd.Series) -> dict[str, float]:
+    '''
+    Compute mean return percentage for each confusion quadrant.
+
+    Args:
+        pred (pd.Series): Binary predictions
+        actual (pd.Series): Binary actuals
+        open_px (pd.Series): Open prices for the evaluated rows
+        price_change (pd.Series): Close - open for the evaluated rows
+
+    Returns:
+        dict[str, float]: Mean return percentages for TP/FP/TN/FN
+    '''
+
+    pred = pd.to_numeric(pd.Series(np.asarray(pred)), errors='coerce').to_numpy()
+    actual = pd.to_numeric(pd.Series(np.asarray(actual)), errors='coerce').to_numpy()
+    open_px = pd.to_numeric(pd.Series(np.asarray(open_px)), errors='coerce').to_numpy()
+    price_change = pd.to_numeric(pd.Series(np.asarray(price_change)), errors='coerce').to_numpy()
+
+    return_pct = (price_change / open_px) * 100.0
+    valid = (
+        ~np.isnan(pred) &
+        ~np.isnan(actual) &
+        ~np.isnan(open_px) &
+        (open_px != 0) &
+        np.isfinite(return_pct)
+    )
+
+    pred = pred[valid].astype(int)
+    actual = actual[valid].astype(int)
+    return_pct = return_pct[valid]
+
+    def _mean(mask: np.ndarray) -> float:
+        values = return_pct[mask]
+        return round(float(values.mean()), 3) if values.size else np.nan
+
+    return {
+        'tp_mean_return_pct': _mean((pred == 1) & (actual == 1)),
+        'fp_mean_return_pct': _mean((pred == 1) & (actual == 0)),
+        'tn_mean_return_pct': _mean((pred == 0) & (actual == 0)),
+        'fn_mean_return_pct': _mean((pred == 0) & (actual == 1)),
+    }
+
+
 def _permutation_confusion_metrics(self: Any,
                                   x: str,
                                   round_id: int,
@@ -34,7 +81,9 @@ def _permutation_confusion_metrics(self: Any,
         pd.DataFrame: One-row table with columns 'x_name', 'n_kept', 'pred_pos_rate_pct',
                       'actual_pos_rate_pct', 'precision_pct', 'recall_pct', 'pred_pos_count',
                       'tp_count', 'fp_count', 'tp_x_mean', 'tp_x_median', 'fp_x_mean', 'fp_x_median',
-                      'pred_pos_x_mean', 'pred_pos_x_median', 'tp_fp_cohen_d', 'tp_fp_ks'
+                      'pred_pos_x_mean', 'pred_pos_x_median', 'tp_fp_cohen_d', 'tp_fp_ks',
+                      'tp_mean_return_pct', 'fp_mean_return_pct', 'tn_mean_return_pct',
+                      'fn_mean_return_pct'
     '''
 
     df = self.permutation_prediction_performance(round_id)
@@ -47,7 +96,7 @@ def _permutation_confusion_metrics(self: Any,
         df[pred_col] = (df[proba_col].astype(float) >= float(threshold)).astype(int)
 
     # Validate required columns
-    for col in (pred_col, actual_col, x):
+    for col in (pred_col, actual_col, x, 'open', 'price_change'):
         if col not in df:
             raise ValueError(f'column "{col}" not found')
 
@@ -136,6 +185,12 @@ def _permutation_confusion_metrics(self: Any,
     fp_x = df.loc[m_fp, x].to_numpy()
     tp_fp_cohen_d = _cohen_d(tp_x, fp_x)
     tp_fp_ks = _ks(tp_x, fp_x)
+    mean_return_pct = _confusion_mean_return_pct(
+        df[pred_col],
+        df[actual_col],
+        df['open'],
+        df['price_change'],
+    )
 
     return pd.DataFrame.from_records([{
         **(id_cols or {}),
@@ -156,5 +211,5 @@ def _permutation_confusion_metrics(self: Any,
         'tp_fp_ks': float(tp_fp_ks),
         'x_name': x,
         'n_kept': int(n),
+        **mean_return_pct,
     }])
-

--- a/limen/sfd/reference_architecture/base.py
+++ b/limen/sfd/reference_architecture/base.py
@@ -6,6 +6,7 @@ import numpy as np
 import pandas as pd
 
 from limen.backtest.backtest_snapshot import backtest_snapshot
+from limen.log._permutation_confusion_metrics import _confusion_mean_return_pct
 
 
 class ReferenceModel(ABC):
@@ -67,7 +68,13 @@ class ReferenceModel(ABC):
 
         ...
 
-    def _compute_confusion(self, preds: np.ndarray, y_test: np.ndarray) -> dict:
+    def _price_data_to_pandas(self, price_data_for_backtest: Any) -> pd.DataFrame:
+        return price_data_for_backtest.to_pandas()
+
+    def _compute_confusion(self,
+                           preds: np.ndarray,
+                           y_test: np.ndarray,
+                           price_data_for_backtest: Any | None = None) -> dict:
 
         '''
         Compute confusion matrix metrics from binary predictions.
@@ -91,7 +98,7 @@ class ReferenceModel(ABC):
         precision = round(tp / (tp + fp), 3) if (tp + fp) > 0 else 0.0
         recall = round(tp / (tp + fn), 3) if (tp + fn) > 0 else 0.0
 
-        return {
+        results = {
             'confusion_tp': tp,
             'confusion_fp': fp,
             'confusion_tn': tn,
@@ -99,6 +106,21 @@ class ReferenceModel(ABC):
             'confusion_precision': precision,
             'confusion_recall': recall,
         }
+
+        if price_data_for_backtest is None:
+            raise ValueError('price_data_for_backtest is required for inline confusion mean return metrics')
+
+        price_pd = self._price_data_to_pandas(price_data_for_backtest)
+
+        confusion_return_pct = _confusion_mean_return_pct(
+            preds,
+            y_test,
+            price_pd['open'],
+            price_pd['close'] - price_pd['open'],
+        )
+        results.update({f'confusion_{k}': v for k, v in confusion_return_pct.items()})
+
+        return results
 
     def _compute_backtest(self, preds: np.ndarray, data: dict) -> dict:
 
@@ -116,14 +138,7 @@ class ReferenceModel(ABC):
         if 'price_data_for_backtest' not in data:
             return {}
 
-        price_df = data['price_data_for_backtest']
-
-        if isinstance(price_df, pd.DataFrame):
-            price_pd = price_df
-        elif hasattr(price_df, 'to_pandas'):
-            price_pd = price_df.to_pandas()
-        else:
-            return {}
+        price_pd = self._price_data_to_pandas(data['price_data_for_backtest'])
 
         bt_input = pd.DataFrame({
             'predictions': np.asarray(preds).astype(int),

--- a/limen/sfd/reference_architecture/logreg_binary.py
+++ b/limen/sfd/reference_architecture/logreg_binary.py
@@ -73,7 +73,7 @@ class LogRegBinary(ReferenceModel):
         results['_preds'] = preds
 
         if inline_metrics:
-            results.update(self._compute_confusion(preds, data['y_test']))
+            results.update(self._compute_confusion(preds, data['y_test'], data.get('price_data_for_backtest')))
             results.update(self._compute_backtest(preds, data))
 
         return results

--- a/limen/sfd/reference_architecture/random_binary.py
+++ b/limen/sfd/reference_architecture/random_binary.py
@@ -76,7 +76,7 @@ class RandomBinary(ReferenceModel):
         results['_preds'] = preds
 
         if inline_metrics:
-            results.update(self._compute_confusion(preds, data['y_test']))
+            results.update(self._compute_confusion(preds, data['y_test'], data.get('price_data_for_backtest')))
             results.update(self._compute_backtest(preds, data))
 
         return results

--- a/limen/sfd/reference_architecture/tabpfn_binary.py
+++ b/limen/sfd/reference_architecture/tabpfn_binary.py
@@ -135,7 +135,7 @@ class TabPFNBinary(ReferenceModel):
         results['_preds'] = preds
 
         if inline_metrics:
-            results.update(self._compute_confusion(preds, data['y_test']))
+            results.update(self._compute_confusion(preds, data['y_test'], data.get('price_data_for_backtest')))
             results.update(self._compute_backtest(preds, data))
 
         return results

--- a/limen/sfd/reference_architecture/xgboost_regressor.py
+++ b/limen/sfd/reference_architecture/xgboost_regressor.py
@@ -85,7 +85,7 @@ class XGBoostRegressor(ReferenceModel):
             y_test = np.asarray(data['y_test'])
             pred_direction = (preds > 0).astype(int)
             actual_direction = (y_test > 0).astype(int)
-            results.update(self._compute_confusion(pred_direction, actual_direction))
+            results.update(self._compute_confusion(pred_direction, actual_direction, data.get('price_data_for_backtest')))
             results.update(self._compute_backtest(pred_direction, data))
 
         return results

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaquum_limen"
-version = "2.3.1"
+version = "2.3.2"
 description = "Bitcoin-first research and trading platform."
 readme = "README.md"
 authors = [

--- a/tests/test_inline_metrics.py
+++ b/tests/test_inline_metrics.py
@@ -39,12 +39,21 @@ def test_inline_and_post_experiment_metrics() -> None:
         assert col in log_cols, f"Missing inline confusion column: {col}"
         assert uel.experiment_log[col].null_count() == 0, f"Null values in {col}"
 
+    for col in ['confusion_tp_mean_return_pct', 'confusion_fp_mean_return_pct',
+                'confusion_tn_mean_return_pct', 'confusion_fn_mean_return_pct']:
+        assert col in log_cols, f"Missing inline confusion return column: {col}"
+
     for col in ['backtest_trade_win_rate_pct', 'backtest_max_drawdown_pct',
                 'backtest_total_return_net_pct', 'backtest_sharpe_per_bar']:
         assert col in log_cols, f"Missing inline backtest column: {col}"
         assert uel.experiment_log[col].null_count() == 0, f"Null values in {col}"
 
+    assert 'backtest_mean_kelly_pct' in log_cols
+
     assert uel.experiment_confusion_metrics is not None
     assert len(uel.experiment_confusion_metrics) > 0
+    for col in ['tp_mean_return_pct', 'fp_mean_return_pct', 'tn_mean_return_pct', 'fn_mean_return_pct']:
+        assert col in uel.experiment_confusion_metrics.columns, f"Missing confusion metric column: {col}"
     assert uel.experiment_backtest_results is not None
     assert len(uel.experiment_backtest_results) > 0
+    assert 'mean_kelly_pct' in uel.experiment_backtest_results.columns

--- a/tests/test_metrics_and_log_helpers.py
+++ b/tests/test_metrics_and_log_helpers.py
@@ -1,8 +1,12 @@
 import numpy as np
 import polars as pl
+import pandas as pd
 import pytest
 from sklearn.metrics import accuracy_score, precision_score, recall_score
 
+from limen.backtest.backtest_snapshot import backtest_snapshot
+from limen.log._permutation_confusion_metrics import _confusion_mean_return_pct
+from limen.log._permutation_confusion_metrics import _permutation_confusion_metrics
 from limen.log._permutation_prediction_performance import _permutation_prediction_performance
 from limen.metrics.balanced_metric import balanced_metric
 from limen.metrics.multiclass_metrics import multiclass_metrics
@@ -64,6 +68,30 @@ class _DummyPerfWithoutInverseScaler:
         return pl.DataFrame({'open': [1.0, 2.0], 'close': [1.5, 1.5]})
 
 
+class _DummyConfusionMetrics:
+
+    def permutation_prediction_performance(self, round_id: int) -> pd.DataFrame:
+        assert round_id == 0
+        return pd.DataFrame({
+            'predictions': [1, 1, 0, 0],
+            'actuals': [1, 0, 0, 1],
+            'open': [100.0, 100.0, 100.0, 100.0],
+            'close': [110.0, 90.0, 95.0, 105.0],
+            'price_change': [10.0, -10.0, -5.0, 5.0],
+        })
+
+
+class _DummyConfusionMetricsMissingPriceChange:
+
+    def permutation_prediction_performance(self, round_id: int) -> pd.DataFrame:
+        assert round_id == 0
+        return pd.DataFrame({
+            'predictions': [1, 1, 0, 0],
+            'actuals': [1, 0, 0, 1],
+            'open': [100.0, 100.0, 100.0, 100.0],
+        })
+
+
 def test_permutation_prediction_performance_preserves_inverse_scaled_features() -> None:
     perf = _permutation_prediction_performance(_DummyPerfWithInverseScaler(), round_id=0)
 
@@ -93,6 +121,61 @@ def test_permutation_prediction_performance_falls_back_to_single_argument_prep()
     assert perf['predictions'].tolist() == [0, 1]
     assert perf['actuals'].tolist() == [0, 1]
     assert perf['price_change'].tolist() == [0.5, -0.5]
+
+
+def test_permutation_confusion_metrics_adds_mean_return_pct_columns() -> None:
+    result = _permutation_confusion_metrics(
+        _DummyConfusionMetrics(),
+        x='price_change',
+        round_id=0,
+        outlier_quantiles=(0.0, 1.0),
+    ).iloc[0]
+
+    assert result['tp_x_mean'] == 10.0
+    assert result['fp_x_mean'] == -10.0
+    assert result['tp_mean_return_pct'] == 10.0
+    assert result['fp_mean_return_pct'] == -10.0
+    assert result['tn_mean_return_pct'] == -5.0
+    assert result['fn_mean_return_pct'] == 5.0
+
+
+def test_permutation_confusion_metrics_uses_positional_alignment_for_returns() -> None:
+    result = _confusion_mean_return_pct(
+        pd.Series([1, 1, 0, 0]),
+        pd.Series([1, 0, 0, 1]),
+        pd.Series([100.0, 100.0, 100.0, 100.0], index=[10, 11, 12, 13]),
+        pd.Series([10.0, -10.0, -5.0, 5.0], index=[10, 11, 12, 13]),
+    )
+
+    assert result['tp_mean_return_pct'] == 10.0
+    assert result['fp_mean_return_pct'] == -10.0
+    assert result['tn_mean_return_pct'] == -5.0
+    assert result['fn_mean_return_pct'] == 5.0
+
+
+def test_permutation_confusion_metrics_requires_return_columns() -> None:
+    with pytest.raises(ValueError, match='column \"price_change\" not found'):
+        _permutation_confusion_metrics(
+            _DummyConfusionMetricsMissingPriceChange(),
+            x='open',
+            round_id=0,
+            outlier_quantiles=(0.0, 1.0),
+        )
+
+
+def test_backtest_snapshot_adds_mean_kelly_pct() -> None:
+    result = backtest_snapshot(
+        pd.DataFrame({
+            'predictions': [1, 0, 1, 0],
+            'open': [100.0, 100.0, 100.0, 100.0],
+            'close': [120.0, 100.0, 90.0, 100.0],
+            'price_change': [20.0, 0.0, -10.0, 0.0],
+        }),
+        fee_bps=0.0,
+        slip_bps=0.0,
+    ).iloc[0]
+
+    assert result['mean_kelly_pct'] == 25.0
 
 
 def test_multiclass_metrics_returns_expected_rounded_summary() -> None:

--- a/tests/test_reference_architecture.py
+++ b/tests/test_reference_architecture.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pandas as pd
+import polars as pl
 
 from limen.sfd.reference_architecture import XGBoostRegressor
 from limen.sfd.reference_architecture import LogRegBinary
@@ -34,7 +35,7 @@ def _make_data(n=200, binary=False, with_val=True, with_price=True):
 
     if with_price:
         n_test = n - split_val
-        data['price_data_for_backtest'] = pd.DataFrame({
+        data['price_data_for_backtest'] = pl.DataFrame({
             'open': np.random.uniform(100, 200, n_test),
             'high': np.random.uniform(200, 300, n_test),
             'low': np.random.uniform(50, 100, n_test),
@@ -65,11 +66,14 @@ def test_xgboost_evaluate_returns_all_metric_types():
         assert key in results, f"Missing results key: {key}"
 
     for key in ['confusion_tp', 'confusion_fp', 'confusion_tn', 'confusion_fn',
-                'confusion_precision', 'confusion_recall']:
+                'confusion_precision', 'confusion_recall',
+                'confusion_tp_mean_return_pct', 'confusion_fp_mean_return_pct',
+                'confusion_tn_mean_return_pct', 'confusion_fn_mean_return_pct']:
         assert key in results, f"Missing confusion key: {key}"
 
     for key in ['backtest_trade_win_rate_pct', 'backtest_max_drawdown_pct',
-                'backtest_total_return_net_pct', 'backtest_sharpe_per_bar']:
+                'backtest_total_return_net_pct', 'backtest_sharpe_per_bar',
+                'backtest_mean_kelly_pct']:
         assert key in results, f"Missing backtest key: {key}"
 
     assert '_preds' in results
@@ -77,7 +81,7 @@ def test_xgboost_evaluate_returns_all_metric_types():
 
 def test_logreg_train_evaluate_end_to_end():
 
-    data = _make_data(binary=True, with_price=False)
+    data = _make_data(binary=True, with_price=True)
     model = LogRegBinary().train(data, solver='lbfgs', max_iter=200)
     results = model.evaluate(data)
 
@@ -95,7 +99,7 @@ def test_logreg_train_evaluate_end_to_end():
 
 def test_random_binary_train_evaluate_end_to_end():
 
-    data = _make_data(binary=True, with_price=False)
+    data = _make_data(binary=True, with_price=True)
     model = RandomBinary().train(data, random_weights=0.5)
     results = model.evaluate(data)
 
@@ -113,7 +117,7 @@ def test_tabpfn_train_evaluate_end_to_end():
     if TabPFNBinary is None:
         return
 
-    data = _make_data(binary=True, with_price=False)
+    data = _make_data(binary=True, with_price=True)
     model = TabPFNBinary().train(data, n_ensemble_configurations=2, device='cpu')
     results = model.evaluate(data)
 


### PR DESCRIPTION
## Summary
- add `mean_kelly_pct` back to the existing snapshot backtest output
- add `tp_mean_return_pct`, `fp_mean_return_pct`, `tn_mean_return_pct`, and `fn_mean_return_pct` to the existing confusion metrics outputs
- keep this scoped to the existing confusion metrics flow plus the smallest inline hook needed to emit the same fields in the experiment log

## Scope
- based on current `main` after the full revert of #447
- no `experiment_core` changes
- no new metric surface
- no backtest-side label plumbing
- no architecture move; this is just the smallest possible addition of these metrics where they already belong

## Validation
- `uv run --with pytest pytest tests/test_metrics_and_log_helpers.py tests/test_reference_architecture.py tests/test_inline_metrics.py -q`
- `uv run --with ruff ruff check limen/backtest/backtest_snapshot.py limen/log/_permutation_confusion_metrics.py limen/sfd/reference_architecture/base.py limen/sfd/reference_architecture/logreg_binary.py limen/sfd/reference_architecture/random_binary.py limen/sfd/reference_architecture/tabpfn_binary.py limen/sfd/reference_architecture/xgboost_regressor.py tests/test_inline_metrics.py tests/test_metrics_and_log_helpers.py tests/test_reference_architecture.py`
- `uv run --with pytest --with coverage coverage run -m tests.run`
- `uv run --with coverage coverage report`
