### PR TITLE
refactor: align Manifest API with RFC-1004 terminology and remove LOOP_ENV

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -803,3 +803,11 @@ Note: add all new changelog entries to the bottom of this file.
 - Make standard-path `UniversalExperimentLoop` writes honor `experiment_dir` by storing `<experiment_name>.csv` under the requested directory
 - Preserve legacy standard-path CSV placement when `experiment_dir` is not set and keep MSQ artifact filenames unchanged
 - Add regression coverage for standard-path `experiment_dir` CSV placement and rerun header behavior
+
+## v2.5.7 on 29th of April, 2026
+
+- Rename `Manifest.with_model()` to `with_reference_architecture()` and fields `model_function` → `architecture_function`, `model_params` → `architecture_params` for RFC-1004 alignment
+- Rename `Manifest.with_target()` to `with_target_label()` for RFC-1004 alignment
+- Remove `Manifest.fetch_data_for_env()` and `LOOP_ENV` environment variable dispatch
+- Add `test_mode: bool = False` to `UniversalExperimentLoop.__init__()`: when `True` and a test data source is configured, `fetch_test_data()` is used instead of `fetch_data()`
+- Trainer now always calls `manifest.fetch_data()` directly when no explicit data is provided

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -804,7 +804,7 @@ Note: add all new changelog entries to the bottom of this file.
 - Preserve legacy standard-path CSV placement when `experiment_dir` is not set and keep MSQ artifact filenames unchanged
 - Add regression coverage for standard-path `experiment_dir` CSV placement and rerun header behavior
 
-## v2.5.7 on 29th of April, 2026
+## v3.0.0 on 29th of April, 2026
 
 - Rename `Manifest.with_model()` to `with_reference_architecture()` and fields `model_function` → `architecture_function`, `model_params` → `architecture_params` for RFC-1004 alignment
 - Rename `Manifest.with_target()` to `with_target_label()` for RFC-1004 alignment

--- a/docs/Built-In-SFDs.md
+++ b/docs/Built-In-SFDs.md
@@ -106,7 +106,7 @@ uel.run(
 )
 ```
 
-If you omit `data=`, the manifest fetches data according to its configured data source and `LOOP_ENV`.
+If you omit `data=`, the manifest fetches data using `fetch_data()`. Pass `test_mode=True` to UEL to use the test data source instead.
 
 ## How To Choose
 

--- a/docs/Developer/Contributing-Foundational-SFDs.md
+++ b/docs/Developer/Contributing-Foundational-SFDs.md
@@ -93,9 +93,9 @@ def manifest():
         .set_split_config(8, 1, 2)
         .add_indicator(...)
         .add_feature(...)
-        .with_target(...)
+        .with_target_label(...)
         .set_scaler_from_params('scaler_type')
-        .with_model(your_model)
+        .with_reference_architecture(your_model)
     )
 ```
 

--- a/docs/Experiment-Manifest.md
+++ b/docs/Experiment-Manifest.md
@@ -56,14 +56,14 @@ def manifest():
         .add_indicator(wilder_rsi)
         .add_feature(vwap)
         .add_feature(kline_imbalance)
-        .with_target('quantile_flag')
+        .with_target_label('quantile_flag')
             .add_fitted_transform(quantile_flag)
                 .fit_param('_quantile_cutoff', compute_quantile_cutoff, col='roc_{roc_period}', q='q')
                 .with_params(col='roc_{roc_period}', cutoff='_quantile_cutoff')
             .add_transform(shift_column_transform, shift='shift', column='target_column')
             .done()
         .set_scaler(LogRegScaler)
-        .with_model(logreg_binary)
+        .with_reference_architecture(logreg_binary)
     )
 ```
 
@@ -122,7 +122,7 @@ from limen.data import HistoricalData
 
 ### `set_test_data_source(method, params=None)`
 
-Configure the test data source used when `LOOP_ENV='test'`.
+Configure the test data source used when `test_mode=True` is passed to `UniversalExperimentLoop`.
 
 ```python
 .set_test_data_source(
@@ -131,16 +131,12 @@ Configure the test data source used when `LOOP_ENV='test'`.
 )
 ```
 
-### Environment selection
+### Data source selection
 
-`Manifest.fetch_data_for_env()` uses:
+Pass `test_mode=True` to `UniversalExperimentLoop` to fetch from the test data source instead of the production source.
+When `test_mode=True` and a test data source is configured, `fetch_test_data()` is called; otherwise `fetch_data()` is used.
 
-- the test data source when `LOOP_ENV='test'` and a test source exists
-- the production data source otherwise
-
-If `LOOP_ENV='test'` but no test data source is configured, Limen falls back to the production data source.
-
-That is why foundational SFDs can run locally with no explicit `data=` and still use the configured test data source by default when one is defined.
+That is why foundational SFDs can run locally with no explicit `data=` and still use the configured test data source.
 To keep local runs lightweight, configure `set_test_data_source()` with explicit `kline_size` and `n_rows`.
 
 ## Pipeline Configuration
@@ -386,10 +382,10 @@ Then in `params()`:
 
 ## Target Configuration
 
-Target construction is handled through `with_target(...)`.
+Target construction is handled through `with_target_label(...)`.
 
 ```python
-.with_target('quantile_flag')
+.with_target_label('quantile_flag')
     ...
     .done()
 ```
@@ -401,7 +397,7 @@ The target column is placed last before Limen finalizes the `data_dict`.
 Use fitted transforms when a target step needs a value computed on the training split first, then reused on validation and test.
 
 ```python
-.with_target('quantile_flag')
+.with_target_label('quantile_flag')
     .add_fitted_transform(quantile_flag)
         .fit_param('_quantile_cutoff', compute_quantile_cutoff, col='roc_{roc_period}', q='q')
         .with_params(col='roc_{roc_period}', cutoff='_quantile_cutoff')
@@ -421,7 +417,7 @@ This is the manifest-safe way to compute train-only thresholds.
 Use plain transforms when the step does not need fitted state.
 
 ```python
-.with_target('quantile_flag')
+.with_target_label('quantile_flag')
     .add_transform(shift_column_transform, shift='shift', column='target_column')
     .done()
 ```
@@ -486,7 +482,7 @@ manifest = (
     .add_indicator(wilder_rsi, period='rsi_period')
     .add_indicator(ema, period='ema_period')
     .with_strategy(conditions, entry='entry')
-    .with_model(rule_based)
+    .with_reference_architecture(rule_based)
 )
 ```
 
@@ -579,14 +575,14 @@ This is the safe alternative to writing Python code — the polars SQL parser re
 
 ## Model Configuration
 
-### `with_model(model_function)`
+### `with_reference_architecture(architecture_function)`
 
 Configure the final model function.
 
 ```python
 from limen.sfd.reference_architecture import logreg_binary
 
-.with_model(logreg_binary)
+.with_reference_architecture(logreg_binary)
 ```
 
 The model function must accept the prepared `data_dict` as its first argument.
@@ -719,7 +715,7 @@ Use fitted transforms when the function depends on train-only fitted state. Use 
 
 ### Model functions
 
-The model function configured in `with_model(...)` must:
+The architecture function configured in `with_reference_architecture(...)` must:
 
 - accept the finalized `data_dict` as its first argument
 - accept any searched model parameters as named kwargs
@@ -734,7 +730,7 @@ If the model returns `_preds`, UEL stores them in `uel.preds` and the `Log` laye
 This is the most important target recipe in the current Limen style:
 
 ```python
-.with_target('quantile_flag')
+.with_target_label('quantile_flag')
     .add_fitted_transform(quantile_flag)
         .fit_param('_cutoff', compute_quantile_cutoff, col='roc_{roc_period}', q='q')
         .with_params(col='roc_{roc_period}', cutoff='_cutoff')

--- a/docs/Features.md
+++ b/docs/Features.md
@@ -38,7 +38,7 @@ def manifest():
         .add_indicator(atr, period=14)
         .add_feature(vwap)
         .add_feature(kline_imbalance, window='imbalance_window')
-        .with_model(logreg_binary)
+        .with_reference_architecture(logreg_binary)
     )
 ```
 

--- a/docs/Indicators.md
+++ b/docs/Indicators.md
@@ -37,7 +37,7 @@ def manifest():
         .add_indicator(atr, period=14)
         .add_indicator(ppo)
         .add_indicator(wilder_rsi)
-        .with_model(logreg_binary)
+        .with_reference_architecture(logreg_binary)
     )
 ```
 

--- a/docs/Reference-Architecture.md
+++ b/docs/Reference-Architecture.md
@@ -134,7 +134,7 @@ This is the same contract that `Trainer` eventually relies on when it promotes f
 Most foundational manifests call the function wrapper:
 
 ```python
-.with_model(logreg_binary)
+.with_reference_architecture(logreg_binary)
 ```
 
 That wrapper typically:

--- a/docs/Single-File-Decoder.md
+++ b/docs/Single-File-Decoder.md
@@ -72,14 +72,14 @@ def manifest():
         )
         .set_split_config(8, 1, 2)
         .add_indicator(roc, period='roc_period')
-        .with_target('quantile_flag')
+        .with_target_label('quantile_flag')
             .add_fitted_transform(quantile_flag)
                 .fit_param('_cutoff', compute_quantile_cutoff, col='roc_{roc_period}', q='q')
                 .with_params(col='roc_{roc_period}', cutoff='_cutoff')
             .add_transform(shift_column_transform, shift='shift', column='target_column')
             .done()
         .set_scaler(LogRegScaler)
-        .with_model(logreg_binary)
+        .with_reference_architecture(logreg_binary)
     )
 ```
 

--- a/docs/Trainer.md
+++ b/docs/Trainer.md
@@ -137,7 +137,7 @@ This is expected behavior, not a special case in the docs.
 | `experiment_dir` | path to the completed experiment directory |
 | `data` | optional dataframe override; if omitted, Trainer fetches data from the reconstructed manifest |
 
-Use `data=` when you already have the exact dataframe you want Trainer to use. Otherwise Trainer falls back to `manifest.fetch_data_for_env()`.
+Use `data=` when you already have the exact dataframe you want Trainer to use. Otherwise Trainer falls back to `manifest.fetch_data()`.
 
 ## `train(permutation_ids)`
 

--- a/docs/Transforms.md
+++ b/docs/Transforms.md
@@ -39,7 +39,7 @@ from limen.features import compute_quantile_cutoff, quantile_flag
 from limen.transforms import shift_column_transform
 
 (
-    manifest.with_target('quantile_flag')
+    manifest.with_target_label('quantile_flag')
     .add_fitted_transform(quantile_flag)
         .fit_param('_quantile_cutoff', compute_quantile_cutoff, col='roc_{roc_period}', q='q')
         .with_params(col='roc_{roc_period}', cutoff='_quantile_cutoff')

--- a/docs/Universal-Experiment-Loop.md
+++ b/docs/Universal-Experiment-Loop.md
@@ -84,7 +84,7 @@ uel = limen.UniversalExperimentLoop(
 
 - If the SFD exposes `manifest()` and you do not pass `data=`, UEL fetches data from the manifest.
 - If the SFD is custom and has no manifest, `data=` is required.
-- For manifest-driven SFDs, the data source used by auto-fetch depends on `LOOP_ENV`.
+- For manifest-driven SFDs, the data source used is `fetch_data()` by default; pass `test_mode=True` to use the test data source.
 
 ## `run()` Contract
 

--- a/limen/experiment/experiment_core.py
+++ b/limen/experiment/experiment_core.py
@@ -93,7 +93,7 @@ class UniversalExperimentLoop:
             else:
                 self.data = data
 
-            if self.manifest.architecture_function is not None:
+            if getattr(self.manifest, 'architecture_function', None) is not None:
                 self.prep = lambda data, round_params=None: self.manifest.prepare_data(data, round_params or {})
                 self.model = lambda data, round_params: self.manifest.run_model(data, round_params or {})
             else:

--- a/limen/experiment/experiment_core.py
+++ b/limen/experiment/experiment_core.py
@@ -41,7 +41,8 @@ class UniversalExperimentLoop:
                  feedback_interval: int = 100,
                  checkpoint_interval: int = 1000,
                  experiment_dir: str | Path | None = None,
-                 intra_callback: Callable[[Any, MSQ], None] | None = None) -> None:
+                 intra_callback: Callable[[Any, MSQ], None] | None = None,
+                 test_mode: bool = False) -> None:
 
         '''
         Initialize the UniversalExperimentLoop.
@@ -63,6 +64,7 @@ class UniversalExperimentLoop:
             checkpoint_interval (int): Save checkpoint every N rounds
             experiment_dir (str | Path | None): Directory for all experiment artifacts
             intra_callback (Callable | None): Python callback receiving (log, msq)
+            test_mode (bool): When True and data is None, fetch from test_data_source_config instead of production
 
         '''
 
@@ -84,17 +86,20 @@ class UniversalExperimentLoop:
                         'to manifest or pass data explicitly.'
                     )
 
-                self.data = self.manifest.fetch_data_for_env()
+                if test_mode and self.manifest.test_data_source_config is not None:
+                    self.data = self.manifest.fetch_test_data()
+                else:
+                    self.data = self.manifest.fetch_data()
             else:
                 self.data = data
 
-            if hasattr(self.manifest, 'model_function') and self.manifest.model_function:
+            if self.manifest.architecture_function is not None:
                 self.prep = lambda data, round_params=None: self.manifest.prepare_data(data, round_params or {})
                 self.model = lambda data, round_params: self.manifest.run_model(data, round_params or {})
             else:
                 raise ValueError(
-                    'Manifest without model_function is not supported. '
-                    'Use .with_model(model_func) in your manifest.'
+                    'Manifest without architecture_function is not supported. '
+                    'Use .with_reference_architecture(func) in your manifest.'
                 )
         else:
             if data is None:

--- a/limen/experiment/manifest_core.py
+++ b/limen/experiment/manifest_core.py
@@ -2,7 +2,6 @@ import copy
 import inspect
 import importlib
 import logging
-import os
 import random
 from collections.abc import Callable
 from dataclasses import dataclass, field
@@ -177,8 +176,8 @@ class Manifest:
     ablation_config: AblationConfig | None = None
     data_dict_extension: Callable = None
 
-    model_function: Callable = None
-    model_params: dict[str, ParamValue] = field(default_factory=dict)
+    architecture_function: Callable = None
+    architecture_params: dict[str, ParamValue] = field(default_factory=dict)
     metrics_params: dict[str, ParamValue] = field(default_factory=dict)
     _rule_based: 'RuleBasedConfig | None' = field(default=None, init=False, repr=False)
 
@@ -259,21 +258,6 @@ class Manifest:
             raise ValueError('No test data source configured')
 
         return DataSourceResolver.resolve(self.test_data_source_config)
-
-    def fetch_data_for_env(self) -> pl.DataFrame:
-
-        '''
-        Fetch data based on LOOP_ENV environment variable.
-
-        Returns:
-            pl.DataFrame: Fetched data from test or production source
-
-        '''
-
-        env = os.getenv('LOOP_ENV', 'test')
-        if env == 'test' and self.test_data_source_config is not None:
-            return self.fetch_test_data()
-        return self.fetch_data()
 
     def add_feature(self,
                     func: Callable,
@@ -453,7 +437,7 @@ class Manifest:
         return self
 
 
-    def with_target(self, target_column: str) -> TargetBuilder:
+    def with_target_label(self, target_column: str) -> TargetBuilder:
 
         '''
         Start building target transformations with context.
@@ -467,22 +451,22 @@ class Manifest:
 
         return TargetBuilder(self, target_column)
 
-    def with_model(self, model_function: Callable) -> 'Manifest':
+    def with_reference_architecture(self, architecture_function: Callable) -> 'Manifest':
 
         '''
-        Configure model function for training and evaluation.
+        Configure reference architecture function for training and evaluation.
 
         Args:
-            model_function (Callable): Model function that takes (data, **params) and returns results
+            architecture_function (Callable): Architecture function that takes (data, **params) and returns results
 
         Returns:
             Manifest: Self for method chaining
 
-        NOTE: The model function should accept data dict and return results dict with metrics and predictions.
-        Parameters are auto-mapped from round_params based on model function signature.
+        NOTE: The architecture function should accept data dict and return results dict with metrics and predictions.
+        Parameters are auto-mapped from round_params based on function signature.
         '''
 
-        self.model_function = model_function
+        self.architecture_function = architecture_function
 
         return self
 
@@ -763,10 +747,10 @@ class Manifest:
 
         '''
 
-        if self.model_function is None:
-            raise ValueError('Model function not configured. Use .with_model(model_function) before run_model() or resolve_model_kwargs().')
+        if self.architecture_function is None:
+            raise ValueError('Architecture function not configured. Use .with_reference_architecture(func) before run_model() or resolve_model_kwargs().')
 
-        sig = inspect.signature(self.model_function)
+        sig = inspect.signature(self.architecture_function)
         model_kwargs: dict[str, Any] = {}
 
         for param_name, param_obj in sig.parameters.items():
@@ -808,7 +792,7 @@ class Manifest:
         '''
 
         model_kwargs = self.resolve_model_kwargs(round_params)
-        round_results = self.model_function(data, **model_kwargs)
+        round_results = self.architecture_function(data, **model_kwargs)
 
         return round_results
 

--- a/limen/experiment/trainer/trainer.py
+++ b/limen/experiment/trainer/trainer.py
@@ -86,7 +86,7 @@ class Trainer:
         if data is not None:
             self._data = data
         else:
-            self._data = self._manifest.fetch_data_for_env()
+            self._data = self._manifest.fetch_data()
 
 
     def _load_round_data(self) -> dict[int, dict[str, Any]]:
@@ -167,13 +167,13 @@ class Trainer:
 
         '''
 
-        if self._manifest.model_function is None:
+        if self._manifest.architecture_function is None:
             raise ValueError(
-                'Model function not configured on manifest. '
+                'Architecture function not configured on manifest. '
                 'Cannot resolve model class.'
             )
 
-        module_name = self._manifest.model_function.__module__
+        module_name = self._manifest.architecture_function.__module__
         module = importlib.import_module(module_name)
 
         classes = [

--- a/limen/sfd/foundational_sfd/logreg_binary.py
+++ b/limen/sfd/foundational_sfd/logreg_binary.py
@@ -58,7 +58,7 @@ def manifest():
         .add_feature(vwap, group='volume')
         .add_feature(kline_imbalance, group='volume')
 
-        .with_target('quantile_flag')
+        .with_target_label('quantile_flag')
             .add_fitted_transform(quantile_flag)
                 .fit_param('_quantile_cutoff', compute_quantile_cutoff, col='roc_{roc_period}', q='q')
                 .with_params(col='roc_{roc_period}', cutoff='_quantile_cutoff')
@@ -68,5 +68,5 @@ def manifest():
         .set_scaler_from_params('scaler_type')
         .set_feature_ablation()
 
-        .with_model(logreg_binary)
+        .with_reference_architecture(logreg_binary)
     )

--- a/limen/sfd/foundational_sfd/random_binary.py
+++ b/limen/sfd/foundational_sfd/random_binary.py
@@ -30,11 +30,11 @@ def manifest():
             'datetime', 'high', 'low', 'close', 'volume', 'maker_ratio',
             'no_of_trades'
         ])
-        .with_target('outcome')
+        .with_target_label('outcome')
             .add_transform(lambda data: data.with_columns(
                 pl.Series('outcome', np.random.randint(0, 2, size=data.height))
             ))
             .add_transform(lambda data: data[:-1])
             .done()
-        .with_model(random_binary)
+        .with_reference_architecture(random_binary)
     )

--- a/limen/sfd/foundational_sfd/rule_based.py
+++ b/limen/sfd/foundational_sfd/rule_based.py
@@ -54,5 +54,5 @@ def manifest() -> Manifest:
         .add_indicator(wilder_rsi, period='rsi_period', group='momentum')
         .add_indicator(ema, period='ema_period', group='trend')
         .with_strategy(_CONDITIONS, entry='entry')
-        .with_model(rule_based)
+        .with_reference_architecture(rule_based)
     )

--- a/limen/sfd/foundational_sfd/tabpfn_binary.py
+++ b/limen/sfd/foundational_sfd/tabpfn_binary.py
@@ -68,7 +68,7 @@ def manifest() -> Manifest:
 
         .add_indicator(bollinger_position)
 
-        .with_target('forward_breakout')
+        .with_target_label('forward_breakout')
             .add_transform(forward_breakout_target,
                 forward_periods='forward_periods',
                 threshold='threshold_pct',
@@ -76,5 +76,5 @@ def manifest() -> Manifest:
             )
             .done()
 
-        .with_model(tabpfn_binary)
+        .with_reference_architecture(tabpfn_binary)
     )

--- a/limen/sfd/foundational_sfd/xgboost_regressor.py
+++ b/limen/sfd/foundational_sfd/xgboost_regressor.py
@@ -74,12 +74,12 @@ def manifest():
             'order_flow_imbalance',
             'stoch_k',
         ], lag=1)
-        .with_target('next_return')
+        .with_target_label('next_return')
             .add_transform(
                 lambda df: df.with_columns([
                     (((pl.col('close').shift(-1) - pl.col('close')) / pl.col('close')) * 100).alias('next_return')
                 ])
             )
             .done()
-        .with_model(xgboost_regressor)
+        .with_reference_architecture(xgboost_regressor)
     )

--- a/limen/sfd/loop/loop_sfd.py
+++ b/limen/sfd/loop/loop_sfd.py
@@ -237,7 +237,7 @@ class LoopSFD:
             label_func = FEATURE_REGISTRY[label_name]
             target_col = get_target_column(label_name)
             user_params = label.get('params', {}) or {}
-            target_builder = m.with_target(target_col)
+            target_builder = m.with_target_label(target_col)
 
             fitted_config = FITTED_LABELS.get(label_name)
             if fitted_config is not None:
@@ -260,7 +260,7 @@ class LoopSFD:
                 )
             m.set_scaler(scaler_class)
 
-        m.with_model(self._arch_func)
+        m.with_reference_architecture(self._arch_func)
 
         return m
 
@@ -529,7 +529,7 @@ class LoopSFD:
         `.add_fitted_transform().fit_param().with_params()` calls.
 
         Args:
-            target_builder: Limen TargetBuilder returned from .with_target()
+            target_builder: Limen TargetBuilder returned from .with_target_label()
             label_func (Callable): The label function (from FEATURE_REGISTRY)
             label_name (str): Label name as used in the payload
             user_params (dict): Label params from the payload entry

--- a/limen/sfd/loop/run.py
+++ b/limen/sfd/loop/run.py
@@ -207,7 +207,7 @@ def run_experiment(payload_path: Path,
     (experiment_dir / 'payload.json').write_text(payload_text)
 
     # Fetch data from the payload's data source config and pass it to UEL
-    # via data=, bypassing manifest.fetch_data_for_env.
+    # via data=, bypassing manifest.fetch_data().
     raw_data = _fetch_data_from_payload(payload)
 
     sfd = LoopSFD(payload)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaquum_limen"
-version = "2.5.7"
+version = "3.0.0"
 description = "Bitcoin-first research and trading platform."
 readme = "README.md"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaquum_limen"
-version = "2.5.6"
+version = "2.5.7"
 description = "Bitcoin-first research and trading platform."
 readme = "README.md"
 authors = [

--- a/tests/run.py
+++ b/tests/run.py
@@ -209,6 +209,7 @@ from tests.test_experiment_core_msq import test_experiment_parameter_correlation
 from tests.test_experiment_core_msq import test_experiment_parameter_correlation_validates_metric_and_sort_key_presence
 from tests.test_experiment_core_msq import test_experiment_parameter_correlation_requires_numeric_features_after_cleaning
 from tests.test_experiment_core_msq import test_experiment_parameter_correlation_rejects_logs_without_metric_rows
+from tests.test_experiment_core_msq import test_uel_test_mode_routes_to_test_data_source
 from tests.test_sanity_reducer import test_nan_above_threshold
 from tests.test_sanity_reducer import test_min_observations_gate
 from tests.test_sanity_reducer import test_early_returns
@@ -519,7 +520,7 @@ from tests.test_trainer import test_trainer_with_fractional_diff
 from tests.test_trainer import test_load_round_data_skips_blank_and_malformed_lines
 from tests.test_trainer import test_load_round_data_requires_round_data_file
 from tests.test_trainer import test_load_original_log_returns_none_when_results_csv_is_missing
-from tests.test_trainer import test_resolve_model_class_requires_configured_model_function
+from tests.test_trainer import test_resolve_model_class_requires_configured_architecture_function
 from tests.test_trainer import test_resolve_model_class_rejects_modules_without_reference_model_subclasses
 from tests.test_trainer import test_resolve_model_class_rejects_modules_with_multiple_reference_model_subclasses
 from tests.test_trainer import test_validate_metrics_ignores_metadata_fields_and_accepts_small_stochastic_drift
@@ -544,7 +545,7 @@ from tests.test_loop_sfd import test_loop_sfd_params_includes_unnamespaced_model
 from tests.test_loop_sfd import test_loop_sfd_params_extracts_namespaced_arch_params
 from tests.test_loop_sfd import test_loop_sfd_manifest_split_config
 from tests.test_loop_sfd import test_loop_sfd_manifest_target_column
-from tests.test_loop_sfd import test_loop_sfd_manifest_model_function
+from tests.test_loop_sfd import test_loop_sfd_manifest_architecture_function
 from tests.test_loop_sfd import test_loop_sfd_manifest_scaler_set
 from tests.test_loop_sfd import test_loop_sfd_manifest_feature_transforms_order
 from tests.test_loop_sfd import test_loop_sfd_ignores_payload_transforms
@@ -774,6 +775,7 @@ tests = [
     test_experiment_parameter_correlation_validates_metric_and_sort_key_presence,
     test_experiment_parameter_correlation_requires_numeric_features_after_cleaning,
     test_experiment_parameter_correlation_rejects_logs_without_metric_rows,
+    test_uel_test_mode_routes_to_test_data_source,
     test_nan_above_threshold,
     test_early_returns,
     test_min_observations_gate,
@@ -1132,7 +1134,7 @@ tests = [
     test_load_round_data_skips_blank_and_malformed_lines,
     test_load_round_data_requires_round_data_file,
     test_load_original_log_returns_none_when_results_csv_is_missing,
-    test_resolve_model_class_requires_configured_model_function,
+    test_resolve_model_class_requires_configured_architecture_function,
     test_resolve_model_class_rejects_modules_without_reference_model_subclasses,
     test_resolve_model_class_rejects_modules_with_multiple_reference_model_subclasses,
     test_validate_metrics_ignores_metadata_fields_and_accepts_small_stochastic_drift,
@@ -1157,7 +1159,7 @@ tests = [
     test_loop_sfd_params_extracts_namespaced_arch_params,
     test_loop_sfd_manifest_split_config,
     test_loop_sfd_manifest_target_column,
-    test_loop_sfd_manifest_model_function,
+    test_loop_sfd_manifest_architecture_function,
     test_loop_sfd_manifest_scaler_set,
     test_loop_sfd_manifest_feature_transforms_order,
     test_loop_sfd_ignores_payload_transforms,

--- a/tests/test_experiment_core_msq.py
+++ b/tests/test_experiment_core_msq.py
@@ -4,6 +4,8 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from types import SimpleNamespace
 
+import polars as pl
+
 import pandas as pd
 import pytest
 
@@ -20,7 +22,7 @@ from tests.stubs.stubs import make_msq
 from tests.stubs.stubs import StubPruningStrategy
 
 
-def _make_uel(strategy_cls=RandomStrategy, **kwargs):
+def _make_uel(strategy_cls=RandomStrategy, test_mode=True, **kwargs):
 
     params = sfd_module.params()
     domain = ParamDomain(params)
@@ -33,6 +35,7 @@ def _make_uel(strategy_cls=RandomStrategy, **kwargs):
         checkpoint_interval=kwargs.get('checkpoint_interval', 1000),
         experiment_dir=kwargs.get('experiment_dir'),
         intra_callback=kwargs.get('intra_callback'),
+        test_mode=test_mode,
     )
     return uel, strategy, domain
 
@@ -594,3 +597,80 @@ def test_experiment_parameter_correlation_rejects_logs_without_metric_rows():
             min_n=1,
             n_boot=5,
         )
+
+
+def test_uel_test_mode_routes_to_test_data_source():
+
+    _stub_data = pl.DataFrame({'x': [1, 2, 3]})
+    fetched = []
+
+    class _FakeManifest:
+        data_source_config = object()
+        test_data_source_config = object()
+
+        def architecture_function(self, data, **kw):
+            return {}
+
+        def fetch_data(self):
+            fetched.append('fetch_data')
+            return _stub_data
+
+        def fetch_test_data(self):
+            fetched.append('fetch_test_data')
+            return _stub_data
+
+    class _FakeSfd:
+        def params(self):
+            return {'x': [1, 2]}
+
+        def manifest(self):
+            return _FakeManifest()
+
+    params = _FakeSfd().params()
+    domain = ParamDomain(params)
+    strategy = RandomStrategy(domain, seed=42)
+
+    UniversalExperimentLoop(
+        sfd=_FakeSfd(),
+        search_strategy=strategy,
+        test_mode=True,
+    )
+    assert fetched == ['fetch_test_data']
+
+    fetched.clear()
+    UniversalExperimentLoop(
+        sfd=_FakeSfd(),
+        search_strategy=strategy,
+        test_mode=False,
+    )
+    assert fetched == ['fetch_data']
+
+    class _FakeManifestNoTestSource:
+        data_source_config = object()
+        test_data_source_config = None
+
+        def architecture_function(self, data, **kw):
+            return {}
+
+        def fetch_data(self):
+            fetched.append('fetch_data')
+            return _stub_data
+
+        def fetch_test_data(self):
+            fetched.append('fetch_test_data')
+            return _stub_data
+
+    class _FakeSfdNoTestSource:
+        def params(self):
+            return {'x': [1, 2]}
+
+        def manifest(self):
+            return _FakeManifestNoTestSource()
+
+    fetched.clear()
+    UniversalExperimentLoop(
+        sfd=_FakeSfdNoTestSource(),
+        search_strategy=strategy,
+        test_mode=True,
+    )
+    assert fetched == ['fetch_data']

--- a/tests/test_feature_perturbation.py
+++ b/tests/test_feature_perturbation.py
@@ -26,7 +26,7 @@ def _make_manifest_with_groups() -> Manifest:
             lambda df: df.with_columns(pl.col('close').rolling_mean(10).alias('sma_10')),
             group='trend',
         )
-        .with_target('outcome')
+        .with_target_label('outcome')
             .add_transform(lambda data: data.with_columns(
                 pl.Series('outcome', np.random.randint(0, 2, size=data.height))
             ))
@@ -47,7 +47,7 @@ def _make_manifest_with_include_if() -> Manifest:
             lambda df: df.with_columns((pl.col('close').pct_change()).alias('roc')),
             include_if='include_roc',
         )
-        .with_target('outcome')
+        .with_target_label('outcome')
             .add_transform(lambda data: data.with_columns(
                 pl.Series('outcome', np.random.randint(0, 2, size=data.height))
             ))
@@ -119,7 +119,7 @@ def test_ungrouped_features_always_included():
         .add_indicator(
             lambda df: df.with_columns(pl.col('close').rolling_std(5).alias('vol_5')),
         )
-        .with_target('outcome')
+        .with_target_label('outcome')
             .add_transform(lambda data: data.with_columns(
                 pl.Series('outcome', np.random.randint(0, 2, size=data.height))
             ))
@@ -149,7 +149,7 @@ def test_combined_group_and_include_if():
             lambda df: df.with_columns(pl.col('close').rolling_std(5).alias('vol_5')),
             group='volatility',
         )
-        .with_target('outcome')
+        .with_target_label('outcome')
             .add_transform(lambda data: data.with_columns(
                 pl.Series('outcome', np.random.randint(0, 2, size=data.height))
             ))

--- a/tests/test_foundational_sfd.py
+++ b/tests/test_foundational_sfd.py
@@ -50,6 +50,7 @@ def test_foundational_sfd():
                     pruning_strategies=pruning_strategies,
                     feedback_interval=1,
                     experiment_dir=experiment_dir,
+                    test_mode=True,
                 )
 
                 uel.run(

--- a/tests/test_fractional_diff.py
+++ b/tests/test_fractional_diff.py
@@ -169,7 +169,7 @@ def test_fractional_diff_manifest_integration():
         )
         .set_split_config(3, 1, 1)
         .add_feature(fractional_diff, d=0.4, cols=['close'], threshold=1e-2)
-        .with_target('outcome')
+        .with_target_label('outcome')
             .add_transform(lambda data: data.with_columns(
                 pl.Series('outcome', np.random.randint(0, 2, size=data.height))
             ))

--- a/tests/test_inline_metrics.py
+++ b/tests/test_inline_metrics.py
@@ -21,6 +21,7 @@ def _run_uel(sfd_module=random_binary_sfd,
     uel = UniversalExperimentLoop(
         sfd=sfd_module,
         search_strategy=strategy,
+        test_mode=True,
     )
 
     with TemporaryDirectory() as tmpdir:

--- a/tests/test_loop_sfd.py
+++ b/tests/test_loop_sfd.py
@@ -221,10 +221,10 @@ def test_loop_sfd_manifest_target_column():
     assert m.target_column == 'forward_breakout'
 
 
-def test_loop_sfd_manifest_model_function():
+def test_loop_sfd_manifest_architecture_function():
     sfd = LoopSFD(_load_payload())
     m = sfd.manifest()
-    assert m.model_function is _logreg_binary_func
+    assert m.architecture_function is _logreg_binary_func
 
 
 def test_loop_sfd_manifest_scaler_set():
@@ -1012,7 +1012,7 @@ _TESTS = [
     test_loop_sfd_params_extracts_namespaced_arch_params,
     test_loop_sfd_manifest_split_config,
     test_loop_sfd_manifest_target_column,
-    test_loop_sfd_manifest_model_function,
+    test_loop_sfd_manifest_architecture_function,
     test_loop_sfd_manifest_scaler_set,
     test_loop_sfd_manifest_feature_transforms_order,
     test_loop_sfd_ignores_payload_transforms,

--- a/tests/test_manifest_pre_split_random_selector.py
+++ b/tests/test_manifest_pre_split_random_selector.py
@@ -23,7 +23,7 @@ def test_pre_split_random_selector():
             seed='random_seed'
         )
         .set_split_config(6, 2, 2)
-        .with_target('target')
+        .with_target_label('target')
             .done()
     )
 

--- a/tests/test_manifest_prepare_data.py
+++ b/tests/test_manifest_prepare_data.py
@@ -24,7 +24,7 @@ def _make_manifest() -> Manifest:
             'datetime', 'high', 'low', 'close', 'volume', 'maker_ratio',
             'no_of_trades'
         ])
-        .with_target('outcome')
+        .with_target_label('outcome')
             .add_transform(lambda data: data.with_columns(
                 pl.Series('outcome', np.random.randint(0, 2, size=data.height))
             ))
@@ -44,7 +44,7 @@ def _make_shifted_target_manifest() -> Manifest:
 
     return (Manifest()
         .set_split_config(3, 1, 4)
-        .with_target('target')
+        .with_target_label('target')
             .add_transform(lambda data: data.with_columns(
                 (pl.col('close') > pl.col('open')).cast(pl.Int8).alias('target')
             ))
@@ -247,7 +247,7 @@ def test_column_consistency_drops_mismatched_columns() -> None:
         )
         .set_split_config(8, 1, 1)
         .add_feature(_size_gated_feature)
-        .with_target('outcome')
+        .with_target_label('outcome')
             .add_transform(lambda data: data.with_columns(
                 pl.Series('outcome', np.random.randint(0, 2, size=data.height))
             ))

--- a/tests/test_scalers.py
+++ b/tests/test_scalers.py
@@ -155,7 +155,7 @@ def _make_manifest_with_scaler_from_params() -> Manifest:
             lambda df: df.with_columns((pl.col('close').pct_change()).alias('roc')),
         )
         .set_scaler_from_params('scaler_type')
-        .with_target('outcome')
+        .with_target_label('outcome')
             .add_transform(lambda data: data.with_columns(
                 pl.Series('outcome', np.random.randint(0, 2, size=data.height))
             ))

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -56,6 +56,7 @@ def test_trainer_end_to_end():
             sfd=logreg_sfd,
             search_strategy=strategy,
             experiment_dir=experiment_dir,
+            test_mode=True,
         )
 
         uel.run(
@@ -118,6 +119,7 @@ def test_reconstruction_error_stochastic():
             sfd=random_sfd,
             search_strategy=strategy,
             experiment_dir=experiment_dir,
+            test_mode=True,
         )
 
         uel.run(
@@ -147,6 +149,7 @@ def test_reconstruction_error_tampered_log():
             sfd=logreg_sfd,
             search_strategy=strategy,
             experiment_dir=experiment_dir,
+            test_mode=True,
         )
 
         uel.run(
@@ -183,6 +186,7 @@ def test_deterministic_validation():
             sfd=logreg_sfd,
             search_strategy=strategy,
             experiment_dir=experiment_dir,
+            test_mode=True,
         )
 
         uel.run(
@@ -212,6 +216,7 @@ def test_pass2_uses_full_data():
             sfd=logreg_sfd,
             search_strategy=strategy,
             experiment_dir=experiment_dir,
+            test_mode=True,
         )
 
         uel.run(
@@ -250,6 +255,7 @@ def test_sensor_inference():
             sfd=logreg_sfd,
             search_strategy=strategy,
             experiment_dir=experiment_dir,
+            test_mode=True,
         )
 
         uel.run(
@@ -290,6 +296,7 @@ def test_trainer_with_feature_ablation():
             sfd=logreg_sfd,
             search_strategy=strategy,
             experiment_dir=experiment_dir,
+            test_mode=True,
         )
 
         uel.run(
@@ -383,21 +390,21 @@ def test_load_original_log_returns_none_when_results_csv_is_missing() -> None:
         assert trainer._load_original_log() is None
 
 
-def test_resolve_model_class_requires_configured_model_function() -> None:
+def test_resolve_model_class_requires_configured_architecture_function() -> None:
     trainer = object.__new__(Trainer)
-    trainer._manifest = SimpleNamespace(model_function=None)
+    trainer._manifest = SimpleNamespace(architecture_function=None)
 
-    with pytest.raises(ValueError, match='Model function not configured'):
+    with pytest.raises(ValueError, match='Architecture function not configured'):
         trainer._resolve_model_class()
 
 
 def test_resolve_model_class_rejects_modules_without_reference_model_subclasses() -> None:
-    def model_function():
+    def architecture_function():
         return None
 
-    model_function.__module__ = 'dummy.no_model'
+    architecture_function.__module__ = 'dummy.no_model'
     trainer = object.__new__(Trainer)
-    trainer._manifest = SimpleNamespace(model_function=model_function)
+    trainer._manifest = SimpleNamespace(architecture_function=architecture_function)
 
     with pytest.MonkeyPatch.context() as monkeypatch:
         monkeypatch.setattr(
@@ -411,12 +418,12 @@ def test_resolve_model_class_rejects_modules_without_reference_model_subclasses(
 
 
 def test_resolve_model_class_rejects_modules_with_multiple_reference_model_subclasses() -> None:
-    def model_function():
+    def architecture_function():
         return None
 
-    model_function.__module__ = 'dummy.multi_model'
+    architecture_function.__module__ = 'dummy.multi_model'
     trainer = object.__new__(Trainer)
-    trainer._manifest = SimpleNamespace(model_function=model_function)
+    trainer._manifest = SimpleNamespace(architecture_function=architecture_function)
 
     with pytest.MonkeyPatch.context() as monkeypatch:
         monkeypatch.setattr(


### PR DESCRIPTION
**NOTE:** The author must always **first review the PR themselves**, before requesting review from others, that means carefully having reviewed the full diff in GitHub.

## What does this PR change?

- Rename `Manifest.with_model()` to `with_reference_architecture()` and fields `model_function` → `architecture_function`, `model_params` → `architecture_params` for RFC-1004 alignment
- Rename `Manifest.with_target()` to `with_target_label()` for RFC-1004 alignment
- Remove `Manifest.fetch_data_for_env()` and `LOOP_ENV` environment variable dispatch
- Add `test_mode: bool = False` to `UniversalExperimentLoop.__init__()`: when `True` and a test data source is configured, `fetch_test_data()` is used instead of `fetch_data()`
- Trainer now always calls `manifest.fetch_data()` directly when no explicit data is provided

Implements Phase 1 of #381 

## Checklist

- [x] I have reviewed full diff in “Files changed”
- [x] I left no unnecessary files in the changes
- [x] I ran `python tests/run.py` locally without errors (where applicable)
- [x] I updated `/docs` (if behavior/API/config/user/etc changed)
- [x] I added and/or updated docstrings as per [Writing Docstrings](https://github.com/Vaquum/Limen/blob/main/docs/Developer/Writing-Docstrings.md) (for any changed public functions/classes)
- [x] I updated CHANGELOG.md (unless only docs or other non-code aspect was changed)
- [x] I updated pyproject.toml (unless only docs or other non-code aspect was changed)
- [x] I added and/or updated tests (if behavior changed or new code paths added)
- [x] I validated changes manually
- [x] I validated changes with LLM
- [x] I removed any extraneous examples/comments
- [x] I linked issue to auto-close on merge (e.g., “Fixes #123”) when applicable
