### PR TITLE
fix: harden standard results csv serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -730,3 +730,9 @@ Note: add all new changelog entries to the bottom of this file.
 - Drop `HistoricalData.DEFAULT_TEST_FILE_PATH` and `HistoricalData.DEFAULT_TEST_FILE_URL`
 - Move historical-data regression coverage to a small checked-in test fixture under `tests/fixtures`
 - Update first-run and historical-data examples to use `get_spot_klines()` or explicit caller-owned file paths
+
+## v2.4.1 on 20th of April, 2026
+
+- Harden standard-path experiment CSV serialization so commas, quotes, and embedded newlines in logged string fields are emitted safely
+- Make standard-path reruns with the same `experiment_name` write the CSV header only when the file is new or empty, preventing duplicate mid-file headers
+- Add regression coverage for special-string round-trips and reruns against an existing standard-path results CSV

--- a/limen/experiment/experiment_core.py
+++ b/limen/experiment/experiment_core.py
@@ -251,14 +251,13 @@ class UniversalExperimentLoop:
             else:
                 self.experiment_log = self.experiment_log.vstack(pl.DataFrame([round_results]))
 
-            # Handle writing to the file
-            if i == 0:
-                with Path(experiment_name + '.csv').open('a', newline='') as f:
-                    writer = csv.writer(f)
-                    writer.writerow(round_results.keys())
-
-            with Path(experiment_name + '.csv').open('a', newline='') as f:
+            # Match the MSQ path: only write a header when the CSV is new or empty.
+            csv_path = Path(f'{experiment_name}.csv')
+            write_header = not csv_path.exists() or csv_path.stat().st_size == 0
+            with csv_path.open('a', newline='') as f:
                 writer = csv.writer(f)
+                if write_header:
+                    writer.writerow(round_results.keys())
                 writer.writerow(self.experiment_log.row(i))
 
         self._finalize()

--- a/limen/experiment/experiment_core.py
+++ b/limen/experiment/experiment_core.py
@@ -253,13 +253,13 @@ class UniversalExperimentLoop:
 
             # Handle writing to the file
             if i == 0:
-                header_colnames = ','.join(list(round_results.keys()))
-                with Path(experiment_name + '.csv').open('a') as f:
-                    f.write(f"{header_colnames}\n")
+                with Path(experiment_name + '.csv').open('a', newline='') as f:
+                    writer = csv.writer(f)
+                    writer.writerow(round_results.keys())
 
-            log_string = f"{', '.join(map(str, self.experiment_log.row(i)))}\n"
-            with Path(experiment_name + '.csv').open('a') as f:
-                f.write(log_string)
+            with Path(experiment_name + '.csv').open('a', newline='') as f:
+                writer = csv.writer(f)
+                writer.writerow(self.experiment_log.row(i))
 
         self._finalize()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaquum_limen"
-version = "2.4.0"
+version = "2.4.1"
 description = "Bitcoin-first research and trading platform."
 readme = "README.md"
 authors = [

--- a/tests/run.py
+++ b/tests/run.py
@@ -157,6 +157,7 @@ from tests.test_experiment_core_msq import test_run_with_msq_context_params
 from tests.test_experiment_core_msq import test_run_with_msq_feedback_trigger
 from tests.test_experiment_core_msq import test_run_with_msq_checkpoint_trigger
 from tests.test_experiment_core_standard_csv import test_standard_run_csv_round_trips_special_string_fields
+from tests.test_experiment_core_standard_csv import test_standard_run_csv_does_not_append_duplicate_headers_on_rerun
 from tests.test_experiment_core_msq import test_checkpoint_saves_feedback_and_pruning_state
 from tests.test_experiment_core_msq import test_run_with_msq_shutdown_resume_full_data
 from tests.test_experiment_core_msq import test_run_with_msq_shutdown_resume_grid
@@ -571,6 +572,7 @@ tests = [
     test_run_with_msq_feedback_trigger,
     test_run_with_msq_checkpoint_trigger,
     test_standard_run_csv_round_trips_special_string_fields,
+    test_standard_run_csv_does_not_append_duplicate_headers_on_rerun,
     test_checkpoint_saves_feedback_and_pruning_state,
     test_run_with_msq_shutdown_resume_full_data,
     test_run_with_msq_shutdown_resume_grid,

--- a/tests/run.py
+++ b/tests/run.py
@@ -156,6 +156,7 @@ from tests.test_experiment_core_msq import test_run_with_msq_basic_flow
 from tests.test_experiment_core_msq import test_run_with_msq_context_params
 from tests.test_experiment_core_msq import test_run_with_msq_feedback_trigger
 from tests.test_experiment_core_msq import test_run_with_msq_checkpoint_trigger
+from tests.test_experiment_core_standard_csv import test_standard_run_csv_round_trips_special_string_fields
 from tests.test_experiment_core_msq import test_checkpoint_saves_feedback_and_pruning_state
 from tests.test_experiment_core_msq import test_run_with_msq_shutdown_resume_full_data
 from tests.test_experiment_core_msq import test_run_with_msq_shutdown_resume_grid
@@ -569,6 +570,7 @@ tests = [
     test_run_with_msq_context_params,
     test_run_with_msq_feedback_trigger,
     test_run_with_msq_checkpoint_trigger,
+    test_standard_run_csv_round_trips_special_string_fields,
     test_checkpoint_saves_feedback_and_pruning_state,
     test_run_with_msq_shutdown_resume_full_data,
     test_run_with_msq_shutdown_resume_grid,

--- a/tests/test_experiment_core_standard_csv.py
+++ b/tests/test_experiment_core_standard_csv.py
@@ -1,0 +1,85 @@
+import csv
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from types import SimpleNamespace
+
+import polars as pl
+
+from limen.experiment.experiment_core import UniversalExperimentLoop
+from limen.data.utils.splits import split_data_to_prep_output
+from limen.data.utils.splits import split_sequential
+
+
+def _make_standard_csv_test_data() -> pl.DataFrame:
+    opens = [100.0] * 16
+    closes = [101.0, 100.0, 99.0, 100.0] * 4
+
+    return pl.DataFrame({
+        'datetime': pl.datetime_range(
+            start=pl.datetime(2025, 1, 1, 0, 0, 0),
+            end=pl.datetime(2025, 1, 1, 15, 0, 0),
+            interval='1h',
+            eager=True,
+        ),
+        'feature': list(range(16)),
+        'open': opens,
+        'close': closes,
+        'target': [1, 0, 1, 0] * 4,
+    })
+
+
+def _standard_csv_test_prep(
+    data: pl.DataFrame,
+    round_params: dict | None = None,
+) -> dict:
+    _ = round_params
+    split_data = split_sequential(data, (3, 0, 1))
+    return split_data_to_prep_output(
+        split_data,
+        list(data.columns),
+        data['datetime'].to_list(),
+    )
+
+
+def _standard_csv_test_model(data: dict, round_params: dict) -> dict:
+    _ = round_params
+    preds = data['y_test'].to_list()
+    return {
+        'accuracy': 1.0,
+        '_preds': preds,
+    }
+
+
+def test_standard_run_csv_round_trips_special_string_fields() -> None:
+    note = 'alpha, "beta"\nline2'
+    label = 'gamma,delta'
+
+    sfd = SimpleNamespace(
+        params=lambda: {'marker': [0]},
+        prep=_standard_csv_test_prep,
+        model=_standard_csv_test_model,
+    )
+
+    with TemporaryDirectory() as tmpdir:
+        experiment_name = str(Path(tmpdir) / 'standard_csv')
+
+        uel = UniversalExperimentLoop(
+            data=_make_standard_csv_test_data(),
+            sfd=sfd,
+        )
+        uel.run(
+            experiment_name=experiment_name,
+            n_permutations=1,
+            prep_each_round=True,
+            random_search=False,
+            context_params={'note': note, 'label': label},
+        )
+
+        csv_path = Path(f'{experiment_name}.csv')
+        with csv_path.open(newline='') as f:
+            rows = list(csv.DictReader(f))
+
+    assert len(rows) == 1
+    assert list(rows[0].keys()) == uel.experiment_log.columns
+    assert rows[0]['note'] == note
+    assert rows[0]['label'] == label

--- a/tests/test_experiment_core_standard_csv.py
+++ b/tests/test_experiment_core_standard_csv.py
@@ -75,7 +75,7 @@ def test_standard_run_csv_round_trips_special_string_fields() -> None:
             context_params={'note': note, 'label': label},
         )
 
-        csv_path = Path(f'{experiment_name}.csv')
+        csv_path = Path(f"{experiment_name}.csv")
         with csv_path.open(newline='') as f:
             rows = list(csv.DictReader(f))
 
@@ -83,3 +83,50 @@ def test_standard_run_csv_round_trips_special_string_fields() -> None:
     assert list(rows[0].keys()) == uel.experiment_log.columns
     assert rows[0]['note'] == note
     assert rows[0]['label'] == label
+
+
+def test_standard_run_csv_does_not_append_duplicate_headers_on_rerun() -> None:
+    first_note = 'alpha, "beta"\nline2'
+    second_note = 'omega, "delta"\nline2'
+
+    sfd = SimpleNamespace(
+        params=lambda: {'marker': [0]},
+        prep=_standard_csv_test_prep,
+        model=_standard_csv_test_model,
+    )
+
+    with TemporaryDirectory() as tmpdir:
+        experiment_name = str(Path(tmpdir) / 'standard_csv')
+
+        first_uel = UniversalExperimentLoop(
+            data=_make_standard_csv_test_data(),
+            sfd=sfd,
+        )
+        first_uel.run(
+            experiment_name=experiment_name,
+            n_permutations=1,
+            prep_each_round=True,
+            random_search=False,
+            context_params={'note': first_note},
+        )
+
+        second_uel = UniversalExperimentLoop(
+            data=_make_standard_csv_test_data(),
+            sfd=sfd,
+        )
+        second_uel.run(
+            experiment_name=experiment_name,
+            n_permutations=1,
+            prep_each_round=True,
+            random_search=False,
+            context_params={'note': second_note},
+        )
+
+        csv_path = Path(f"{experiment_name}.csv")
+        with csv_path.open(newline='') as f:
+            rows = list(csv.DictReader(f))
+
+    assert len(rows) == 2
+    assert rows[0]['note'] == first_note
+    assert rows[1]['note'] == second_note
+    assert rows[1]['id'] != 'id'


### PR DESCRIPTION
## Summary
- replace manual standard-path CSV string writes with csv.writer so commas, quotes, and newlines are escaped correctly
- add a standard-path regression that round-trips special string fields through the emitted results CSV
- register the regression in the local test harness

Closes #471

## Validation
- ./.venv/bin/ruff check .
- ./.venv/bin/python -m tests.run