### PR TITLE
refactor: split Manifest into MLManifest and RuleBasedManifest subclasses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -839,3 +839,8 @@ Note: add all new changelog entries to the bottom of this file.
 - Add `docs/TechnicalDebt.md` with TD-001 documenting residual `import_module` fallback hardening needed before live-trade deploy
 - Update `docs/Trainer.md` to describe the two-stage SFD load, path-traversal validator, and trust contract on `experiment_dir`
 - Add 3 test groups in `tests/test_trainer.py` pinning the SFD loader contract
+
+## v3.0.4 on 6th of May, 2026
+
+- Split the manifest class into a shared base with separate ML and rule-based subclasses; all foundational SFDs retain the same uniform interface
+- `Manifest.prepare_data()` now raises `NotImplementedError` — replace any direct `Manifest()` usage for data preparation with `MLManifest()` (ML pipelines) or `RuleBasedManifest()` (rule-based pipelines)

--- a/docs/Calibration.md
+++ b/docs/Calibration.md
@@ -177,7 +177,7 @@ The optimizer returns the `default_threshold` with score `0.0` when every candid
 
 - `limen/calibration/` — `sklearn_probability_calibrator`, `grid_threshold_optimizer`, `apply_calibrated_predict`, `CalibratorProtocol`, `ThresholdOptimizerProtocol`
 - `limen.experiment.CalibrationConfig` — the resolved config dataclass injected into the architecture
-- `limen.experiment.CalibrationBuilder` — the fluent builder returned by `Manifest.with_calibration()`
+- `CalibrationBuilder` — the fluent builder returned by `MLManifest.with_calibration()`; not a public import, obtain it only via the fluent chain
 
 ## Read Next
 

--- a/docs/Calibration.md
+++ b/docs/Calibration.md
@@ -29,13 +29,13 @@ The minimum setup: add `with_calibration()` to the manifest.
 
 ```python
 from limen.calibration import grid_threshold_optimizer, sklearn_probability_calibrator
-from limen.experiment import Manifest
+from limen.experiment import MLManifest
 from limen.metrics.balanced_metric import balanced_metric
 from limen.sfd.reference_architecture import logreg_binary
 
 def manifest():
     return (
-        Manifest()
+        MLManifest()
         .set_data_source(...)
         .set_split_config(8, 1, 2)
         .add_indicator(...)
@@ -82,7 +82,7 @@ def params():
 
 def manifest():
     return (
-        Manifest()
+        MLManifest()
         ...
         .with_calibration()
         .probability_calibration(func=sklearn_probability_calibrator, method='cal_method')

--- a/docs/Developer/Contributing-Foundational-SFDs.md
+++ b/docs/Developer/Contributing-Foundational-SFDs.md
@@ -66,8 +66,9 @@ If a needed building block does not exist yet, add it in the right package first
 A strong foundational SFD should look roughly like this:
 
 ```python
-from limen.experiment import Manifest
 from limen.data import HistoricalData
+from limen.experiment import Manifest
+from limen.experiment import MLManifest
 from limen.sfd.reference_architecture import your_model
 
 
@@ -79,9 +80,9 @@ def params():
     }
 
 
-def manifest():
+def manifest() -> Manifest:
     return (
-        Manifest()
+        MLManifest()
         .set_data_source(
             method=HistoricalData.get_spot_klines,
             params={'kline_size': 3600, 'start_date_limit': '2025-01-01'},
@@ -98,6 +99,8 @@ def manifest():
         .with_reference_architecture(your_model)
     )
 ```
+
+The return type is always `Manifest` (the base class) even though the body constructs `MLManifest`. This keeps the interface uniform across all foundational SFDs. For rule-based SFDs, use `RuleBasedManifest` instead — it provides `with_strategy()` and does not expose scalers or ablation.
 
 That is not the only valid shape, but it captures the important properties:
 

--- a/docs/Experiment-Manifest.md
+++ b/docs/Experiment-Manifest.md
@@ -12,13 +12,22 @@ This is the default path for Limen work because it gives you:
 
 Use a manifest when you want Limen's opinionated pipeline. Skip it only when the workflow genuinely needs fully custom `prep()` and `model()` functions.
 
+## Manifest Types
+
+There are two manifest subclasses:
+
+- **`MLManifest`** — for ML pipelines. Supports indicators, features, targets, scalers, ablation, and calibration.
+- **`RuleBasedManifest`** — for rule-based pipelines. Supports indicators and features, plus `with_strategy()` for predicate-driven entry signals. Does not support scalers or ablation.
+
+Both subclasses share a common base (`Manifest`) that owns data fetching, splitting, and model execution. The `manifest()` function in every foundational SFD returns the base `Manifest` type as a uniform interface, while internally constructing the correct subclass.
+
 ## Golden Path Example
 
 This is a complete manifest-driven SFD in the style Limen uses today.
 
 ```python
 from limen.data import HistoricalData
-from limen.experiment import Manifest
+from limen.experiment import MLManifest
 from limen.features import kline_imbalance, vwap
 from limen.indicators import atr, ppo, roc, wilder_rsi
 from limen.scalers import LogRegScaler
@@ -37,9 +46,9 @@ def params():
         'tol': [0.001, 0.01],
     }
 
-def manifest():
+def manifest() -> Manifest:
     return (
-        Manifest()
+        MLManifest()
         .set_data_source(
             method=HistoricalData.get_spot_klines,
             params={'kline_size': 3600, 'start_date_limit': '2025-01-01'},
@@ -441,6 +450,7 @@ Use `with_strategy()` when the strategy is expressed as boolean predicate logic 
 Configure a rule-based strategy from a list of condition config dicts and an entry signal id.
 
 ```python
+from limen.experiment import RuleBasedManifest
 from limen.sfd.reference_architecture.rule_based import rule_based
 
 conditions = [
@@ -450,7 +460,7 @@ conditions = [
 ]
 
 manifest = (
-    Manifest()
+    RuleBasedManifest()
     .add_indicator(wilder_rsi, period='rsi_period')
     .add_indicator(ema, period='ema_period')
     .with_strategy(conditions, entry='entry')
@@ -775,7 +785,7 @@ def params():
     }
 
 manifest = (
-    Manifest()
+    MLManifest()
     .add_indicator(roc, group='momentum', period='roc_period')
     .add_feature(vwap, group='microstructure')
 )
@@ -789,7 +799,7 @@ def params():
         'scaler_type': ['logreg', 'robust'],
     }
 
-manifest = Manifest().set_scaler_from_params('scaler_type')
+manifest = MLManifest().set_scaler_from_params('scaler_type')
 ```
 
 ### Retrain on all data

--- a/docs/Experiment-Manifest.md
+++ b/docs/Experiment-Manifest.md
@@ -27,6 +27,7 @@ This is a complete manifest-driven SFD in the style Limen uses today.
 
 ```python
 from limen.data import HistoricalData
+from limen.experiment import Manifest
 from limen.experiment import MLManifest
 from limen.features import kline_imbalance, vwap
 from limen.indicators import atr, ppo, roc, wilder_rsi

--- a/docs/Experiment-Manifest.md
+++ b/docs/Experiment-Manifest.md
@@ -19,7 +19,7 @@ There are two manifest subclasses:
 - **`MLManifest`** — for ML pipelines. Supports indicators, features, targets, scalers, ablation, and calibration.
 - **`RuleBasedManifest`** — for rule-based pipelines. Supports indicators and features, plus `with_strategy()` for predicate-driven entry signals. Does not support scalers or ablation.
 
-Both subclasses share a common base (`Manifest`) that owns data fetching, splitting, and model execution. The `manifest()` function in every foundational SFD returns the base `Manifest` type as a uniform interface, while internally constructing the correct subclass.
+Both subclasses share a common base (`Manifest`) that owns data fetching, splitting, and model execution. The `manifest()` function in every foundational SFD returns the base `Manifest` type as a uniform interface, while internally constructing the correct subclass. `Manifest` itself is not meant to be instantiated directly — its `prepare_data()` raises `NotImplementedError`.
 
 ## Golden Path Example
 

--- a/docs/Single-File-Decoder.md
+++ b/docs/Single-File-Decoder.md
@@ -44,6 +44,7 @@ Manifest-driven SFDs expose `manifest()` instead of custom `prep()` and `model()
 ```python
 from limen.data import HistoricalData
 from limen.experiment import Manifest
+from limen.experiment import MLManifest
 from limen.indicators import roc
 from limen.scalers import LogRegScaler
 from limen.sfd.reference_architecture import logreg_binary
@@ -58,9 +59,9 @@ def params():
         'class_weight': [0.45, 0.65, 0.85],
     }
 
-def manifest():
+def manifest() -> Manifest:
     return (
-        Manifest()
+        MLManifest()
         .set_data_source(
             method=HistoricalData.get_spot_klines,
             params={'kline_size': 3600, 'start_date_limit': '2025-01-01'},

--- a/limen/__init__.py
+++ b/limen/__init__.py
@@ -2,7 +2,9 @@ from limen.data import HistoricalData
 from limen.log.log import Log
 from limen.trading import Account
 from limen.backtest.backtest_sequential import BacktestSequential
+from limen.experiment import MLManifest
 from limen.experiment import Manifest
+from limen.experiment import RuleBasedManifest
 from limen.experiment import ReconstructionError
 from limen.experiment import Sensor
 from limen.experiment import Trainer
@@ -26,9 +28,11 @@ __all__ = [
     'Cohort',
     'HistoricalData',
     'Log',
+    'MLManifest',
     'Manifest',
     'ReconstructionError',
     'RegimeDiversifiedOpinionPools',
+    'RuleBasedManifest',
     'Sensor',
     'Trainer',
     'UniversalExperimentLoop',

--- a/limen/experiment/__init__.py
+++ b/limen/experiment/__init__.py
@@ -1,5 +1,4 @@
 from limen.experiment.experiment_core import UniversalExperimentLoop
-from limen.experiment.manifest_core import CalibrationBuilder
 from limen.experiment.manifest_core import CalibrationConfig
 from limen.experiment.manifest_core import MLManifest
 from limen.experiment.manifest_core import Manifest
@@ -13,7 +12,6 @@ from limen.experiment.trainer import Trainer
 
 __all__ = [
     'STRATEGY_REGISTRY',
-    'CalibrationBuilder',
     'CalibrationConfig',
     'GridStrategy',
     'MLManifest',

--- a/limen/experiment/__init__.py
+++ b/limen/experiment/__init__.py
@@ -1,7 +1,9 @@
 from limen.experiment.experiment_core import UniversalExperimentLoop
 from limen.experiment.manifest_core import CalibrationBuilder
 from limen.experiment.manifest_core import CalibrationConfig
+from limen.experiment.manifest_core import MLManifest
 from limen.experiment.manifest_core import Manifest
+from limen.experiment.manifest_core import RuleBasedManifest
 from limen.experiment.param_search import GridStrategy
 from limen.experiment.param_search import RandomStrategy
 from limen.experiment.param_search import STRATEGY_REGISTRY
@@ -14,9 +16,11 @@ __all__ = [
     'CalibrationBuilder',
     'CalibrationConfig',
     'GridStrategy',
+    'MLManifest',
     'Manifest',
     'RandomStrategy',
     'ReconstructionError',
+    'RuleBasedManifest',
     'Sensor',
     'Trainer',
     'UniversalExperimentLoop',

--- a/limen/experiment/experiment_core.py
+++ b/limen/experiment/experiment_core.py
@@ -22,6 +22,7 @@ from limen.experiment.reducer.pruning_strategy import PruningStrategy
 from limen.experiment.param_search.search_strategy import SearchStrategy
 from limen.utils.param_space import ParamSpace
 from limen.log.log import Log
+from limen.experiment.manifest_core import RuleBasedManifest
 
 logger = logging.getLogger(__name__)
 
@@ -289,7 +290,7 @@ class UniversalExperimentLoop:
 
         self._log = Log(uel_object=self, cols_to_multilabel=cols_to_multilabel)
 
-        is_rule_based = self.manifest is not None and self.manifest._rule_based is not None
+        is_rule_based = isinstance(self.manifest, RuleBasedManifest)
         self.experiment_confusion_metrics = (
             None if is_rule_based
             else self._log.experiment_confusion_metrics('price_change')

--- a/limen/experiment/manifest_core.py
+++ b/limen/experiment/manifest_core.py
@@ -565,14 +565,10 @@ class Manifest:
     ) -> dict:
 
         '''
-        Compute final data dictionary from raw data using manifest configuration.
+        Interface method — implemented by MLManifest and RuleBasedManifest.
 
-        Args:
-            raw_data (pl.DataFrame): Raw input dataset
-            round_params (Dict[str, Any]): Parameter values for current round
-
-        Returns:
-            dict: Final data dictionary ready for model training
+        Raises:
+            NotImplementedError: Always. Construct MLManifest or RuleBasedManifest instead of Manifest directly.
         '''
 
         raise NotImplementedError(
@@ -924,6 +920,12 @@ class RuleBasedManifest(Manifest):
         Returns:
             dict: Final data dictionary ready for model training
         '''
+
+        if self.strategy is None:
+            raise ValueError(
+                'RuleBasedManifest.prepare_data() called without a strategy. '
+                'Call with_strategy(conditions, entry=...) before running.'
+            )
 
         split_data, all_datetimes, _ = _run_prepare_setup(self, raw_data, round_params)
 

--- a/limen/experiment/manifest_core.py
+++ b/limen/experiment/manifest_core.py
@@ -91,6 +91,11 @@ class CalibrationBuilder:
 
     def __init__(self, manifest: 'MLManifest') -> None:
 
+        if not isinstance(manifest, MLManifest):
+            raise ValueError(
+                f'CalibrationBuilder requires an MLManifest, got {type(manifest).__name__}. '
+                'Use MLManifest().with_calibration() to configure calibration.'
+            )
         self._manifest = manifest
         self._calibration_func: CalibratorProtocol | None = None
         self._calibration_params: dict[str, Any] = {}

--- a/limen/experiment/manifest_core.py
+++ b/limen/experiment/manifest_core.py
@@ -1341,24 +1341,21 @@ def _align_split_columns(split_data: list[pl.DataFrame]) -> list[pl.DataFrame]:
 
 
 def _finalize_to_data_dict(
-        manifest: Manifest,
+        manifest: 'MLManifest',
         split_data: list[pl.DataFrame],
         all_datetimes: list,
         fitted_params: dict[str, Any],
         round_params: dict[str, Any],
-        price_data_for_backtest: pl.DataFrame | None = None
+        price_data_for_backtest: pl.DataFrame | None = None,
 ) -> dict:
 
-    # Validate all splits have datetime column
     for i, split_df in enumerate(split_data):
         assert 'datetime' in split_df.columns, f"Split {i} missing 'datetime' column"
 
-    # Ensure target_column is last column in all splits
     if manifest.target_column:
         for i, split_df in enumerate(split_data):
             cols = list(split_df.columns)
             if manifest.target_column in cols:
-                # Move target_column to end
                 cols.remove(manifest.target_column)
                 cols.append(manifest.target_column)
                 split_data[i] = split_df.select(cols)
@@ -1369,7 +1366,6 @@ def _finalize_to_data_dict(
 
     data_dict = split_data_to_prep_output(split_data, cols, all_datetimes)
 
-    # Add fitted parameters to data_dict
     for param_name, param_value in fitted_params.items():
         data_dict[param_name] = param_value
 
@@ -1378,7 +1374,6 @@ def _finalize_to_data_dict(
     if price_data_for_backtest is not None:
         data_dict['price_data_for_backtest'] = price_data_for_backtest
 
-    # Apply data_dict extension if configured
     if manifest.data_dict_extension:
         data_dict = manifest.data_dict_extension(
             data_dict=data_dict,

--- a/limen/experiment/manifest_core.py
+++ b/limen/experiment/manifest_core.py
@@ -89,7 +89,7 @@ class CalibrationBuilder:
 
     '''Fluent builder for calibration configuration.'''
 
-    def __init__(self, manifest: 'Manifest') -> None:
+    def __init__(self, manifest: 'MLManifest') -> None:
 
         self._manifest = manifest
         self._calibration_func: CalibratorProtocol | None = None
@@ -131,13 +131,13 @@ class CalibrationBuilder:
         self._threshold_params = params
         return self
 
-    def done(self) -> 'Manifest':
+    def done(self) -> 'MLManifest':
 
         '''
         Finalise calibration configuration and return the manifest.
 
         Returns:
-            Manifest: The parent manifest with prediction_calibration_config set
+            MLManifest: The parent manifest with prediction_calibration_config set
 
         Raises:
             ValueError: If neither probability_calibration() nor threshold_function() was called before done()
@@ -216,7 +216,7 @@ class DataSourceResolver:
 @dataclass
 class Manifest:
 
-    '''Defines manifest for Loop experiments.'''
+    '''Base manifest with shared data pipeline configuration for Loop experiments.'''
 
     data_source_config: DataSourceConfig = None
     test_data_source_config: DataSourceConfig = None
@@ -227,15 +227,10 @@ class Manifest:
     feature_transforms: list[TransformEntry] = field(default_factory=list)
     target_column: str | None = None
     target_class_config: TargetClassConfig | None = None
-    scaler: FittedTransformEntry = None
-    ablation_config: AblationConfig | None = None
-    data_dict_extension: Callable = None
 
     architecture_function: Callable = None
     architecture_params: dict[str, ParamValue] = field(default_factory=dict)
     metrics_params: dict[str, ParamValue] = field(default_factory=dict)
-    prediction_calibration_config: CalibrationConfig | None = None
-    _rule_based: 'RuleBasedConfig | None' = field(default=None, init=False, repr=False)
 
     def _add_transform(self,
                        func: Callable,
@@ -434,65 +429,6 @@ class Manifest:
 
         return self
 
-    def set_scaler(self, transform_class: Any, param_name: str = '_scaler') -> 'Manifest':
-
-        '''
-        Set scaler transformation using make_fitted_scaler.
-
-        Args:
-            transform_class: Transform class to use for scaling
-            param_name (str): Parameter name for fitted scaler
-
-        Returns:
-            Manifest: Self for method chaining
-        '''
-
-        self.scaler = make_fitted_scaler(param_name, transform_class)
-
-        return self
-
-
-    def set_scaler_from_params(self,
-                               param_name: str = 'scaler_type') -> 'Manifest':
-
-        '''
-        Configure scaler selection from round_params at runtime.
-
-        The scaler class is resolved from the scaler registry using
-        the value of round_params[param_name].
-
-        Args:
-            param_name (str): round_params key that holds the scaler type string
-
-        Returns:
-            Manifest: Self for method chaining
-        '''
-
-        def _scaler_factory(data: 'pl.DataFrame',
-                            scaler_type: str = '') -> Any:
-
-            if scaler_type not in SCALER_REGISTRY:
-                if scaler_type == param_name:
-                    raise ValueError(
-                        f"round_params['{param_name}'] is required when using "
-                        f"set_scaler_from_params(). "
-                        f"Available types: {sorted(SCALER_REGISTRY)}"
-                    )
-                raise ValueError(
-                    f"Unknown scaler type '{scaler_type}'. "
-                    f"Available: {sorted(SCALER_REGISTRY)}"
-                )
-            return SCALER_REGISTRY[scaler_type](data)
-
-        self.scaler = (
-            [('_scaler', _scaler_factory, {'scaler_type': param_name})],
-            _apply_fitted_transform,
-            {'fitted_transform': '_scaler'},
-        )
-
-        return self
-
-
     def with_target_label(self,
                           target_name: str,
                           target_class: type,
@@ -543,81 +479,6 @@ class Manifest:
 
         self.architecture_function = architecture_function
 
-        return self
-
-    def with_calibration(self) -> 'CalibrationBuilder':
-
-        '''
-        Begin fluent calibration configuration.
-
-        Returns:
-            CalibrationBuilder: Builder for configuring probability calibration and threshold optimisation
-
-        NOTE: Call .probability_calibration(), optionally .threshold_function(), then .done() to finalise.
-        '''
-
-        return CalibrationBuilder(self)
-
-    def with_strategy(self, conditions: list[dict], entry: str) -> 'Manifest':
-
-        '''
-        Configure rule-based strategy conditions and entry signal.
-
-        Args:
-            conditions (list[dict]): List of predicate and compound operator condition configs
-            entry (str): ID of the condition that produces the per-bar position signal
-
-        Returns:
-            Manifest: Self for method chaining
-        '''
-
-        from limen.sfd.rule_based.config import RuleBasedConfig  # local to avoid circular import
-        self._rule_based = RuleBasedConfig(conditions=list(conditions), entry=entry)
-
-        return self
-
-    def set_feature_ablation(self,
-                             drop_count_key: str = 'feature_drop_count',
-                             seed_key: str = 'feature_drop_seed') -> 'Manifest':
-
-        '''
-        Configure random feature ablation (Drop-N).
-
-        Randomly drops N feature columns per permutation using a
-        deterministic seed from round_params. Runs after feature and
-        target transforms in the prepare_data pipeline.
-
-        Args:
-            drop_count_key (str): round_params key for number of columns to drop
-            seed_key (str): round_params key for random seed
-
-        Returns:
-            Manifest: Self for method chaining
-        '''
-
-        self.ablation_config = AblationConfig(
-            drop_count_key=drop_count_key,
-            seed_key=seed_key,
-        )
-        return self
-
-
-    def add_to_data_dict(self, func: Callable) -> 'Manifest':
-
-        '''
-        Configure data_dict extension function to add custom entries after data preparation.
-
-        Args:
-            func (Callable): Extension function with signature (data_dict, split_data, round_params, fitted_params) -> dict
-
-        Returns:
-            Manifest: Self for method chaining
-
-        NOTE: The extension function receives the base data_dict and full split DataFrames.
-        It should modify and return the data_dict with any additional custom entries needed by the model.
-        '''
-
-        self.data_dict_extension = func
         return self
 
     def with_params_override(self, **overrides: Any) -> 'Manifest':
@@ -714,107 +575,10 @@ class Manifest:
             dict: Final data dictionary ready for model training
         '''
 
-        if self._rule_based is not None:
-            if self.scaler is not None:
-                raise ValueError(
-                    'Scalers cannot be used with rule-based SFDs — predicates depend on '
-                    'original indicator scales and produce incorrect signals on scaled values.'
-                )
-            if self.ablation_config is not None:
-                raise ValueError(
-                    'Feature ablation cannot be used with rule-based SFDs — predicate '
-                    'columns are derived from specific indicator columns.'
-                )
-
-        if self.pre_split_data_selector:
-            func, base_params = self.pre_split_data_selector
-            resolved = _resolve_params(base_params, round_params)
-            raw_data = func(raw_data, **resolved)
-
-        split_data = split_sequential(raw_data, self.split_config)
-
-        datetime_bar_pairs = [_process_bars(self, split, round_params) for split in split_data]
-        all_datetimes = [dt for datetimes, _ in datetime_bar_pairs for dt in datetimes]
-        split_data = [bar_data for _, bar_data in datetime_bar_pairs]
-
-        price_cols = ['datetime', 'open', 'high', 'low', 'close']
-        test_split = split_data[2]
-        available = [c for c in price_cols if c in test_split.columns]
-        price_data_for_backtest = test_split.select(available) if len(available) == len(price_cols) else None
-
-        all_fitted_params = {}
-        columns_to_drop: list[str] | None = None
-        pre_transform_columns = frozenset(split_data[0].columns)
-
-        for i in range(len(split_data)):
-            lazy_data = split_data[i].lazy()
-
-            lazy_data = _apply_feature_transforms(self, lazy_data, round_params)
-
-            data = lazy_data.collect()
-
-            if self.target_class_config is not None:
-                data, all_fitted_params = _apply_class_based_target(
-                    self, data, round_params, all_fitted_params, is_training=(i == 0)
-                )
-
-            if self.ablation_config is not None:
-                data, columns_to_drop = _apply_feature_ablation(
-                    data, self, round_params, columns_to_drop,
-                    pre_transform_columns,
-                )
-
-            data = data.fill_nan(None).drop_nulls()
-
-            data, all_fitted_params = _apply_scaler(
-                self, data, round_params, all_fitted_params, is_training=(i == 0)
-            )
-
-            split_data[i] = data.fill_nan(None).drop_nulls()
-
-        non_empty_splits = [s for s in split_data if s.height > 0]
-        if non_empty_splits:
-            reference_cols = non_empty_splits[0].columns
-
-            if len(non_empty_splits) > 1:
-                common_cols = set(reference_cols)
-                for split in non_empty_splits[1:]:
-                    common_cols &= set(split.columns)
-
-                for i, split in enumerate(split_data):
-                    if split.height == 0:
-                        continue
-                    extra = set(split.columns) - common_cols
-                    if extra:
-                        logger.warning(
-                            'Dropping columns %s from split %d — '
-                            'not present in all splits',
-                            sorted(extra), i,
-                        )
-                        ordered_cols = [c for c in split.columns if c in common_cols]
-                        split_data[i] = split.select(ordered_cols)
-                reference_cols = [c for c in reference_cols if c in common_cols]
-
-            for i, split in enumerate(split_data):
-                if split.height == 0:
-                    missing = set(reference_cols) - set(split.columns)
-                    if missing:
-                        split_data[i] = split.with_columns(
-                            [pl.lit(None).alias(c) for c in reference_cols if c in missing]
-                        ).select(reference_cols)
-                    else:
-                        split_data[i] = split.select(reference_cols)
-
-        if price_data_for_backtest is not None:
-            final_datetimes = split_data[2].select('datetime')
-            price_data_for_backtest = final_datetimes.join(
-                price_data_for_backtest, on='datetime', how='left',
-                maintain_order='left'
-            )
-
-        if self._rule_based is not None:
-            return _finalize_rule_based_data(self, split_data, all_datetimes, round_params)
-        return _finalize_to_data_dict(self, split_data, all_datetimes, all_fitted_params, round_params, price_data_for_backtest)
+        raise NotImplementedError(
+            f'{type(self).__name__} must implement prepare_data(). '
+            'Use MLManifest for ML pipelines or RuleBasedManifest for rule-based pipelines.'
+        )
 
     def resolve_model_kwargs(self, round_params: dict[str, Any]) -> dict[str, Any]:
 
@@ -892,6 +656,204 @@ class Manifest:
         '''
 
         model_kwargs = self.resolve_model_kwargs(round_params)
+        return self.architecture_function(data, **model_kwargs)
+
+
+@dataclass
+class MLManifest(Manifest):
+
+    '''Manifest for ML pipelines with scaler, ablation, and calibration support.'''
+
+    scaler: FittedTransformEntry = None
+    ablation_config: AblationConfig | None = None
+    data_dict_extension: Callable = None
+    prediction_calibration_config: CalibrationConfig | None = None
+
+    def set_scaler(self, transform_class: Any, param_name: str = '_scaler') -> 'MLManifest':
+
+        '''
+        Set scaler transformation using make_fitted_scaler.
+
+        Args:
+            transform_class: Transform class to use for scaling
+            param_name (str): Parameter name for fitted scaler
+
+        Returns:
+            MLManifest: Self for method chaining
+        '''
+
+        self.scaler = make_fitted_scaler(param_name, transform_class)
+
+        return self
+
+
+    def set_scaler_from_params(self,
+                               param_name: str = 'scaler_type') -> 'MLManifest':
+
+        '''
+        Configure scaler selection from round_params at runtime.
+
+        The scaler class is resolved from the scaler registry using
+        the value of round_params[param_name].
+
+        Args:
+            param_name (str): round_params key that holds the scaler type string
+
+        Returns:
+            MLManifest: Self for method chaining
+        '''
+
+        def _scaler_factory(data: 'pl.DataFrame',
+                            scaler_type: str = '') -> Any:
+
+            if scaler_type not in SCALER_REGISTRY:
+                if scaler_type == param_name:
+                    raise ValueError(
+                        f"round_params['{param_name}'] is required when using "
+                        f"set_scaler_from_params(). "
+                        f"Available types: {sorted(SCALER_REGISTRY)}"
+                    )
+                raise ValueError(
+                    f"Unknown scaler type '{scaler_type}'. "
+                    f"Available: {sorted(SCALER_REGISTRY)}"
+                )
+            return SCALER_REGISTRY[scaler_type](data)
+
+        self.scaler = (
+            [('_scaler', _scaler_factory, {'scaler_type': param_name})],
+            _apply_fitted_transform,
+            {'fitted_transform': '_scaler'},
+        )
+
+        return self
+
+    def set_feature_ablation(self,
+                             drop_count_key: str = 'feature_drop_count',
+                             seed_key: str = 'feature_drop_seed') -> 'MLManifest':
+
+        '''
+        Configure random feature ablation (Drop-N).
+
+        Randomly drops N feature columns per permutation using a
+        deterministic seed from round_params. Runs after feature and
+        target transforms in the prepare_data pipeline.
+
+        Args:
+            drop_count_key (str): round_params key for number of columns to drop
+            seed_key (str): round_params key for random seed
+
+        Returns:
+            MLManifest: Self for method chaining
+        '''
+
+        self.ablation_config = AblationConfig(
+            drop_count_key=drop_count_key,
+            seed_key=seed_key,
+        )
+        return self
+
+
+    def add_to_data_dict(self, func: Callable) -> 'MLManifest':
+
+        '''
+        Configure data_dict extension function to add custom entries after data preparation.
+
+        Args:
+            func (Callable): Extension function with signature (data_dict, split_data, round_params, fitted_params) -> dict
+
+        Returns:
+            MLManifest: Self for method chaining
+
+        NOTE: The extension function receives the base data_dict and full split DataFrames.
+        It should modify and return the data_dict with any additional custom entries needed by the model.
+        '''
+
+        self.data_dict_extension = func
+        return self
+
+    def with_calibration(self) -> 'CalibrationBuilder':
+
+        '''
+        Begin fluent calibration configuration.
+
+        Returns:
+            CalibrationBuilder: Builder for configuring probability calibration and threshold optimisation
+
+        NOTE: Call .probability_calibration(), optionally .threshold_function(), then .done() to finalise.
+        '''
+
+        return CalibrationBuilder(self)
+
+    def prepare_data(
+        self,
+        raw_data: pl.DataFrame,
+        round_params: dict[str, Any]
+    ) -> dict:
+
+        '''
+        Compute final data dictionary from raw data using the ML pipeline.
+
+        Args:
+            raw_data (pl.DataFrame): Raw input dataset
+            round_params (Dict[str, Any]): Parameter values for current round
+
+        Returns:
+            dict: Final data dictionary ready for model training
+        '''
+
+        split_data, all_datetimes, price_data_for_backtest = _run_prepare_setup(self, raw_data, round_params)
+
+        all_fitted_params: dict[str, Any] = {}
+        columns_to_drop: list[str] | None = None
+        pre_transform_columns = frozenset(split_data[0].columns)
+
+        for i, split in enumerate(split_data):
+            lazy = split.lazy()
+            lazy = _apply_feature_transforms(self, lazy, round_params)
+            data = lazy.collect()
+
+            if self.target_class_config is not None:
+                data, all_fitted_params = _apply_class_based_target(
+                    self, data, round_params, all_fitted_params, i == 0
+                )
+
+            if self.ablation_config is not None:
+                data, columns_to_drop = _apply_feature_ablation(
+                    data, self, round_params, columns_to_drop, pre_transform_columns,
+                )
+
+            data = data.fill_nan(None).drop_nulls()
+            data, all_fitted_params = _apply_scaler(self, data, round_params, all_fitted_params, i == 0)
+            split_data[i] = data.fill_nan(None).drop_nulls()
+
+        split_data = _align_split_columns(split_data)
+
+        if price_data_for_backtest is not None:
+            final_datetimes = split_data[2].select('datetime')
+            price_data_for_backtest = final_datetimes.join(
+                price_data_for_backtest, on='datetime', how='left',
+                maintain_order='left'
+            )
+
+        return _finalize_to_data_dict(self, split_data, all_datetimes, all_fitted_params, round_params, price_data_for_backtest)
+
+    def run_model(self, data: dict, round_params: dict[str, Any]) -> dict:
+
+        '''
+        Execute model training and evaluation, injecting resolved calibration config when configured.
+
+        Args:
+            data (dict): Prepared data dictionary
+            round_params (dict[str, Any]): Parameter values for current round
+
+        Returns:
+            dict: Results including predictions, metrics, and optional extras
+
+        NOTE: Calibration injection honours use_calibration and use_threshold round_params flags
+        (both default True). Setting either to False masks that step while keeping the other active.
+        '''
+
+        model_kwargs = self.resolve_model_kwargs(round_params)
         if self.prediction_calibration_config is not None:
             use_calibration = round_params.get('use_calibration', True)
             use_threshold = round_params.get('use_threshold', True)
@@ -918,10 +880,71 @@ class Manifest:
                     threshold_params=resolved.threshold_params,
                 )
                 model_kwargs['prediction_calibration_config'] = config
-        round_results = self.architecture_function(data, **model_kwargs)
+        return self.architecture_function(data, **model_kwargs)
 
-        return round_results
 
+@dataclass
+class RuleBasedManifest(Manifest):
+
+    '''Manifest for rule-based pipelines with predicate conditions and entry signals.'''
+
+    strategy: 'RuleBasedConfig | None' = field(default=None, init=False, repr=False)
+
+    def with_strategy(self, conditions: list[dict], entry: str) -> 'RuleBasedManifest':
+
+        '''
+        Configure rule-based strategy conditions and entry signal.
+
+        Args:
+            conditions (list[dict]): List of predicate and compound operator condition configs
+            entry (str): ID of the condition that produces the per-bar position signal
+
+        Returns:
+            RuleBasedManifest: Self for method chaining
+        '''
+
+        from limen.sfd.rule_based.config import RuleBasedConfig  # local to avoid circular import
+        self.strategy = RuleBasedConfig(conditions=list(conditions), entry=entry)
+
+        return self
+
+    def prepare_data(
+        self,
+        raw_data: pl.DataFrame,
+        round_params: dict[str, Any]
+    ) -> dict:
+
+        '''
+        Compute final data dictionary from raw data using the rule-based pipeline.
+
+        Args:
+            raw_data (pl.DataFrame): Raw input dataset
+            round_params (Dict[str, Any]): Parameter values for current round
+
+        Returns:
+            dict: Final data dictionary ready for model training
+        '''
+
+        split_data, all_datetimes, _ = _run_prepare_setup(self, raw_data, round_params)
+
+        all_fitted_params: dict[str, Any] = {}
+
+        for i, split in enumerate(split_data):
+            lazy = split.lazy()
+            lazy = _apply_feature_transforms(self, lazy, round_params)
+            data = lazy.collect()
+
+            if self.target_class_config is not None:
+                data, all_fitted_params = _apply_class_based_target(
+                    self, data, round_params, all_fitted_params, i == 0
+                )
+
+            data = data.fill_nan(None).drop_nulls()
+            split_data[i] = data.fill_nan(None).drop_nulls()
+
+        split_data = _align_split_columns(split_data)
+
+        return _finalize_rule_based_data(self, split_data, all_datetimes, round_params)
 
 
 def _apply_fitted_transform(data: pl.DataFrame, fitted_transform: Any) -> pl.DataFrame:
@@ -1252,6 +1275,71 @@ def _apply_scaler(
     return data, all_fitted_params
 
 
+def _run_prepare_setup(
+        manifest: Manifest,
+        raw_data: pl.DataFrame,
+        round_params: dict[str, Any],
+) -> tuple[list[pl.DataFrame], list, pl.DataFrame | None]:
+
+    if manifest.pre_split_data_selector:
+        func, base_params = manifest.pre_split_data_selector
+        resolved = _resolve_params(base_params, round_params)
+        raw_data = func(raw_data, **resolved)
+
+    split_data = split_sequential(raw_data, manifest.split_config)
+
+    datetime_bar_pairs = [_process_bars(manifest, split, round_params) for split in split_data]
+    all_datetimes = [dt for datetimes, _ in datetime_bar_pairs for dt in datetimes]
+    split_data = [bar_data for _, bar_data in datetime_bar_pairs]
+
+    price_cols = ['datetime', 'open', 'high', 'low', 'close']
+    test_split = split_data[2]
+    available = [c for c in price_cols if c in test_split.columns]
+    price_data_for_backtest = test_split.select(available) if len(available) == len(price_cols) else None
+
+    return split_data, all_datetimes, price_data_for_backtest
+
+
+def _align_split_columns(split_data: list[pl.DataFrame]) -> list[pl.DataFrame]:
+
+    non_empty_splits = [s for s in split_data if s.height > 0]
+    if not non_empty_splits:
+        return split_data
+
+    reference_cols = non_empty_splits[0].columns
+
+    if len(non_empty_splits) > 1:
+        common_cols = set(reference_cols)
+        for split in non_empty_splits[1:]:
+            common_cols &= set(split.columns)
+
+        for i, split in enumerate(split_data):
+            if split.height == 0:
+                continue
+            extra = set(split.columns) - common_cols
+            if extra:
+                logger.warning(
+                    'Dropping columns %s from split %d — '
+                    'not present in all splits',
+                    sorted(extra), i,
+                )
+                ordered_cols = [c for c in split.columns if c in common_cols]
+                split_data[i] = split.select(ordered_cols)
+        reference_cols = [c for c in reference_cols if c in common_cols]
+
+    for i, split in enumerate(split_data):
+        if split.height == 0:
+            missing = set(reference_cols) - set(split.columns)
+            if missing:
+                split_data[i] = split.with_columns(
+                    [pl.lit(None).alias(c) for c in reference_cols if c in missing]
+                ).select(reference_cols)
+            else:
+                split_data[i] = split.select(reference_cols)
+
+    return split_data
+
+
 def _finalize_to_data_dict(
         manifest: Manifest,
         split_data: list[pl.DataFrame],
@@ -1303,7 +1391,7 @@ def _finalize_to_data_dict(
 
 
 def _finalize_rule_based_data(
-        manifest: Manifest,
+        manifest: RuleBasedManifest,
         split_data: list[pl.DataFrame],
         all_datetimes: list,
         round_params: dict[str, Any],
@@ -1313,7 +1401,7 @@ def _finalize_rule_based_data(
 
     data_dict = split_data_to_rule_based_prep_output(split_data, all_datetimes)
 
-    config = manifest._rule_based
+    config = manifest.strategy
     predicate_conditions = [c for c in config.conditions if 'type' in c]
     predicate_ids = [c['id'] for c in predicate_conditions]
     predicate_exprs = [

--- a/limen/sfd/foundational_sfd/logreg_binary.py
+++ b/limen/sfd/foundational_sfd/logreg_binary.py
@@ -1,6 +1,7 @@
 from limen.calibration import grid_threshold_optimizer
 from limen.calibration import sklearn_probability_calibrator
 from limen.data import HistoricalData
+from limen.experiment import MLManifest
 from limen.experiment import Manifest
 from limen.features import fractional_diff
 from limen.features import kline_imbalance
@@ -45,7 +46,7 @@ def params() -> dict:
 
 def manifest() -> Manifest:
 
-    return (Manifest()
+    return (MLManifest()
         .set_data_source(
             method=HistoricalData.get_spot_klines,
             params={'kline_size': 3600, 'start_date_limit': '2025-01-01'}

--- a/limen/sfd/foundational_sfd/random_binary.py
+++ b/limen/sfd/foundational_sfd/random_binary.py
@@ -1,4 +1,5 @@
 from limen.data import HistoricalData
+from limen.experiment import MLManifest
 from limen.experiment import Manifest
 from limen.sfd.reference_architecture import random_binary
 from limen.targets import RandomBinaryTarget
@@ -13,8 +14,8 @@ def params():
     }
 
 
-def manifest():
-    return (Manifest()
+def manifest() -> Manifest:
+    return (MLManifest()
         .set_data_source(
             method=HistoricalData.get_spot_klines,
             params={'kline_size': 3600, 'start_date_limit': '2025-01-01'}

--- a/limen/sfd/foundational_sfd/rule_based.py
+++ b/limen/sfd/foundational_sfd/rule_based.py
@@ -1,5 +1,6 @@
 from limen.data import HistoricalData
 from limen.experiment import Manifest
+from limen.experiment import RuleBasedManifest
 from limen.indicators import ema
 from limen.indicators import wilder_rsi
 from limen.sfd.reference_architecture.rule_based import rule_based
@@ -41,7 +42,7 @@ def params() -> dict:
 
 def manifest() -> Manifest:
 
-    return (Manifest()
+    return (RuleBasedManifest()
         .set_data_source(
             method=HistoricalData.get_spot_klines,
             params={'kline_size': 3600, 'start_date_limit': '2025-01-01'},

--- a/limen/sfd/foundational_sfd/tabpfn_binary.py
+++ b/limen/sfd/foundational_sfd/tabpfn_binary.py
@@ -1,6 +1,7 @@
 from limen.calibration import grid_threshold_optimizer
 from limen.calibration import sklearn_probability_calibrator
 from limen.data import HistoricalData
+from limen.experiment import MLManifest
 from limen.experiment import Manifest
 from limen.indicators import bollinger_bands
 from limen.indicators import bollinger_position
@@ -37,7 +38,7 @@ def params() -> dict[str, list]:
 
 def manifest() -> Manifest:
 
-    return (Manifest()
+    return (MLManifest()
         .set_data_source(
             method=HistoricalData.get_spot_klines,
             params={'kline_size': 3600, 'start_date_limit': '2025-01-01'}

--- a/limen/sfd/foundational_sfd/xgboost_regressor.py
+++ b/limen/sfd/foundational_sfd/xgboost_regressor.py
@@ -1,6 +1,7 @@
 import polars as pl
 
 from limen.data import HistoricalData
+from limen.experiment import MLManifest
 from limen.experiment import Manifest
 from limen.indicators.window_return import window_return
 from limen.indicators.sma import sma
@@ -32,10 +33,10 @@ def params():
     }
 
 
-def manifest():
+def manifest() -> Manifest:
 
     return (
-        Manifest()
+        MLManifest()
         .set_data_source(
             method=HistoricalData.get_spot_klines,
             params={'kline_size': 3600, 'start_date_limit': '2025-01-01'}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaquum_limen"
-version = "3.0.3"
+version = "3.0.4"
 description = "Bitcoin-first research and trading platform."
 readme = "README.md"
 authors = [

--- a/tests/test_calibration.py
+++ b/tests/test_calibration.py
@@ -8,6 +8,7 @@ from limen.calibration import grid_threshold_optimizer
 from limen.calibration import sklearn_probability_calibrator
 from limen.experiment.manifest_core import CalibrationBuilder
 from limen.experiment.manifest_core import CalibrationConfig
+from limen.experiment.manifest_core import MLManifest
 from limen.experiment.manifest_core import Manifest
 from limen.metrics.balanced_metric import balanced_metric
 from limen.sfd.reference_architecture.logreg_binary import LogRegBinary
@@ -85,7 +86,7 @@ def test_calibration_config_resolve_substitutes_string_params() -> None:
 
 
 def test_calibration_builder_done_raises_without_any_func() -> None:
-    builder = CalibrationBuilder(Manifest())
+    builder = CalibrationBuilder(MLManifest())
     try:
         builder.done()
         assert False, 'expected ValueError'
@@ -97,7 +98,7 @@ def test_run_model_raises_when_arch_cannot_accept_calibration_config() -> None:
     def mock_arch(data: dict) -> dict:
         return {}
 
-    m = (Manifest()
+    m = (MLManifest()
          .with_reference_architecture(mock_arch)
          .with_calibration()
          .threshold_function(func=grid_threshold_optimizer)
@@ -117,7 +118,7 @@ def test_run_model_injects_resolved_prediction_calibration_config() -> None:
         received['config'] = prediction_calibration_config
         return {}
 
-    m = (Manifest()
+    m = (MLManifest()
          .with_reference_architecture(mock_arch)
          .with_calibration()
          .probability_calibration(func=sklearn_probability_calibrator, method='isotonic')
@@ -166,7 +167,7 @@ def test_run_model_no_injection_when_both_flags_false() -> None:
         received['config'] = prediction_calibration_config
         return {}
 
-    m = (Manifest()
+    m = (MLManifest()
          .with_reference_architecture(mock_arch)
          .with_calibration()
          .probability_calibration(func=sklearn_probability_calibrator)
@@ -185,7 +186,7 @@ def test_run_model_masks_calibration_func_when_use_calibration_false() -> None:
         received['config'] = prediction_calibration_config
         return {}
 
-    m = (Manifest()
+    m = (MLManifest()
          .with_reference_architecture(mock_arch)
          .with_calibration()
          .probability_calibration(func=sklearn_probability_calibrator)
@@ -206,7 +207,7 @@ def test_run_model_masks_threshold_func_when_use_threshold_false() -> None:
         received['config'] = prediction_calibration_config
         return {}
 
-    m = (Manifest()
+    m = (MLManifest()
          .with_reference_architecture(mock_arch)
          .with_calibration()
          .probability_calibration(func=sklearn_probability_calibrator)

--- a/tests/test_feature_perturbation.py
+++ b/tests/test_feature_perturbation.py
@@ -1,14 +1,14 @@
 import polars as pl
 
-from limen.experiment import Manifest
+from limen.experiment import MLManifest
 from limen.experiment.manifest_core import TransformEntry
 from limen.targets import RandomBinaryTarget
 from tests.utils.historical_data import get_cached_spot_klines_2h
 
 
-def _make_manifest_with_groups() -> Manifest:
+def _make_manifest_with_groups() -> MLManifest:
 
-    return (Manifest()
+    return (MLManifest()
         .set_test_data_source(
             method=get_cached_spot_klines_2h,
             params={'n_rows': 500}
@@ -30,9 +30,9 @@ def _make_manifest_with_groups() -> Manifest:
     )
 
 
-def _make_manifest_with_include_if() -> Manifest:
+def _make_manifest_with_include_if() -> MLManifest:
 
-    return (Manifest()
+    return (MLManifest()
         .set_test_data_source(
             method=get_cached_spot_klines_2h,
             params={'n_rows': 500}
@@ -56,7 +56,7 @@ def _prepare(manifest, round_params=None):
 
 def test_add_indicator_creates_transform_entry():
 
-    manifest = Manifest().add_indicator(lambda x: x, group='momentum', period=14)
+    manifest = MLManifest().add_indicator(lambda x: x, group='momentum', period=14)
     assert len(manifest.feature_transforms) == 1
     entry = manifest.feature_transforms[0]
     assert isinstance(entry, TransformEntry)
@@ -96,7 +96,7 @@ def test_feature_group_absent_includes_all():
 
 def test_ungrouped_features_always_included():
 
-    manifest = (Manifest()
+    manifest = (MLManifest()
         .set_test_data_source(
             method=get_cached_spot_klines_2h,
             params={'n_rows': 500}
@@ -119,7 +119,7 @@ def test_ungrouped_features_always_included():
 
 def test_combined_group_and_include_if():
 
-    manifest = (Manifest()
+    manifest = (MLManifest()
         .set_test_data_source(
             method=get_cached_spot_klines_2h,
             params={'n_rows': 500}

--- a/tests/test_fractional_diff.py
+++ b/tests/test_fractional_diff.py
@@ -1,7 +1,7 @@
 import numpy as np
 import polars as pl
 
-from limen.experiment import Manifest
+from limen.experiment import MLManifest
 from limen.features.fractional_diff import _get_weights_ffd
 from limen.features.fractional_diff import find_min_d
 from limen.features.fractional_diff import fractional_diff
@@ -163,7 +163,7 @@ def test_find_min_d_small_data_skips():
 
 def test_fractional_diff_manifest_integration():
 
-    manifest = (Manifest()
+    manifest = (MLManifest()
         .set_test_data_source(
             method=get_cached_spot_klines_2h,
             params={'n_rows': 500}

--- a/tests/test_manifest_pre_split_random_selector.py
+++ b/tests/test_manifest_pre_split_random_selector.py
@@ -1,7 +1,7 @@
 import polars as pl
 import numpy as np
 from datetime import datetime, timedelta
-from limen.experiment import Manifest
+from limen.experiment import MLManifest
 from limen.data.utils import random_slice
 from limen.targets import IdentityTarget
 
@@ -15,7 +15,7 @@ def test_pre_split_random_selector():
         'target': np.random.randn(1000)
     })
 
-    manifest = (Manifest()
+    manifest = (MLManifest()
         .set_pre_split_data_selector(
             random_slice,
             rows='random_slice_size',

--- a/tests/test_manifest_prepare_data.py
+++ b/tests/test_manifest_prepare_data.py
@@ -2,16 +2,16 @@ import numpy as np
 import polars as pl
 
 from limen.data import HistoricalData
-from limen.experiment import Manifest
+from limen.experiment import MLManifest
 from limen.sfd.foundational_sfd import logreg_binary as logreg_sfd
 from limen.targets import RandomBinaryTarget
 from limen.targets import ThresholdBinaryTarget
 from tests.utils.historical_data import get_cached_spot_klines_2h
 
 
-def _make_manifest() -> Manifest:
+def _make_manifest() -> MLManifest:
 
-    return (Manifest()
+    return (MLManifest()
         .set_data_source(
             method=HistoricalData.get_spot_klines,
             params={'kline_size': 3600, 'start_date_limit': '2025-01-01'}
@@ -29,16 +29,16 @@ def _make_manifest() -> Manifest:
     )
 
 
-def _prepare_data_with_manifest(manifest: Manifest) -> dict:
+def _prepare_data_with_manifest(manifest: MLManifest) -> dict:
 
     raw_data = manifest.fetch_test_data()
     round_params = {'bar_type': 'base'}
     return manifest.prepare_data(raw_data, round_params)
 
 
-def _make_shifted_target_manifest() -> Manifest:
+def _make_shifted_target_manifest() -> MLManifest:
 
-    return (Manifest()
+    return (MLManifest()
         .set_split_config(3, 1, 4)
         .add_indicator(lambda df: df.with_columns(
             (pl.col('close') - pl.col('open')).alias('close_minus_open')
@@ -214,7 +214,7 @@ def test_unknown_override_key_raises() -> None:
 
 def test_split_validation_rejects_invalid() -> None:
 
-    manifest = Manifest()
+    manifest = MLManifest()
     try:
         manifest.set_split_config(0, 1, 1)
         assert False, 'Expected ValueError'
@@ -236,7 +236,7 @@ def test_column_consistency_drops_mismatched_columns() -> None:
             return data.with_columns(pl.lit(1.0).alias('big_split_col'))
         return data
 
-    manifest = (Manifest()
+    manifest = (MLManifest()
         .set_test_data_source(
             method=get_cached_spot_klines_2h,
             params={'n_rows': 5000}

--- a/tests/test_manifest_rule_based.py
+++ b/tests/test_manifest_rule_based.py
@@ -1,6 +1,6 @@
 import polars as pl
 
-from limen.experiment import Manifest
+from limen.experiment import RuleBasedManifest
 
 
 def _make_raw_data() -> pl.DataFrame:
@@ -26,17 +26,17 @@ _CONDITIONS = [
 
 
 def test_with_strategy_sets_sentinel_and_returns_self() -> None:
-    m = Manifest()
+    m = RuleBasedManifest()
     result = m.with_strategy(_CONDITIONS, entry='entry_signal')
 
     assert result is m
-    assert m._rule_based is not None
-    assert m._rule_based.entry == 'entry_signal'
-    assert m._rule_based.conditions == _CONDITIONS
+    assert m.strategy is not None
+    assert m.strategy.entry == 'entry_signal'
+    assert m.strategy.conditions == _CONDITIONS
 
 
 def test_prepare_data_rule_based_returns_split_dataframes() -> None:
-    m = Manifest().with_strategy(_CONDITIONS, entry='entry_signal')
+    m = RuleBasedManifest().with_strategy(_CONDITIONS, entry='entry_signal')
     data = m.prepare_data(_make_raw_data(), {})
 
     assert set(data.keys()) >= {'train', 'val', 'test', '_alignment', 'strategy'}
@@ -46,7 +46,7 @@ def test_prepare_data_rule_based_returns_split_dataframes() -> None:
 
 
 def test_prepare_data_rule_based_adds_predicate_columns() -> None:
-    m = Manifest().with_strategy(_CONDITIONS, entry='entry_signal')
+    m = RuleBasedManifest().with_strategy(_CONDITIONS, entry='entry_signal')
     data = m.prepare_data(_make_raw_data(), {})
 
     for split in ('train', 'val', 'test'):
@@ -56,7 +56,7 @@ def test_prepare_data_rule_based_adds_predicate_columns() -> None:
 
 
 def test_prepare_data_rule_based_attaches_strategy_config() -> None:
-    m = Manifest().with_strategy(_CONDITIONS, entry='entry_signal')
+    m = RuleBasedManifest().with_strategy(_CONDITIONS, entry='entry_signal')
     data = m.prepare_data(_make_raw_data(), {})
 
     assert data['strategy']['entry'] == 'entry_signal'
@@ -64,7 +64,7 @@ def test_prepare_data_rule_based_attaches_strategy_config() -> None:
 
 
 def test_prepare_data_rule_based_compound_condition_not_added_as_column() -> None:
-    m = Manifest().with_strategy(_CONDITIONS, entry='entry_signal')
+    m = RuleBasedManifest().with_strategy(_CONDITIONS, entry='entry_signal')
     data = m.prepare_data(_make_raw_data(), {})
 
     for split in ('train', 'val', 'test'):
@@ -72,24 +72,14 @@ def test_prepare_data_rule_based_compound_condition_not_added_as_column() -> Non
 
 
 def test_prepare_data_rule_based_rejects_scaler() -> None:
-    from limen.scalers.robust_scaler import RobustScaler
-    m = Manifest().with_strategy(_CONDITIONS, entry='entry_signal').set_scaler(RobustScaler)
-    try:
-        m.prepare_data(_make_raw_data(), {})
-        assert False, 'Expected ValueError'
-    except ValueError as e:
-        assert 'Scalers cannot be used' in str(e)
+    m = RuleBasedManifest()
+    assert not hasattr(m, 'set_scaler'), 'RuleBasedManifest must not expose set_scaler'
+    assert not hasattr(m, 'set_scaler_from_params'), 'RuleBasedManifest must not expose set_scaler_from_params'
 
 
 def test_prepare_data_rule_based_rejects_ablation() -> None:
-    m = (Manifest()
-         .with_strategy(_CONDITIONS, entry='entry_signal')
-         .set_feature_ablation(drop_count_key='drop_n', seed_key='seed'))
-    try:
-        m.prepare_data(_make_raw_data(), {})
-        assert False, 'Expected ValueError'
-    except ValueError as e:
-        assert 'Feature ablation cannot be used' in str(e)
+    m = RuleBasedManifest()
+    assert not hasattr(m, 'set_feature_ablation'), 'RuleBasedManifest must not expose set_feature_ablation'
 
 
 def test_prepare_data_rule_based_rejects_condition_id_colliding_with_column() -> None:
@@ -97,7 +87,7 @@ def test_prepare_data_rule_based_rejects_condition_id_colliding_with_column() ->
         {'id': 'rsi_14', 'type': 'threshold', 'column': 'rsi_14', 'operator': '<', 'value': 30},
         {'id': 'entry_signal', 'operator': 'and', 'operands': ['rsi_14']},
     ]
-    m = Manifest().with_strategy(colliding_conditions, entry='entry_signal')
+    m = RuleBasedManifest().with_strategy(colliding_conditions, entry='entry_signal')
     try:
         m.prepare_data(_make_raw_data(), {})
         assert False, 'Expected ValueError for column name collision'

--- a/tests/test_scalers.py
+++ b/tests/test_scalers.py
@@ -1,7 +1,7 @@
 import polars as pl
 import numpy as np
 
-from limen.experiment import Manifest
+from limen.experiment import MLManifest
 from limen.scalers.rank_gauss_scaler import RankGaussScaler
 from limen.scalers.registry import SCALER_REGISTRY
 from limen.scalers.robust_scaler import RobustScaler
@@ -144,9 +144,9 @@ def test_robust_scaler_all_null_column():
     assert 'normal' in scaler.medians
 
 
-def _make_manifest_with_scaler_from_params() -> Manifest:
+def _make_manifest_with_scaler_from_params() -> MLManifest:
 
-    return (Manifest()
+    return (MLManifest()
         .set_test_data_source(
             method=get_cached_spot_klines_2h,
             params={'n_rows': 500}


### PR DESCRIPTION
**NOTE:** The author must always **first review the PR themselves**, before requesting review from others, that means carefully having reviewed the full diff in GitHub.

## What does this PR change?

 Split the manifest class into a shared base with separate ML and rule-based subclasses; all foundational SFDs retain the same uniform interface

closes #381

## Checklist

- [x] I have reviewed full diff in “Files changed”
- [x] I left no unnecessary files in the changes
- [x] I ran `python tests/run.py` locally without errors (where applicable)
- [x] I updated `/docs` (if behavior/API/config/user/etc changed)
- [x] I added and/or updated docstrings as per [Writing Docstrings](https://github.com/Vaquum/Limen/blob/main/docs/Developer/Writing-Docstrings.md) (for any changed public functions/classes)
- [x] I updated CHANGELOG.md (unless only docs or other non-code aspect was changed)
- [x] I updated pyproject.toml (unless only docs or other non-code aspect was changed)
- [x] I added and/or updated tests (if behavior changed or new code paths added)
- [x] I validated changes manually
- [x] I validated changes with LLM
- [x] I removed any extraneous examples/comments
- [x] I linked issue to auto-close on merge (e.g., “Fixes #123”) when applicable
