### PR TITLE
fix: return sample-major cohort probabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -764,3 +764,8 @@ Note: add all new changelog entries to the bottom of this file.
 - Raise explicit error when `return_probs=True` is requested in fallback mode
 - Add comprehensive Cohort tests for constructor validation, aggregation behavior, passthrough behavior, and output-option contracts
 - Add integration test coverage validating Cohort as a decoder-compatible replacement at inference
+
+## v2.5.1 on 25th of April, 2026
+
+- Return `Cohort.predict(..., return_probs=True)` probability traces in sample-major order `(n_samples, n_members)` so per-bar cohort inspection matches the supported consumer contract
+- Add regression coverage for sample-major probability traces, `permutation_ids` column ordering, and single-member fallback vote conversion on the canonical `tests.run` path

--- a/docs/Cohort.md
+++ b/docs/Cohort.md
@@ -122,7 +122,7 @@ Input contract:
 Where:
 
 - `probs` is a per-decoder probability matrix with shape
-  `(n_members, n_samples)` in the same order as `permutation_ids`
+  `(n_samples, n_members)` in the same order as `permutation_ids`
 - `meta` currently contains:
   - `permutation_ids`
   - `decoder_count`

--- a/limen/cohort/cohort.py
+++ b/limen/cohort/cohort.py
@@ -200,7 +200,7 @@ class Cohort:
             X (Any): Decoder-style input dict consumed by member decoders.
             return_probs (bool): Whether to also return per-decoder
                 probabilities as a matrix with shape
-                `(n_members, n_samples)`. Only valid in
+                `(n_samples, n_members)`. Only valid in
                 probability-weighted mode.
             return_meta (bool): Whether to also return structured cohort metadata
                 (placeholder schema) alongside predictions.
@@ -258,7 +258,7 @@ class Cohort:
                     probs,
                     return_probs=return_probs,
                     return_meta=return_meta,
-                    probs_for_return=np.vstack([probs]),
+                    probs_for_return=probs[:, None],
                 )
 
             raw_preds = np.asarray(result['_preds'], dtype=float)
@@ -301,7 +301,7 @@ class Cohort:
                 probs,
                 return_probs=return_probs,
                 return_meta=return_meta,
-                probs_for_return=probs_matrix,
+                probs_for_return=probs_matrix.T,
             )
 
         if self.aggregation_mode == 'majority_vote':

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaquum_limen"
-version = "2.5.0"
+version = "2.5.1"
 description = "Bitcoin-first research and trading platform."
 readme = "README.md"
 authors = [

--- a/tests/run.py
+++ b/tests/run.py
@@ -566,6 +566,7 @@ from tests.test_proto_cohort import test_validate_probability_range_rejects_non_
 from tests.test_proto_cohort import test_cohort_is_drop_in_decoder_replacement_for_dict_input
 from tests.test_proto_cohort import test_member_failure_propagates_and_fails_whole_call
 from tests.test_proto_cohort import test_predict_return_probs_probability_mode_returns_per_sample_probs
+from tests.test_proto_cohort import test_predict_return_probs_single_member_returns_sample_major_column
 from tests.test_proto_cohort import test_majority_vote_uses_binary_votes_for_continuous_fallback_members
 
 tests = [
@@ -1113,6 +1114,7 @@ tests = [
     test_single_decoder_passthrough_returns_member_preds_unchanged,
     test_probability_weighted_predict_requires_members,
     test_predict_return_probs_probability_mode_returns_per_sample_probs,
+    test_predict_return_probs_single_member_returns_sample_major_column,
     test_majority_vote_tie_returns_zero,
     test_probability_weighted_tie_returns_zero,
     test_majority_vote_multimember_expected_output,

--- a/tests/run.py
+++ b/tests/run.py
@@ -568,6 +568,7 @@ from tests.test_proto_cohort import test_member_failure_propagates_and_fails_who
 from tests.test_proto_cohort import test_predict_return_probs_probability_mode_returns_per_sample_probs
 from tests.test_proto_cohort import test_predict_return_probs_single_member_returns_sample_major_column
 from tests.test_proto_cohort import test_majority_vote_uses_binary_votes_for_continuous_fallback_members
+from tests.test_proto_cohort import test_single_member_fallback_predict_returns_binary_votes
 
 tests = [
     test_param_domain_init,
@@ -1121,6 +1122,7 @@ tests = [
     test_probability_weighted_vote_rejects_shape_mismatch,
     test_majority_vote_rejects_shape_mismatch,
     test_majority_vote_uses_binary_votes_for_continuous_fallback_members,
+    test_single_member_fallback_predict_returns_binary_votes,
     test_predict_return_meta_returns_metadata_placeholder,
     test_predict_return_probs_and_return_meta_returns_three_tuple,
     test_predict_return_probs_rejected_in_fallback_mode,

--- a/tests/test_proto_cohort.py
+++ b/tests/test_proto_cohort.py
@@ -543,6 +543,26 @@ def test_majority_vote_uses_binary_votes_for_continuous_fallback_members():
         assert out['_preds'].tolist() == [1, 0, 1, 0]
 
 
+def test_single_member_fallback_predict_returns_binary_votes():
+
+    with TemporaryDirectory() as tmpdir:
+        exp_dir = Path(tmpdir) / 'exp'
+        _run_real_experiment(exp_dir, n_permutations=1)
+
+        _patch_round_architecture(exp_dir, {0: 'xgboost_regressor'})
+        cohort = Cohort(experiment_log_path=str(exp_dir), permutation_ids=[0])
+
+        member = _FallbackContinuousMember(
+            0,
+            np.array([0.2, -0.3, 1.1, 0.0], dtype=float),
+        )
+        cohort.set_members([member])
+
+        out = cohort.predict({'x_test': np.zeros((4, 2), dtype=float)})
+
+        assert out['_preds'].tolist() == [1, 0, 1, 0]
+
+
 def test_majority_vote_tie_returns_zero():
 
     vote = Cohort._majority_vote([

--- a/tests/test_proto_cohort.py
+++ b/tests/test_proto_cohort.py
@@ -608,12 +608,40 @@ def test_predict_return_probs_probability_mode_returns_per_sample_probs():
 
         cohort = Cohort(experiment_log_path=str(
             exp_dir), permutation_ids=[0, 1])
+        cohort.set_members(list(reversed(sensors)))
+
+        by_pid = {sensor.permutation_id: sensor for sensor in sensors}
+        y_pred, probs = cohort.predict({'x_test': x_test}, return_probs=True)
+
+        member_probs = np.column_stack([
+            np.asarray(by_pid[pid].predict({'x_test': x_test})['_probs'], dtype=float)
+            for pid in cohort.permutation_ids
+        ])
+
+        assert isinstance(probs, np.ndarray)
+        assert np.asarray(probs).shape == (np.asarray(y_pred).shape[0], 2)
+        assert np.allclose(np.asarray(probs, dtype=float), member_probs)
+
+
+def test_predict_return_probs_single_member_returns_sample_major_column():
+
+    with TemporaryDirectory() as tmpdir:
+        exp_dir = Path(tmpdir) / 'exp'
+        _run_real_experiment(exp_dir, n_permutations=1)
+
+        sensors, x_test = _train_real_members_and_input(exp_dir, [0])
+
+        cohort = Cohort(experiment_log_path=str(exp_dir), permutation_ids=[0])
         cohort.set_members(sensors)
 
         y_pred, probs = cohort.predict({'x_test': x_test}, return_probs=True)
+        expected_probs = np.asarray(
+            sensors[0].predict({'x_test': x_test})['_probs'],
+            dtype=float,
+        )[:, None]
 
-        assert isinstance(probs, np.ndarray)
-        assert np.asarray(probs).shape == (2, np.asarray(y_pred).shape[0])
+        assert np.asarray(probs).shape == (np.asarray(y_pred).shape[0], 1)
+        assert np.allclose(np.asarray(probs, dtype=float), expected_probs)
 
 
 def test_predict_return_meta_returns_metadata_placeholder():
@@ -655,7 +683,7 @@ def test_predict_return_probs_and_return_meta_returns_three_tuple():
         )
 
         assert isinstance(probs, np.ndarray)
-        assert np.asarray(probs).shape == (2, np.asarray(y_pred).shape[0])
+        assert np.asarray(probs).shape == (np.asarray(y_pred).shape[0], 2)
         assert meta['permutation_ids'] == [0, 1]
         assert meta['decoder_count'] == 2
         assert np.asarray(y_pred).shape[0] == np.asarray(x_test).shape[0]


### PR DESCRIPTION
## Summary
- switch optional `return_probs=True` output to sample-major orientation
- keep the main/default `Cohort.predict()` contract unchanged
- add narrow regression coverage for multi-member ordering and single-member shape

## Why
The consumer-facing use case is sample-first: for a given bar/sample, inspect what all members said. This keeps the main sensor-compatible path untouched and changes only the optional probability matrix returned when callers explicitly request member-level introspection.

## Proof
- `python3 -m py_compile limen/cohort/cohort.py tests/test_proto_cohort.py tests/run.py`
- isolated numpy repro against `limen/cohort/cohort.py` verifying:
  - multi-member `return_probs=True` now returns `(n_samples, n_members)`
  - single-member `return_probs=True` now returns `(n_samples, 1)`
- Claude Code CLI review focused on intent and minimality
