### PR TITLE
ci: add test runtime profiling and budget gate

### DIFF
--- a/.github/workflows/pr_checks_tests.yml
+++ b/.github/workflows/pr_checks_tests.yml
@@ -49,16 +49,77 @@ jobs:
           LIMEN_COVERAGE_RUN: '1'
         run: |
           set -x
-          python -m coverage run -m tests.run
-          python -m coverage report
           mkdir -p coverage-artifacts
-          mv .coverage coverage-artifacts/coverage.db
+          test_exit=0
+          python -m coverage run -m tests.run || test_exit=$?
+          if [ -f .coverage ]; then
+            python -m coverage report
+            mv .coverage coverage-artifacts/coverage.db
+          fi
+          exit $test_exit
+
+      - name: Publish runtime summary
+        if: ${{ always() && hashFiles('coverage-artifacts/test_runtime_profile.json') != '' }}
+        run: |
+          python -m tests.runtime_gate \
+            --profile coverage-artifacts/test_runtime_profile.json \
+            --budget tests/runtime_budget.json \
+            --summary-file "$GITHUB_STEP_SUMMARY"
 
       - name: Upload coverage artifact
+        if: ${{ always() && hashFiles('coverage-artifacts/coverage.db') != '' }}
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: coverage-data
           path: coverage-artifacts/coverage.db
+
+      - name: Upload runtime artifact
+        if: ${{ always() && hashFiles('coverage-artifacts/test_runtime_profile.json') != '' }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: test-runtime-profile
+          path: coverage-artifacts/test_runtime_profile.json
+
+  pr_checks_runtime:
+    name: PR Checks Runtime
+    if: ${{ always() }}
+    needs: pr_checks_tests
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+
+      - name: Set up Python
+        uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4
+        with:
+          python-version: '3.10'
+
+      - name: Download runtime artifact
+        if: ${{ needs.pr_checks_tests.result == 'success' }}
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: test-runtime-profile
+          path: coverage-artifacts
+
+      - name: Skip runtime enforcement after upstream failure
+        if: ${{ needs.pr_checks_tests.result != 'success' }}
+        run: |
+          {
+            echo "## Test Runtime"
+            echo
+            echo "Skipped runtime enforcement because \`PR Checks Tests\` did not succeed."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Enforce suite runtime budget
+        if: ${{ needs.pr_checks_tests.result == 'success' }}
+        run: |
+          python -m tests.runtime_gate \
+            --profile coverage-artifacts/test_runtime_profile.json \
+            --budget tests/runtime_budget.json \
+            --summary-file "$GITHUB_STEP_SUMMARY" \
+            --enforce
 
   pr_checks_coverage:
     name: PR Checks Coverage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -731,6 +731,13 @@ Note: add all new changelog entries to the bottom of this file.
 - Move historical-data regression coverage to a small checked-in test fixture under `tests/fixtures`
 - Update first-run and historical-data examples to use `get_spot_klines()` or explicit caller-owned file paths
 
+## v2.4.2 on 20th of April, 2026
+
+- Add structured runtime profiling to `tests/run.py`, including per-test JSON output, suite totals, and a sorted slowest-tests summary on the canonical coverage-enabled test path
+- Add a committed suite runtime budget in `tests/runtime_budget.json` based on recent green `main` CI runs and enforce it in the new `PR Checks Runtime` workflow job
+- Publish the runtime profile as a GitHub Actions artifact and render a runtime job summary with threshold counts and slowest tests during `PR Validation`
+- Add regression coverage for runtime profile emission plus pass/fail runtime-gate behavior without touching `limen/` package code
+
 ## v2.4.1 on 20th of April, 2026
 
 - Harden standard-path experiment CSV serialization so commas, quotes, and embedded newlines in logged string fields are emitted safely

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -731,15 +731,15 @@ Note: add all new changelog entries to the bottom of this file.
 - Move historical-data regression coverage to a small checked-in test fixture under `tests/fixtures`
 - Update first-run and historical-data examples to use `get_spot_klines()` or explicit caller-owned file paths
 
+## v2.4.1 on 20th of April, 2026
+
+- Harden standard-path experiment CSV serialization so commas, quotes, and embedded newlines in logged string fields are emitted safely
+- Make standard-path reruns with the same `experiment_name` write the CSV header only when the file is new or empty, preventing duplicate mid-file headers
+- Add regression coverage for special-string round-trips and reruns against an existing standard-path results CSV
+
 ## v2.4.2 on 20th of April, 2026
 
 - Add structured runtime profiling to `tests/run.py`, including per-test JSON output, suite totals, and a sorted slowest-tests summary on the canonical coverage-enabled test path
 - Add a committed suite runtime budget in `tests/runtime_budget.json` based on recent green `main` CI runs and enforce it in the new `PR Checks Runtime` workflow job
 - Publish the runtime profile as a GitHub Actions artifact and render a runtime job summary with threshold counts and slowest tests during `PR Validation`
 - Add regression coverage for runtime profile emission plus pass/fail runtime-gate behavior without touching `limen/` package code
-
-## v2.4.1 on 20th of April, 2026
-
-- Harden standard-path experiment CSV serialization so commas, quotes, and embedded newlines in logged string fields are emitted safely
-- Make standard-path reruns with the same `experiment_name` write the CSV header only when the file is new or empty, preventing duplicate mid-file headers
-- Add regression coverage for special-string round-trips and reruns against an existing standard-path results CSV

--- a/docs/Developer/README.md
+++ b/docs/Developer/README.md
@@ -30,6 +30,13 @@ Before opening or updating a Limen PR:
 4. Review the full GitHub diff yourself before requesting review.
 5. Make sure the PR template items are genuinely true, not just checked.
 
+## Test Runtime Budget
+
+- `PR Validation` now publishes a `test-runtime-profile` artifact from the canonical `python -m coverage run -m tests.run` path.
+- `PR Checks Runtime` enforces the suite ceiling committed in `tests/runtime_budget.json`.
+- Update `tests/runtime_budget.json` only when recent green `main` CI runs show a real new baseline, and keep that evidence in the linked issue or PR.
+- Do not raise the budget to absorb avoidable slow tests; everything executed through `tests/run.py` is timed automatically.
+
 ## Scope Notes
 
 - `/docs` is the canonical public docs layer.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaquum_limen"
-version = "2.4.1"
+version = "2.4.2"
 description = "Bitcoin-first research and trading platform."
 readme = "README.md"
 authors = [

--- a/tests/run.py
+++ b/tests/run.py
@@ -1,11 +1,12 @@
-import sys
-import time
-import traceback
 import logging
+import os
+import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
+from tests.utils.runtime_tracking import DEFAULT_SLOWEST_TESTS_LIMIT
+from tests.utils.runtime_tracking import execute_test_suite
 from tests.utils.cleanup import cleanup_csv_files
 from tests.utils.cleanup import setup_cleanup_handlers
 
@@ -158,6 +159,9 @@ from tests.test_experiment_core_msq import test_run_with_msq_feedback_trigger
 from tests.test_experiment_core_msq import test_run_with_msq_checkpoint_trigger
 from tests.test_experiment_core_standard_csv import test_standard_run_csv_round_trips_special_string_fields
 from tests.test_experiment_core_standard_csv import test_standard_run_csv_does_not_append_duplicate_headers_on_rerun
+from tests.test_runtime_tracking import test_execute_test_suite_writes_profile_and_stops_on_first_failure
+from tests.test_runtime_tracking import test_runtime_gate_writes_summary_and_passes_when_within_budget
+from tests.test_runtime_tracking import test_runtime_gate_fails_when_profile_exceeds_budget
 from tests.test_experiment_core_msq import test_checkpoint_saves_feedback_and_pruning_state
 from tests.test_experiment_core_msq import test_run_with_msq_shutdown_resume_full_data
 from tests.test_experiment_core_msq import test_run_with_msq_shutdown_resume_grid
@@ -573,6 +577,9 @@ tests = [
     test_run_with_msq_checkpoint_trigger,
     test_standard_run_csv_round_trips_special_string_fields,
     test_standard_run_csv_does_not_append_duplicate_headers_on_rerun,
+    test_execute_test_suite_writes_profile_and_stops_on_first_failure,
+    test_runtime_gate_writes_summary_and_passes_when_within_budget,
+    test_runtime_gate_fails_when_profile_exceeds_budget,
     test_checkpoint_saves_feedback_and_pruning_state,
     test_run_with_msq_shutdown_resume_full_data,
     test_run_with_msq_shutdown_resume_grid,
@@ -942,24 +949,46 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
-setup_cleanup_handlers()
 
-for test in tests:
+def _runtime_profile_output_path() -> Path | None:
+    configured_path = os.getenv('LIMEN_RUNTIME_PROFILE_PATH')
+    if configured_path:
+        return Path(configured_path)
 
-    try:
-        start_time = time.time()
-        test()
-        end_time = time.time()
-        duration = end_time - start_time
-        logger.info('✅ %s: PASSED (%.3fs)', test.__name__, duration)
+    if os.getenv('LIMEN_COVERAGE_RUN') or os.getenv('CI'):
+        return Path('coverage-artifacts/test_runtime_profile.json')
 
-    except Exception as e:
-        end_time = time.time()
-        duration = end_time - start_time
+    return None
 
-        logger.error('❌ %s: FAILED (%.3fs) - %s', test.__name__, duration, str(e))
-        cleanup_csv_files()
-        traceback.print_exc()
-        sys.exit(1)
 
-cleanup_csv_files()
+def _runtime_slowest_tests_limit() -> int:
+    configured_limit = os.getenv('LIMEN_RUNTIME_SLOWEST_LIMIT')
+    if not configured_limit:
+        return DEFAULT_SLOWEST_TESTS_LIMIT
+
+    parsed_limit = int(configured_limit)
+    if parsed_limit <= 0:
+        raise ValueError('LIMEN_RUNTIME_SLOWEST_LIMIT must be a positive integer')
+
+    return parsed_limit
+
+
+def main() -> int:
+    setup_cleanup_handlers()
+    result = execute_test_suite(
+        tests=tests,
+        logger=logger,
+        profile_output_path=_runtime_profile_output_path(),
+        slowest_tests_limit=_runtime_slowest_tests_limit(),
+    )
+
+    cleanup_csv_files()
+
+    if result.failure_traceback is not None:
+        sys.stderr.write(result.failure_traceback)
+
+    return result.exit_code
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/tests/runtime_budget.json
+++ b/tests/runtime_budget.json
@@ -18,6 +18,7 @@
     "observed_median_seconds": 97.0,
     "observed_min_seconds": 85.0,
     "observed_max_seconds": 119.0,
-    "headroom_seconds": 16.0
+    "headroom_seconds": 16.0,
+    "note": "ceiling = observed_max_seconds + headroom_seconds"
   }
 }

--- a/tests/runtime_budget.json
+++ b/tests/runtime_budget.json
@@ -1,0 +1,23 @@
+{
+  "schema_version": 1,
+  "max_total_seconds": 135,
+  "slowest_tests_limit": 10,
+  "threshold_bands_seconds": [
+    1,
+    5,
+    10
+  ],
+  "baseline": {
+    "workflow": "PR Validation",
+    "job": "PR Checks Tests",
+    "step": "Run limen tests with coverage",
+    "sample_count": 12,
+    "window_start": "2026-04-18T05:15:53Z",
+    "window_end": "2026-04-20T07:03:45Z",
+    "observed_average_seconds": 101.83,
+    "observed_median_seconds": 97.0,
+    "observed_min_seconds": 85.0,
+    "observed_max_seconds": 119.0,
+    "headroom_seconds": 16.0
+  }
+}

--- a/tests/runtime_gate.py
+++ b/tests/runtime_gate.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from tests.utils.runtime_tracking import evaluate_runtime_budget
+from tests.utils.runtime_tracking import load_runtime_budget
+from tests.utils.runtime_tracking import load_runtime_profile
+from tests.utils.runtime_tracking import render_runtime_summary_markdown
+from tests.utils.runtime_tracking import write_runtime_summary
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description='Render Limen test runtime summaries and enforce suite budgets.',
+    )
+    parser.add_argument(
+        '--profile',
+        required=True,
+        help='Path to the test runtime profile JSON emitted by tests.run.',
+    )
+    parser.add_argument(
+        '--budget',
+        required=True,
+        help='Path to the committed runtime budget JSON.',
+    )
+    parser.add_argument(
+        '--summary-file',
+        help='Optional path for the rendered markdown summary.',
+    )
+    parser.add_argument(
+        '--enforce',
+        action='store_true',
+        help='Fail with a non-zero exit code when the suite exceeds the budget.',
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    profile = load_runtime_profile(Path(args.profile))
+    budget = load_runtime_budget(Path(args.budget))
+    summary_markdown = render_runtime_summary_markdown(profile, budget=budget)
+
+    if args.summary_file:
+        write_runtime_summary(Path(args.summary_file), summary_markdown)
+
+    sys.stdout.write(summary_markdown + '\n')
+
+    if not args.enforce:
+        return 0
+
+    verdict = evaluate_runtime_budget(profile, budget)
+    if verdict['within_budget']:
+        sys.stdout.write(
+            'Runtime budget passed: '
+            f"{verdict['observed_total_seconds']:.3f}s <= "
+            f"{verdict['max_total_seconds']:.3f}s\n",
+        )
+        return 0
+
+    sys.stderr.write(
+        'Runtime budget exceeded: '
+        f"{verdict['observed_total_seconds']:.3f}s > "
+        f"{verdict['max_total_seconds']:.3f}s "
+        f"(over by {verdict['overage_seconds']:.3f}s)\n",
+    )
+    return 1
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/tests/test_runtime_tracking.py
+++ b/tests/test_runtime_tracking.py
@@ -1,0 +1,181 @@
+import json
+import logging
+import subprocess
+import sys
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from tests.utils.runtime_tracking import execute_test_suite
+from tests.utils.runtime_tracking import load_runtime_profile
+
+
+def _make_runtime_logger(name: str) -> logging.Logger:
+    logger = logging.getLogger(name)
+    logger.handlers.clear()
+    logger.addHandler(logging.NullHandler())
+    logger.propagate = False
+    return logger
+
+
+def test_execute_test_suite_writes_profile_and_stops_on_first_failure() -> None:
+    execution_order: list[str] = []
+
+    def passing_test() -> None:
+        execution_order.append('passing')
+
+    def failing_test() -> None:
+        execution_order.append('failing')
+        raise RuntimeError('boom')
+
+    def trailing_test() -> None:
+        execution_order.append('trailing')
+
+    with TemporaryDirectory() as tmpdir:
+        profile_path = Path(tmpdir) / 'runtime_profile.json'
+        result = execute_test_suite(
+            tests=[passing_test, failing_test, trailing_test],
+            logger=_make_runtime_logger('tests.runtime_tracking.failure'),
+            profile_output_path=profile_path,
+            slowest_tests_limit=2,
+        )
+        profile = load_runtime_profile(profile_path)
+
+    assert result.exit_code == 1
+    assert result.failure_traceback is not None
+    assert 'RuntimeError: boom' in result.failure_traceback
+    assert execution_order == ['passing', 'failing']
+    assert profile['suite']['test_count'] == 2
+    assert profile['suite']['passed_count'] == 1
+    assert profile['suite']['failed_count'] == 1
+    assert profile['tests'][1]['status'] == 'failed'
+    assert profile['tests'][1]['error'] == 'RuntimeError: boom'
+
+
+def test_runtime_gate_writes_summary_and_passes_when_within_budget() -> None:
+    profile = {
+        'schema_version': 1,
+        'suite': {
+            'started_at': '2026-04-20T07:00:00.000Z',
+            'finished_at': '2026-04-20T07:00:03.500Z',
+            'duration_seconds': 3.5,
+            'test_count': 2,
+            'passed_count': 2,
+            'failed_count': 0,
+        },
+        'tests': [
+            {
+                'test_name': 'test_fast',
+                'module': 'tests.test_runtime_tracking',
+                'status': 'passed',
+                'duration_seconds': 0.5,
+                'started_at': '2026-04-20T07:00:00.000Z',
+                'finished_at': '2026-04-20T07:00:00.500Z',
+            },
+            {
+                'test_name': 'test_slow',
+                'module': 'tests.test_runtime_tracking',
+                'status': 'passed',
+                'duration_seconds': 3.0,
+                'started_at': '2026-04-20T07:00:00.500Z',
+                'finished_at': '2026-04-20T07:00:03.500Z',
+            },
+        ],
+    }
+    budget = {
+        'schema_version': 1,
+        'max_total_seconds': 5,
+        'slowest_tests_limit': 2,
+        'threshold_bands_seconds': [1, 5, 10],
+    }
+
+    with TemporaryDirectory() as tmpdir:
+        profile_path = Path(tmpdir) / 'runtime_profile.json'
+        budget_path = Path(tmpdir) / 'runtime_budget.json'
+        summary_path = Path(tmpdir) / 'runtime_summary.md'
+
+        profile_path.write_text(json.dumps(profile), encoding='utf-8')
+        budget_path.write_text(json.dumps(budget), encoding='utf-8')
+
+        result = subprocess.run(  # noqa: S603
+            [
+                sys.executable,
+                '-m',
+                'tests.runtime_gate',
+                '--profile',
+                str(profile_path),
+                '--budget',
+                str(budget_path),
+                '--summary-file',
+                str(summary_path),
+                '--enforce',
+            ],
+            cwd=Path(__file__).resolve().parent.parent,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        summary = summary_path.read_text(encoding='utf-8')
+
+    assert result.returncode == 0
+    assert 'Runtime budget passed' in result.stdout
+    assert 'Budget status: `PASS`' in summary
+    assert '| > 1s | 1 |' in summary
+    assert 'test_slow' in summary
+
+
+def test_runtime_gate_fails_when_profile_exceeds_budget() -> None:
+    profile = {
+        'schema_version': 1,
+        'suite': {
+            'started_at': '2026-04-20T07:00:00.000Z',
+            'finished_at': '2026-04-20T07:00:06.200Z',
+            'duration_seconds': 6.2,
+            'test_count': 1,
+            'passed_count': 1,
+            'failed_count': 0,
+        },
+        'tests': [
+            {
+                'test_name': 'test_over_budget',
+                'module': 'tests.test_runtime_tracking',
+                'status': 'passed',
+                'duration_seconds': 6.2,
+                'started_at': '2026-04-20T07:00:00.000Z',
+                'finished_at': '2026-04-20T07:00:06.200Z',
+            },
+        ],
+    }
+    budget = {
+        'schema_version': 1,
+        'max_total_seconds': 5,
+        'slowest_tests_limit': 10,
+        'threshold_bands_seconds': [1, 5, 10],
+    }
+
+    with TemporaryDirectory() as tmpdir:
+        profile_path = Path(tmpdir) / 'runtime_profile.json'
+        budget_path = Path(tmpdir) / 'runtime_budget.json'
+
+        profile_path.write_text(json.dumps(profile), encoding='utf-8')
+        budget_path.write_text(json.dumps(budget), encoding='utf-8')
+
+        result = subprocess.run(  # noqa: S603
+            [
+                sys.executable,
+                '-m',
+                'tests.runtime_gate',
+                '--profile',
+                str(profile_path),
+                '--budget',
+                str(budget_path),
+                '--enforce',
+            ],
+            cwd=Path(__file__).resolve().parent.parent,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+    assert result.returncode == 1
+    assert 'Runtime budget exceeded' in result.stderr

--- a/tests/test_runtime_tracking.py
+++ b/tests/test_runtime_tracking.py
@@ -7,6 +7,7 @@ from tempfile import TemporaryDirectory
 
 from tests.utils.runtime_tracking import execute_test_suite
 from tests.utils.runtime_tracking import load_runtime_profile
+from tests.utils.runtime_tracking import write_runtime_summary
 
 
 def _make_runtime_logger(name: str) -> logging.Logger:
@@ -179,3 +180,15 @@ def test_runtime_gate_fails_when_profile_exceeds_budget() -> None:
 
     assert result.returncode == 1
     assert 'Runtime budget exceeded' in result.stderr
+
+
+def test_write_runtime_summary_appends_to_existing_summary_file() -> None:
+    with TemporaryDirectory() as tmpdir:
+        summary_path = Path(tmpdir) / 'runtime_summary.md'
+        summary_path.write_text('Existing section\n', encoding='utf-8')
+
+        write_runtime_summary(summary_path, '## Test Runtime\n\n- Total runtime: `1.000s`')
+
+        summary = summary_path.read_text(encoding='utf-8')
+
+    assert summary == 'Existing section\n## Test Runtime\n\n- Total runtime: `1.000s`\n'

--- a/tests/utils/runtime_tracking.py
+++ b/tests/utils/runtime_tracking.py
@@ -1,0 +1,340 @@
+from __future__ import annotations
+
+import json
+import time
+import traceback
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import datetime
+from datetime import timezone
+from pathlib import Path
+from typing import TYPE_CHECKING
+from typing import Any
+
+if TYPE_CHECKING:
+    import logging
+
+
+DEFAULT_SLOWEST_TESTS_LIMIT = 10
+DEFAULT_THRESHOLD_BANDS_SECONDS = (1.0, 5.0, 10.0)
+
+TestCallable = Callable[[], None]
+
+
+@dataclass
+class TestSuiteRunResult:
+    exit_code: int
+    failure_traceback: str | None
+    profile: dict[str, Any]
+
+
+def utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec='milliseconds').replace(
+        '+00:00',
+        'Z',
+    )
+
+
+def format_duration(seconds: float) -> str:
+    if seconds < 60:
+        return f'{seconds:.3f}s'
+
+    minutes, remaining_seconds = divmod(seconds, 60)
+    return f'{int(minutes)}m {remaining_seconds:05.3f}s'
+
+
+def build_runtime_profile(
+    test_records: list[dict[str, Any]],
+    suite_started_at: str,
+    suite_finished_at: str,
+    total_duration_seconds: float,
+) -> dict[str, Any]:
+    passed_count = sum(record['status'] == 'passed' for record in test_records)
+    failed_count = sum(record['status'] == 'failed' for record in test_records)
+
+    return {
+        'schema_version': 1,
+        'suite': {
+            'started_at': suite_started_at,
+            'finished_at': suite_finished_at,
+            'duration_seconds': round(total_duration_seconds, 6),
+            'test_count': len(test_records),
+            'passed_count': passed_count,
+            'failed_count': failed_count,
+        },
+        'tests': test_records,
+    }
+
+
+def write_runtime_profile(profile: dict[str, Any], output_path: Path) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(
+        json.dumps(profile, indent=2) + '\n',
+        encoding='utf-8',
+    )
+
+
+def load_runtime_profile(profile_path: Path) -> dict[str, Any]:
+    profile = json.loads(profile_path.read_text(encoding='utf-8'))
+
+    if 'suite' not in profile or 'tests' not in profile:
+        raise ValueError('runtime profile must include suite and tests sections')
+
+    return profile
+
+
+def load_runtime_budget(budget_path: Path) -> dict[str, Any]:
+    budget = json.loads(budget_path.read_text(encoding='utf-8'))
+
+    max_total_seconds = float(budget['max_total_seconds'])
+    if max_total_seconds <= 0:
+        raise ValueError('max_total_seconds must be positive')
+
+    slowest_tests_limit = int(budget.get('slowest_tests_limit', DEFAULT_SLOWEST_TESTS_LIMIT))
+    if slowest_tests_limit <= 0:
+        raise ValueError('slowest_tests_limit must be positive')
+
+    threshold_bands = normalize_threshold_bands(
+        budget.get('threshold_bands_seconds'),
+    )
+
+    budget['max_total_seconds'] = max_total_seconds
+    budget['slowest_tests_limit'] = slowest_tests_limit
+    budget['threshold_bands_seconds'] = list(threshold_bands)
+    return budget
+
+
+def normalize_threshold_bands(
+    threshold_bands: list[float] | tuple[float, ...] | None,
+) -> tuple[float, ...]:
+    if threshold_bands is None:
+        return DEFAULT_THRESHOLD_BANDS_SECONDS
+
+    normalized = tuple(float(band) for band in threshold_bands)
+    if not normalized:
+        raise ValueError('threshold_bands_seconds must not be empty')
+
+    if any(band <= 0 for band in normalized):
+        raise ValueError('threshold_bands_seconds values must be positive')
+
+    return normalized
+
+
+def sorted_test_records(
+    profile: dict[str, Any],
+    limit: int | None = None,
+) -> list[dict[str, Any]]:
+    records = sorted(
+        profile['tests'],
+        key=lambda record: float(record['duration_seconds']),
+        reverse=True,
+    )
+
+    if limit is None:
+        return records
+
+    return records[:limit]
+
+
+def count_tests_above_thresholds(
+    profile: dict[str, Any],
+    threshold_bands: list[float] | tuple[float, ...] | None = None,
+) -> list[tuple[float, int]]:
+    normalized_bands = normalize_threshold_bands(threshold_bands)
+    records = profile['tests']
+
+    return [
+        (
+            band,
+            sum(float(record['duration_seconds']) > band for record in records),
+        )
+        for band in normalized_bands
+    ]
+
+
+def evaluate_runtime_budget(
+    profile: dict[str, Any],
+    budget: dict[str, Any],
+) -> dict[str, Any]:
+    observed_total_seconds = float(profile['suite']['duration_seconds'])
+    max_total_seconds = float(budget['max_total_seconds'])
+    overage_seconds = max(0.0, observed_total_seconds - max_total_seconds)
+
+    return {
+        'within_budget': observed_total_seconds <= max_total_seconds,
+        'observed_total_seconds': observed_total_seconds,
+        'max_total_seconds': max_total_seconds,
+        'overage_seconds': overage_seconds,
+    }
+
+
+def render_runtime_summary_markdown(
+    profile: dict[str, Any],
+    budget: dict[str, Any] | None = None,
+) -> str:
+    suite = profile['suite']
+    threshold_bands = (
+        budget['threshold_bands_seconds']
+        if budget is not None
+        else list(DEFAULT_THRESHOLD_BANDS_SECONDS)
+    )
+    slowest_tests_limit = (
+        int(budget['slowest_tests_limit'])
+        if budget is not None
+        else DEFAULT_SLOWEST_TESTS_LIMIT
+    )
+
+    lines = [
+        '## Test Runtime',
+        '',
+        f"- Total runtime: `{format_duration(float(suite['duration_seconds']))}`",
+        f"- Tests recorded: `{suite['test_count']}`",
+        f"- Passed: `{suite['passed_count']}`",
+        f"- Failed: `{suite['failed_count']}`",
+    ]
+
+    if budget is not None:
+        verdict = evaluate_runtime_budget(profile, budget)
+        status = 'PASS' if verdict['within_budget'] else 'FAIL'
+        delta_label = 'Headroom' if verdict['within_budget'] else 'Overage'
+        delta_seconds = (
+            verdict['max_total_seconds'] - verdict['observed_total_seconds']
+            if verdict['within_budget']
+            else verdict['overage_seconds']
+        )
+        lines.extend([
+            f"- Budget status: `{status}`",
+            f"- Budget ceiling: `{format_duration(verdict['max_total_seconds'])}`",
+            f"- {delta_label}: `{format_duration(abs(delta_seconds))}`",
+        ])
+
+    lines.extend([
+        '',
+        '### Threshold Counts',
+        '',
+        '| Threshold | Count |',
+        '| --- | ---: |',
+    ])
+
+    for band, count in count_tests_above_thresholds(profile, threshold_bands):
+        lines.append(f'| > {band:g}s | {count} |')
+
+    lines.extend([
+        '',
+        f'### Slowest Tests (Top {slowest_tests_limit})',
+        '',
+        '| Test | Status | Duration |',
+        '| --- | --- | ---: |',
+    ])
+
+    for record in sorted_test_records(profile, limit=slowest_tests_limit):
+        test_name = str(record['test_name']).replace('|', '\\|')
+        lines.append(
+            '| '
+            f'{test_name} | {record["status"]} | '
+            f'{format_duration(float(record["duration_seconds"]))} |'
+        )
+
+    return '\n'.join(lines)
+
+
+def write_runtime_summary(summary_file: Path, summary_markdown: str) -> None:
+    summary_file.parent.mkdir(parents=True, exist_ok=True)
+    summary_file.write_text(summary_markdown + '\n', encoding='utf-8')
+
+
+def execute_test_suite(
+    tests: list[TestCallable],
+    logger: logging.Logger,
+    profile_output_path: Path | None = None,
+    slowest_tests_limit: int = DEFAULT_SLOWEST_TESTS_LIMIT,
+) -> TestSuiteRunResult:
+    suite_started_at = utc_now_iso()
+    suite_started_clock = time.perf_counter()
+    test_records: list[dict[str, Any]] = []
+    failure_traceback: str | None = None
+
+    for test in tests:
+        test_started_at = utc_now_iso()
+        test_started_clock = time.perf_counter()
+
+        try:
+            test()
+            status = 'passed'
+            error_message = None
+
+        except Exception as exc:
+            status = 'failed'
+            error_message = f'{type(exc).__name__}: {exc}'
+            failure_traceback = traceback.format_exc()
+
+        duration_seconds = time.perf_counter() - test_started_clock
+        test_finished_at = utc_now_iso()
+
+        test_record = {
+            'test_name': test.__name__,
+            'module': test.__module__,
+            'status': status,
+            'duration_seconds': round(duration_seconds, 6),
+            'started_at': test_started_at,
+            'finished_at': test_finished_at,
+        }
+        if error_message is not None:
+            test_record['error'] = error_message
+
+        test_records.append(test_record)
+
+        if status == 'passed':
+            logger.info('✅ %s: PASSED (%.3fs)', test.__name__, duration_seconds)
+            continue
+
+        logger.error(
+            '❌ %s: FAILED (%.3fs) - %s',
+            test.__name__,
+            duration_seconds,
+            error_message,
+        )
+        break
+
+    total_duration_seconds = time.perf_counter() - suite_started_clock
+    suite_finished_at = utc_now_iso()
+    profile = build_runtime_profile(
+        test_records=test_records,
+        suite_started_at=suite_started_at,
+        suite_finished_at=suite_finished_at,
+        total_duration_seconds=total_duration_seconds,
+    )
+
+    if profile_output_path is not None:
+        write_runtime_profile(profile, profile_output_path)
+        logger.info('Runtime profile written to %s', profile_output_path)
+
+    suite = profile['suite']
+    logger.info(
+        'Test suite runtime: %s across %d tests (%d passed, %d failed)',
+        format_duration(float(suite['duration_seconds'])),
+        suite['test_count'],
+        suite['passed_count'],
+        suite['failed_count'],
+    )
+
+    slowest_tests = sorted_test_records(profile, limit=slowest_tests_limit)
+    if slowest_tests:
+        logger.info(
+            'Slowest tests (top %d):',
+            min(slowest_tests_limit, len(slowest_tests)),
+        )
+        for record in slowest_tests:
+            logger.info(
+                '  %s [%s] %s',
+                record['test_name'],
+                record['status'],
+                format_duration(float(record['duration_seconds'])),
+            )
+
+    exit_code = 1 if failure_traceback is not None else 0
+    return TestSuiteRunResult(
+        exit_code=exit_code,
+        failure_traceback=failure_traceback,
+        profile=profile,
+    )

--- a/tests/utils/runtime_tracking.py
+++ b/tests/utils/runtime_tracking.py
@@ -240,7 +240,8 @@ def render_runtime_summary_markdown(
 
 def write_runtime_summary(summary_file: Path, summary_markdown: str) -> None:
     summary_file.parent.mkdir(parents=True, exist_ok=True)
-    summary_file.write_text(summary_markdown + '\n', encoding='utf-8')
+    with summary_file.open('a', encoding='utf-8') as summary_handle:
+        summary_handle.write(summary_markdown + '\n')
 
 
 def execute_test_suite(


### PR DESCRIPTION
Fixes #449

## What this changes
- add structured runtime profiling to `tests/run.py` with per-test JSON output and end-of-run slowest-test summaries
- add a committed suite runtime budget in `tests/runtime_budget.json` based on recent successful `main` CI runs
- publish the runtime profile artifact and add a separate `PR Checks Runtime` gate in `PR Validation`
- add regression coverage for runtime profile emission and runtime-gate pass/fail behavior

## Validation
- `./.venv/bin/ruff check .`
- `./.venv/bin/python -m pytest tests/test_runtime_tracking.py -q`
- `./.venv/bin/python -m tests.run`