### PR TITLE
fix: register experiment-local SFD module in sys.modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -847,5 +847,6 @@ Note: add all new changelog entries to the bottom of this file.
 
 ## v3.0.5 on 7th of May, 2026
 
-- `Trainer._load_sfd_module` now registers the experiment-local SFD module in `sys.modules` under its bare name so downstream `importlib.import_module(name)` lookups (notably `_resolve_model_class` re-importing `architecture_function.__module__`) resolve to the same module instance; the registration is rolled back if `exec_module` raises so a partially-initialised module is never visible
-- Fix self-contained bundles (e.g. `trainer_prep.py`-produced `BtcLogRegEVSFD`-style experiment_dirs whose architecture function is defined inside the SFD file) failing sensor wiring with `ModuleNotFoundError`
+- `Trainer._load_sfd_module` registers the experiment-local SFD module in `sys.modules` so `_resolve_model_class`'s `importlib.import_module(architecture_function.__module__)` resolves to the same instance
+- Save-and-restore semantics on `exec_module` failure: any prior `sys.modules` entry under the same name is preserved
+- Fixes self-contained bundles (architecture function defined inside the SFD file) failing sensor wiring with `ModuleNotFoundError`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -844,3 +844,8 @@ Note: add all new changelog entries to the bottom of this file.
 
 - Split the manifest class into a shared base with separate ML and rule-based subclasses; all foundational SFDs retain the same uniform interface
 - `Manifest.prepare_data()` now raises `NotImplementedError` — replace any direct `Manifest()` usage for data preparation with `MLManifest()` (ML pipelines) or `RuleBasedManifest()` (rule-based pipelines)
+
+## v3.0.5 on 7th of May, 2026
+
+- `Trainer._load_sfd_module` now registers the experiment-local SFD module in `sys.modules` under its bare name so downstream `importlib.import_module(name)` lookups (notably `_resolve_model_class` re-importing `architecture_function.__module__`) resolve to the same module instance; the registration is rolled back if `exec_module` raises so a partially-initialised module is never visible
+- Fix self-contained bundles (e.g. `trainer_prep.py`-produced `BtcLogRegEVSFD`-style experiment_dirs whose architecture function is defined inside the SFD file) failing sensor wiring with `ModuleNotFoundError`

--- a/limen/experiment/trainer/trainer.py
+++ b/limen/experiment/trainer/trainer.py
@@ -3,6 +3,7 @@ import importlib.util
 import inspect
 import json
 import logging
+import sys
 from pathlib import Path
 from types import ModuleType
 from typing import Any
@@ -111,6 +112,21 @@ class Trainer:
         when no such file exists (built-in SFDs referenced by fully
         qualified package path).
 
+        After loading via the experiment-local branch the resulting
+        module is registered in `sys.modules` under `sfd_module_name`
+        before `exec_module` runs. This allows downstream code that
+        resolves the SFD's classes/functions by name — most notably
+        `Trainer._resolve_model_class`, which re-imports the
+        architecture function's module via
+        `importlib.import_module(architecture_function.__module__)` —
+        to see the same module instance loaded here. Without the
+        registration, a self-contained bundle whose architecture
+        function is defined in the SFD file itself fails sensor
+        wiring with `ModuleNotFoundError` at the
+        `_resolve_model_class` call. If `exec_module` raises, the
+        registration is rolled back so a partially-initialised
+        module is never visible to other code.
+
         Rejects any name whose dot-separated segments are not valid
         Python identifiers, so `..`, `/`, `\\`, leading/trailing dots
         and empty segments cannot escape `experiment_dir` via the
@@ -153,7 +169,12 @@ class Trainer:
                     f"Cannot create import spec for SFD file {sfd_path}"
                 )
             module = importlib.util.module_from_spec(spec)
-            spec.loader.exec_module(module)
+            sys.modules[sfd_module_name] = module
+            try:
+                spec.loader.exec_module(module)
+            except BaseException:
+                sys.modules.pop(sfd_module_name, None)
+                raise
             return module
         return importlib.import_module(sfd_module_name)
 

--- a/limen/experiment/trainer/trainer.py
+++ b/limen/experiment/trainer/trainer.py
@@ -123,9 +123,12 @@ class Trainer:
         registration, a self-contained bundle whose architecture
         function is defined in the SFD file itself fails sensor
         wiring with `ModuleNotFoundError` at the
-        `_resolve_model_class` call. If `exec_module` raises, the
-        registration is rolled back so a partially-initialised
-        module is never visible to other code.
+        `_resolve_model_class` call. If `exec_module` raises, any
+        prior `sys.modules` entry under that name is restored (or
+        the key removed if there was no prior entry) so a partially
+        initialised module is never visible to other code and an
+        unrelated module that happened to share the name is not
+        clobbered.
 
         Rejects any name whose dot-separated segments are not valid
         Python identifiers, so `..`, `/`, `\\`, leading/trailing dots
@@ -169,11 +172,15 @@ class Trainer:
                     f"Cannot create import spec for SFD file {sfd_path}"
                 )
             module = importlib.util.module_from_spec(spec)
+            previous = sys.modules.get(sfd_module_name)
             sys.modules[sfd_module_name] = module
             try:
                 spec.loader.exec_module(module)
             except BaseException:
-                sys.modules.pop(sfd_module_name, None)
+                if previous is None:
+                    sys.modules.pop(sfd_module_name, None)
+                else:
+                    sys.modules[sfd_module_name] = previous
                 raise
             return module
         return importlib.import_module(sfd_module_name)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaquum_limen"
-version = "3.0.4"
+version = "3.0.5"
 description = "Bitcoin-first research and trading platform."
 readme = "README.md"
 authors = [

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -521,7 +521,7 @@ def test_trainer_loads_sfd_from_experiment_dir_without_sys_path_mutation() -> No
 
     sys_path_before = list(sys.path)
     sfd_module_name = 'isolated_sfd_for_trainer_test'
-    sys.modules.pop(sfd_module_name, None)
+    previous = sys.modules.pop(sfd_module_name, None)
 
     try:
         with TemporaryDirectory() as tmpdir:
@@ -547,7 +547,10 @@ def test_trainer_loads_sfd_from_experiment_dir_without_sys_path_mutation() -> No
             assert registered is not None
             assert importlib.import_module(sfd_module_name) is registered
     finally:
-        sys.modules.pop(sfd_module_name, None)
+        if previous is None:
+            sys.modules.pop(sfd_module_name, None)
+        else:
+            sys.modules[sfd_module_name] = previous
 
     assert sys.path == sys_path_before
 
@@ -556,11 +559,12 @@ def test_trainer_load_sfd_rolls_back_sys_modules_on_exec_failure() -> None:
 
     '''
     If the SFD module raises during exec_module, the partially
-    initialised module must not remain in sys.modules.
+    initialised module must not remain in sys.modules and any
+    previous entry under the same name must be restored.
     '''
 
     sfd_module_name = 'broken_sfd_for_trainer_test'
-    sys.modules.pop(sfd_module_name, None)
+    previous = sys.modules.pop(sfd_module_name, None)
 
     try:
         with TemporaryDirectory() as tmpdir:
@@ -582,7 +586,50 @@ def test_trainer_load_sfd_rolls_back_sys_modules_on_exec_failure() -> None:
 
             assert sfd_module_name not in sys.modules
     finally:
-        sys.modules.pop(sfd_module_name, None)
+        if previous is None:
+            sys.modules.pop(sfd_module_name, None)
+        else:
+            sys.modules[sfd_module_name] = previous
+
+
+def test_trainer_load_sfd_restores_previous_sys_modules_entry_on_exec_failure() -> None:
+
+    '''
+    If a different module was already registered under
+    `sfd_module_name`, an `exec_module` failure must restore that
+    prior entry instead of leaving the slot empty.
+    '''
+
+    sfd_module_name = 'preexisting_sfd_for_trainer_test'
+    sentinel = types.ModuleType(sfd_module_name)
+    sentinel.__limen_test_sentinel__ = True
+    saved = sys.modules.get(sfd_module_name)
+    sys.modules[sfd_module_name] = sentinel
+
+    try:
+        with TemporaryDirectory() as tmpdir:
+            experiment_dir = Path(tmpdir)
+
+            (experiment_dir / f'{sfd_module_name}.py').write_text(
+                'raise RuntimeError("intentional sfd boom")\n',
+            )
+            (experiment_dir / 'metadata.json').write_text(
+                json.dumps({'sfd_module': sfd_module_name}),
+            )
+            (experiment_dir / 'round_data.jsonl').write_text('')
+
+            with pytest.raises(RuntimeError, match='intentional sfd boom'):
+                Trainer(
+                    experiment_dir,
+                    data=pl.DataFrame({'x': [1, 2, 3]}),
+                )
+
+            assert sys.modules.get(sfd_module_name) is sentinel
+    finally:
+        if saved is None:
+            sys.modules.pop(sfd_module_name, None)
+        else:
+            sys.modules[sfd_module_name] = saved
 
 
 def test_trainer_falls_back_to_import_module_when_no_local_sfd_file() -> None:

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -1,3 +1,4 @@
+import importlib
 import json
 import sys
 from pathlib import Path
@@ -512,33 +513,76 @@ def test_trainer_loads_sfd_from_experiment_dir_without_sys_path_mutation() -> No
     Pin the self-contained-experiment contract: Trainer(experiment_dir)
     must succeed when the SFD .py lives inside experiment_dir and is
     referenced by bare module name in metadata.json, even though that
-    name is not on sys.path.
+    name is not on sys.path. The loaded module must be registered in
+    sys.modules under the bare name so downstream
+    importlib.import_module(name) lookups (e.g. _resolve_model_class)
+    resolve to the same module instance.
     '''
 
     sys_path_before = list(sys.path)
+    sfd_module_name = 'isolated_sfd_for_trainer_test'
+    sys.modules.pop(sfd_module_name, None)
 
-    with TemporaryDirectory() as tmpdir:
-        experiment_dir = Path(tmpdir)
-        sfd_module_name = 'isolated_sfd_for_trainer_test'
+    try:
+        with TemporaryDirectory() as tmpdir:
+            experiment_dir = Path(tmpdir)
 
-        (experiment_dir / f'{sfd_module_name}.py').write_text(
-            _SELF_CONTAINED_SFD_SOURCE,
-        )
-        (experiment_dir / 'metadata.json').write_text(
-            json.dumps({'sfd_module': sfd_module_name}),
-        )
-        (experiment_dir / 'round_data.jsonl').write_text('')
+            (experiment_dir / f'{sfd_module_name}.py').write_text(
+                _SELF_CONTAINED_SFD_SOURCE,
+            )
+            (experiment_dir / 'metadata.json').write_text(
+                json.dumps({'sfd_module': sfd_module_name}),
+            )
+            (experiment_dir / 'round_data.jsonl').write_text('')
 
-        trainer = Trainer(
-            experiment_dir,
-            data=pl.DataFrame({'x': [1, 2, 3]}),
-        )
+            trainer = Trainer(
+                experiment_dir,
+                data=pl.DataFrame({'x': [1, 2, 3]}),
+            )
 
-        assert trainer._param_keys == frozenset({'alpha'})
-        assert trainer._manifest.architecture_function is None
+            assert trainer._param_keys == frozenset({'alpha'})
+            assert trainer._manifest.architecture_function is None
+
+            registered = sys.modules.get(sfd_module_name)
+            assert registered is not None
+            assert importlib.import_module(sfd_module_name) is registered
+    finally:
+        sys.modules.pop(sfd_module_name, None)
 
     assert sys.path == sys_path_before
-    assert sfd_module_name not in sys.modules
+
+
+def test_trainer_load_sfd_rolls_back_sys_modules_on_exec_failure() -> None:
+
+    '''
+    If the SFD module raises during exec_module, the partially
+    initialised module must not remain in sys.modules.
+    '''
+
+    sfd_module_name = 'broken_sfd_for_trainer_test'
+    sys.modules.pop(sfd_module_name, None)
+
+    try:
+        with TemporaryDirectory() as tmpdir:
+            experiment_dir = Path(tmpdir)
+
+            (experiment_dir / f'{sfd_module_name}.py').write_text(
+                'raise RuntimeError("intentional sfd boom")\n',
+            )
+            (experiment_dir / 'metadata.json').write_text(
+                json.dumps({'sfd_module': sfd_module_name}),
+            )
+            (experiment_dir / 'round_data.jsonl').write_text('')
+
+            with pytest.raises(RuntimeError, match='intentional sfd boom'):
+                Trainer(
+                    experiment_dir,
+                    data=pl.DataFrame({'x': [1, 2, 3]}),
+                )
+
+            assert sfd_module_name not in sys.modules
+    finally:
+        sys.modules.pop(sfd_module_name, None)
 
 
 def test_trainer_falls_back_to_import_module_when_no_local_sfd_file() -> None:

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -555,7 +555,7 @@ def test_trainer_loads_sfd_from_experiment_dir_without_sys_path_mutation() -> No
     assert sys.path == sys_path_before
 
 
-def test_trainer_load_sfd_rolls_back_sys_modules_on_exec_failure() -> None:
+def test_trainer_loads_sfd_rolls_back_sys_modules_on_exec_failure() -> None:
 
     '''
     If the SFD module raises during exec_module, the partially
@@ -592,7 +592,7 @@ def test_trainer_load_sfd_rolls_back_sys_modules_on_exec_failure() -> None:
             sys.modules[sfd_module_name] = previous
 
 
-def test_trainer_load_sfd_restores_previous_sys_modules_entry_on_exec_failure() -> None:
+def test_trainer_loads_sfd_restores_previous_sys_modules_entry_on_exec_failure() -> None:
 
     '''
     If a different module was already registered under


### PR DESCRIPTION
**NOTE:** The author must always **first review the PR themselves**, before requesting review from others, that means carefully having reviewed the full diff in GitHub.

## What does this PR change?

`Trainer._load_sfd_module` (added in v3.0.3) loads the experiment-local SFD module via `importlib.util.spec_from_file_location` + `module_from_spec` but did not register the resulting module in `sys.modules`. Downstream code that resolves the SFD's classes/functions by name — most notably `Trainer._resolve_model_class`, which re-imports the architecture function's module via `importlib.import_module(architecture_function.__module__)` — could not find that module and raised `ModuleNotFoundError` at sensor-wiring time. This breaks the entire self-contained-bundle deploy path: a `trainer_prep.py`-produced bundle whose architecture function is defined inside the SFD file (e.g. `BtcLogRegEVSFD__r0001.py`) gets past `Trainer.__init__` but blows up at `train()` → `_resolve_model_class()`.

The fix registers the loaded module in `sys.modules[sfd_module_name]` before `exec_module` runs, with rollback if `exec_module` raises so a partially-initialised module is never visible to other code:

```python
module = importlib.util.module_from_spec(spec)
sys.modules[sfd_module_name] = module
try:
    spec.loader.exec_module(module)
except BaseException:
    sys.modules.pop(sfd_module_name, None)
    raise
return module
```

The fallback `importlib.import_module(...)` branch (legacy fully-qualified package paths) was already populating `sys.modules` correctly, so both branches now leave the module registered consistently.

Tests: the existing `test_trainer_loads_sfd_from_experiment_dir_without_sys_path_mutation` was updated — it previously asserted `sfd_module_name not in sys.modules` (pinning the broken behavior), now asserts the module IS registered and that `importlib.import_module(name)` returns the same instance. New `test_trainer_load_sfd_rolls_back_sys_modules_on_exec_failure` covers the rollback path: an SFD file whose top-level raises a `RuntimeError` propagates the error and leaves no `sys.modules` entry. Both tests pop the module name in `finally` so the test runs are hermetic.

## Checklist

- [x] I have reviewed full diff in "Files changed"
- [x] I left no unnecessary files in the changes
- [x] I ran `python -m pytest` locally without errors (51 passing)
- [ ] I updated `/docs` (if behavior/API/config/user/etc changed)
- [x] I added and/or updated docstrings as per [Writing Docstrings](https://github.com/Vaquum/dev-docs/blob/main/src/Writing-Docstrings.md) (for any changed public functions/classes)
- [x] I updated CHANGELOG.md
- [x] I updated pyproject.toml
- [x] I added and/or updated tests (if behavior changed or new code paths added)
- [x] I validated changes manually
- [x] I validated changes with LLM
- [x] I removed any extraneous examples/comments
- [ ] I linked issue to auto-close on merge (e.g., "Fixes #123456") when applicable