### PR TITLE
fix: use trusted publishing for PyPI release

### DIFF
--- a/.github/workflows/pr_publish_pypi.yml
+++ b/.github/workflows/pr_publish_pypi.yml
@@ -96,6 +96,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      id-token: write
 
     steps:
       - name: Download distributions
@@ -108,5 +109,3 @@ jobs:
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
           skip-existing: true
-          user: ${{ secrets.PYPI_USERNAME }}
-          password: ${{ secrets.PYPI_PASSWORD }}


### PR DESCRIPTION
## Summary
- Grant the PyPI publish job GitHub OIDC token permission with `id-token: write`.
- Stop passing legacy `PYPI_USERNAME` / `PYPI_PASSWORD` secrets to `pypa/gh-action-pypi-publish`, allowing PyPI Trusted Publishing to be used.

## Evidence
- Failed run: https://github.com/Vaquum/Limen/actions/runs/25045371268
- Failed step reported PyPI now requires Trusted Publishers or API tokens for automated uploads.
- Local validation: `git diff --cached --check` and YAML parse passed before commit.

## Note
PyPI must have a Trusted Publisher configured for `Vaquum/Limen` and workflow filename `pr_publish_pypi.yml`.