### PR TITLE
feat: add canonical decoder outcome targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -879,3 +879,10 @@ Note: add all new changelog entries to the bottom of this file.
 - Update `docs/Features.md` to drop the moved `ema_breakout` row and `docs/Targets.md` to document `EmaBreakoutTarget`, `ExitQualityTarget`, `RiskRewardRatioTarget`
 - Raise `tests/runtime_budget.json` ceiling from 180s to 195s to accommodate the small per-test overhead introduced by the added `when/then/EPSILON` guards across the indicator/feature surface
 - `ExitQualityTarget` and `RiskRewardRatioTarget` drop their forward-looking source columns (`exit_reason`, `exit_net_return` and `capturable_breakout`, `max_drawdown` respectively) after computing the target so they cannot re-enter `x_train`/`x_val`/`x_test` via the manifest's all-columns-except-target convention
+
+## v3.1.1 on 17th of May, 2026
+
+- Add canonical decoder outcome targets `NextBarUpTarget`, `NextBarDownTarget`, and `VolNormalizedReturnTarget`
+- Add Parkinson-volatility normalized return labeling with prior-bar sigma shift, dirty OHLC row filtering, zero-volatility nulling, and train-split Parkinson-to-close volatility sanity gate
+- Document the downstream-only bucketing contract for `vol_normalized_return`: fit train `q33`/`q66` of `abs(z)`, persist boundaries, and never refit online
+- Export the canonical outcome targets from `limen.targets` and add direct plus manifest-path regression coverage

--- a/docs/Targets.md
+++ b/docs/Targets.md
@@ -39,7 +39,10 @@ manifest.with_target_label(
 | `ThresholdBinaryTarget` | binary `UInt8` | no | `shift=-1` | Positive label above a fixed numeric threshold. |
 | `ForwardBreakoutTarget` | binary `UInt8` | no | `shift=-1` | Positive label if price rises at least `threshold` over the next `forward_periods` bars. |
 | `EmaBreakoutTarget` | binary `UInt8` | no | n/a | Positive label if price `breakout_horizon` bars ahead exceeds EMA by `breakout_delta`. |
+| `NextBarUpTarget` | binary `UInt8` | no | none | Canonical up decoder outcome: positive label if the next close is higher. |
+| `NextBarDownTarget` | binary `UInt8` | no | none | Canonical down decoder outcome: positive label if the next close is lower. |
 | `NextReturnTarget` | continuous `Float64` | no | n/a | Percentage return over the next N bars. Use with regression architectures. |
+| `VolNormalizedReturnTarget` | continuous `Float64` | yes — train sanity gate | none | Canonical return decoder outcome: log return divided by prior Parkinson volatility. |
 | `RiskRewardRatioTarget` | continuous `Float64` | no | n/a | Ratio of `capturable_breakout` to absolute `max_drawdown` per row. |
 | `ExitQualityTarget` | continuous `Float64` | no | n/a | Categorical score for closed trades based on `exit_reason` and `exit_net_return`. |
 | `RandomBinaryTarget` | binary `UInt8` | no | none | Uniformly random labels. Use as a noise benchmark. |
@@ -158,6 +161,63 @@ Produces a continuous target as the percentage return over the next N bars. Use 
 |---|---|---|
 | `periods` | `int` | Look-ahead window in bars; default `1` |
 | `scale` | `float` | Multiplier applied to the raw return; default `100.0` |
+
+### `NextBarUpTarget`
+
+```python
+NextBarUpTarget(train_data, target_name)
+```
+
+Produces a binary target named `next_bar_up`: `1` when the next close is higher than the current close, `0` otherwise. The final row in each split has no next bar, so it is null and is dropped by manifest preparation.
+
+```python
+.with_target_label('next_bar_up', NextBarUpTarget)
+```
+
+No parameters.
+
+### `NextBarDownTarget`
+
+```python
+NextBarDownTarget(train_data, target_name)
+```
+
+Produces a binary target named `next_bar_down`: `1` when the next close is lower than the current close, `0` otherwise. The final row in each split has no next bar, so it is null and is dropped by manifest preparation.
+
+```python
+.with_target_label('next_bar_down', NextBarDownTarget)
+```
+
+No parameters.
+
+### `VolNormalizedReturnTarget`
+
+```python
+VolNormalizedReturnTarget(train_data, target_name, high_col='high', low_col='low', open_col='open', close_col='close', halflife=50, min_periods=150)
+```
+
+Produces a continuous target named `vol_normalized_return`. The target is `log(close / close.shift(1)) / sigma.shift(1)`, where `sigma` is the EWMA Parkinson volatility from `(log(high / low) ** 2) / (4 * ln(2))`. The one-bar sigma shift prevents the current bar range from entering the current return label.
+
+Dirty OHLC rows are dropped before target construction when `high < max(open, close)` or `low > min(open, close)`. Zero volatility is converted to null, not epsilon.
+
+```python
+.with_target_label(
+    'vol_normalized_return',
+    VolNormalizedReturnTarget,
+    fit_params={'halflife': 50, 'min_periods': 150},
+)
+```
+
+| Parameter | Type | Description |
+|---|---|---|
+| `high_col` | `str` | High price column; default `'high'` |
+| `low_col` | `str` | Low price column; default `'low'` |
+| `open_col` | `str` | Open price column used for dirty-bar filtering; default `'open'` |
+| `close_col` | `str` | Close price column; default `'close'` |
+| `halflife` | `int` | EWMA half-life in bars; default `50` |
+| `min_periods` | `int` | Warmup before volatility is emitted; default `150` |
+
+The training split must pass the Parkinson-to-close volatility sanity gate: median `sigma_P / sigma_C2C` must be within `[0.9, 1.1]`. Bucketing is deliberately downstream: fit `q33`/`q66` of `abs(vol_normalized_return)` on train, persist the boundaries, and load them at inference instead of refitting online.
 
 ### `RiskRewardRatioTarget`
 

--- a/limen/targets/__init__.py
+++ b/limen/targets/__init__.py
@@ -2,20 +2,26 @@ from limen.targets.ema_breakout import EmaBreakoutTarget
 from limen.targets.exit_quality import ExitQualityTarget
 from limen.targets.forward_breakout import ForwardBreakoutTarget
 from limen.targets.identity import IdentityTarget
+from limen.targets.next_bar_down import NextBarDownTarget
+from limen.targets.next_bar_up import NextBarUpTarget
 from limen.targets.next_return import NextReturnTarget
 from limen.targets.quantile_binary import QuantileBinaryTarget
 from limen.targets.random_binary import RandomBinaryTarget
 from limen.targets.risk_reward_ratio import RiskRewardRatioTarget
 from limen.targets.threshold_binary import ThresholdBinaryTarget
+from limen.targets.vol_normalized_return import VolNormalizedReturnTarget
 
 __all__ = [
     'EmaBreakoutTarget',
     'ExitQualityTarget',
     'ForwardBreakoutTarget',
     'IdentityTarget',
+    'NextBarDownTarget',
+    'NextBarUpTarget',
     'NextReturnTarget',
     'QuantileBinaryTarget',
     'RandomBinaryTarget',
     'RiskRewardRatioTarget',
     'ThresholdBinaryTarget',
+    'VolNormalizedReturnTarget',
 ]

--- a/limen/targets/next_bar_down.py
+++ b/limen/targets/next_bar_down.py
@@ -1,0 +1,36 @@
+import polars as pl
+
+
+class NextBarDownTarget:
+
+    '''Binary target for whether the next close is below the current close.'''
+
+    def __init__(self, train_data: pl.DataFrame, target_name: str) -> None:
+
+        '''
+        Store the target column name; no fitting is performed.
+
+        Args:
+            train_data (pl.DataFrame): Training split (not used; kept for interface consistency)
+            target_name (str): Name of the target column to create
+        '''
+
+        self.target_name = target_name
+
+    def transform(self, data: pl.DataFrame) -> pl.DataFrame:
+
+        '''
+        Label 1 if the next close is lower than the current close.
+
+        Args:
+            data (pl.DataFrame): Split to transform (must have 'close' column)
+
+        Returns:
+            pl.DataFrame: Data with target column added
+        '''
+
+        return data.with_columns(
+            (pl.col('close').shift(-1) < pl.col('close'))
+                .cast(pl.UInt8)
+                .alias(self.target_name)
+        )

--- a/limen/targets/next_bar_up.py
+++ b/limen/targets/next_bar_up.py
@@ -1,0 +1,36 @@
+import polars as pl
+
+
+class NextBarUpTarget:
+
+    '''Binary target for whether the next close is above the current close.'''
+
+    def __init__(self, train_data: pl.DataFrame, target_name: str) -> None:
+
+        '''
+        Store the target column name; no fitting is performed.
+
+        Args:
+            train_data (pl.DataFrame): Training split (not used; kept for interface consistency)
+            target_name (str): Name of the target column to create
+        '''
+
+        self.target_name = target_name
+
+    def transform(self, data: pl.DataFrame) -> pl.DataFrame:
+
+        '''
+        Label 1 if the next close is higher than the current close.
+
+        Args:
+            data (pl.DataFrame): Split to transform (must have 'close' column)
+
+        Returns:
+            pl.DataFrame: Data with target column added
+        '''
+
+        return data.with_columns(
+            (pl.col('close').shift(-1) > pl.col('close'))
+                .cast(pl.UInt8)
+                .alias(self.target_name)
+        )

--- a/limen/targets/vol_normalized_return.py
+++ b/limen/targets/vol_normalized_return.py
@@ -1,0 +1,168 @@
+import math
+
+import polars as pl
+
+
+PARKINSON_SCALE = 4.0 * math.log(2.0)
+SIGMA_RATIO_MIN = 0.9
+SIGMA_RATIO_MAX = 1.1
+
+
+class VolNormalizedReturnTarget:
+
+    '''Continuous target as log return normalized by prior Parkinson volatility.'''
+
+    def __init__(self,
+                 train_data: pl.DataFrame,
+                 target_name: str,
+                 high_col: str = 'high',
+                 low_col: str = 'low',
+                 open_col: str = 'open',
+                 close_col: str = 'close',
+                 halflife: int = 50,
+                 min_periods: int = 150) -> None:
+
+        '''
+        Store target settings and validate Parkinson against close-to-close volatility on train.
+
+        Args:
+            train_data (pl.DataFrame): Training split used for the volatility sanity gate
+            target_name (str): Name of the target column to create
+            high_col (str): High price column
+            low_col (str): Low price column
+            open_col (str): Open price column used for dirty-bar filtering
+            close_col (str): Close price column
+            halflife (int): EWMA half-life in bars
+            min_periods (int): Warmup before volatility values are emitted
+        '''
+
+        if halflife <= 0:
+            raise ValueError('halflife must be positive')
+        if min_periods <= 0:
+            raise ValueError('min_periods must be positive')
+
+        self.target_name = target_name
+        self.high_col = high_col
+        self.low_col = low_col
+        self.open_col = open_col
+        self.close_col = close_col
+        self.halflife = halflife
+        self.min_periods = min_periods
+
+        train = self._clean_bars(train_data)
+        median_ratio = self._median_parkinson_to_close_sigma_ratio(train)
+        if median_ratio is not None and not (SIGMA_RATIO_MIN <= median_ratio <= SIGMA_RATIO_MAX):
+            raise ValueError(
+                'median Parkinson-to-close volatility ratio '
+                f'{median_ratio:.6f} is outside [{SIGMA_RATIO_MIN}, {SIGMA_RATIO_MAX}]'
+            )
+
+    def transform(self, data: pl.DataFrame) -> pl.DataFrame:
+
+        '''
+        Compute `log(close / close.shift(1)) / parkinson_sigma.shift(1)`.
+
+        Args:
+            data (pl.DataFrame): Split to transform; must have open/high/low/close columns
+
+        Returns:
+            pl.DataFrame: Cleaned data with target column added
+        '''
+
+        return self._with_target(self._clean_bars(data))
+
+    def _clean_bars(self, data: pl.DataFrame) -> pl.DataFrame:
+        self._validate_columns(data)
+        return data.filter(
+            (pl.col(self.high_col) >= pl.max_horizontal(self.open_col, self.close_col))
+            & (pl.col(self.low_col) <= pl.min_horizontal(self.open_col, self.close_col))
+        )
+
+    def _validate_columns(self, data: pl.DataFrame) -> None:
+        required = {self.high_col, self.low_col, self.open_col, self.close_col}
+        missing = sorted(required - set(data.columns))
+        if missing:
+            raise ValueError(f"VolNormalizedReturnTarget missing columns: {missing}")
+
+    def _with_target(self, data: pl.DataFrame) -> pl.DataFrame:
+        temp_cols = [
+            '_limen_vnr_log_return',
+            '_limen_vnr_parkinson_variance',
+            '_limen_vnr_sigma',
+            '_limen_vnr_prior_sigma',
+        ]
+        return (
+            data
+            .with_columns(
+                [
+                    (pl.col(self.close_col).log() - pl.col(self.close_col).shift(1).log())
+                        .alias(temp_cols[0]),
+                    (((pl.col(self.high_col).log() - pl.col(self.low_col).log()) ** 2) / PARKINSON_SCALE)
+                        .alias(temp_cols[1]),
+                ]
+            )
+            .with_columns(
+                pl.col(temp_cols[1])
+                .ewm_mean(half_life=self.halflife, min_samples=self.min_periods)
+                .clip(lower_bound=0.0)
+                .sqrt()
+                .alias(temp_cols[2])
+            )
+            .with_columns(
+                pl.when(pl.col(temp_cols[2]) == 0.0)
+                .then(None)
+                .otherwise(pl.col(temp_cols[2]))
+                .shift(1)
+                .alias(temp_cols[3])
+            )
+            .with_columns((pl.col(temp_cols[0]) / pl.col(temp_cols[3])).alias(self.target_name))
+            .drop(temp_cols)
+        )
+
+    def _median_parkinson_to_close_sigma_ratio(self, data: pl.DataFrame) -> float | None:
+        if data.is_empty():
+            return None
+
+        stats = (
+            data
+            .with_columns(
+                [
+                    (((pl.col(self.high_col).log() - pl.col(self.low_col).log()) ** 2) / PARKINSON_SCALE)
+                        .alias('_limen_vnr_p_var'),
+                    ((pl.col(self.close_col).log() - pl.col(self.close_col).shift(1).log()) ** 2)
+                        .alias('_limen_vnr_c_var'),
+                ]
+            )
+            .with_columns(
+                [
+                    pl.col('_limen_vnr_p_var')
+                    .ewm_mean(half_life=self.halflife, min_samples=self.min_periods)
+                    .clip(lower_bound=0.0)
+                    .sqrt()
+                    .alias('_limen_vnr_p_sigma'),
+                    pl.col('_limen_vnr_c_var')
+                    .ewm_mean(half_life=self.halflife, min_samples=self.min_periods)
+                    .clip(lower_bound=0.0)
+                    .sqrt()
+                    .alias('_limen_vnr_c_sigma'),
+                ]
+            )
+            .with_columns(
+                pl.when(pl.col('_limen_vnr_c_sigma') == 0.0)
+                .then(None)
+                .otherwise(pl.col('_limen_vnr_p_sigma') / pl.col('_limen_vnr_c_sigma'))
+                .alias('_limen_vnr_sigma_ratio')
+            )
+        )
+
+        ratios = (
+            stats
+            .select('_limen_vnr_sigma_ratio')
+            .drop_nulls()
+            .to_series()
+            .to_list()
+        )
+        finite_ratios = [ratio for ratio in ratios if math.isfinite(ratio)]
+        if not finite_ratios:
+            return None
+        return float(pl.Series(finite_ratios).median())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaquum_limen"
-version = "3.1.0"
+version = "3.1.1"
 description = "Bitcoin-first research and trading platform."
 readme = "README.md"
 authors = [

--- a/tests/run.py
+++ b/tests/run.py
@@ -486,6 +486,13 @@ from tests.test_targets import test_threshold_binary_shift_applied
 from tests.test_targets import test_next_return_computes_percentage_return
 from tests.test_targets import test_next_return_respects_periods
 from tests.test_targets import test_next_return_respects_scale
+from tests.test_targets import test_next_bar_up_labels_next_close_above_current_close
+from tests.test_targets import test_next_bar_down_labels_next_close_below_current_close
+from tests.test_targets import test_vol_normalized_return_matches_unit_parkinson_ratio
+from tests.test_targets import test_vol_normalized_return_uses_prior_sigma_for_current_return
+from tests.test_targets import test_vol_normalized_return_drops_dirty_ohlc_bars
+from tests.test_targets import test_vol_normalized_return_rejects_bad_training_sigma_ratio
+from tests.test_targets import test_canonical_decoder_outcomes_run_through_manifest
 from tests.test_targets import test_with_target_label_sets_target_class_config
 from tests.test_targets import test_with_target_label_applies_transform_to_all_splits
 from tests.test_targets import test_with_target_label_fits_only_on_train
@@ -1072,6 +1079,13 @@ tests = [
     test_next_return_computes_percentage_return,
     test_next_return_respects_periods,
     test_next_return_respects_scale,
+    test_next_bar_up_labels_next_close_above_current_close,
+    test_next_bar_down_labels_next_close_below_current_close,
+    test_vol_normalized_return_matches_unit_parkinson_ratio,
+    test_vol_normalized_return_uses_prior_sigma_for_current_return,
+    test_vol_normalized_return_drops_dirty_ohlc_bars,
+    test_vol_normalized_return_rejects_bad_training_sigma_ratio,
+    test_canonical_decoder_outcomes_run_through_manifest,
     test_with_target_label_sets_target_class_config,
     test_with_target_label_applies_transform_to_all_splits,
     test_with_target_label_fits_only_on_train,

--- a/tests/test_targets.py
+++ b/tests/test_targets.py
@@ -1,16 +1,22 @@
+import math
+
 import polars as pl
 import pytest
 
+from limen.experiment import MLManifest
 from limen.experiment import Manifest
 from limen.targets import EmaBreakoutTarget
 from limen.targets import ExitQualityTarget
 from limen.targets import ForwardBreakoutTarget
 from limen.targets import IdentityTarget
+from limen.targets import NextBarDownTarget
+from limen.targets import NextBarUpTarget
 from limen.targets import NextReturnTarget
 from limen.targets import QuantileBinaryTarget
 from limen.targets import RandomBinaryTarget
 from limen.targets import RiskRewardRatioTarget
 from limen.targets import ThresholdBinaryTarget
+from limen.targets import VolNormalizedReturnTarget
 
 
 def _close_series(values: list[float]) -> pl.DataFrame:
@@ -19,6 +25,36 @@ def _close_series(values: list[float]) -> pl.DataFrame:
 
 def _roc_series(values: list[float]) -> pl.DataFrame:
     return pl.DataFrame({'roc_1': values})
+
+
+def _constant_vol_bars(n_rows: int = 8,
+                       log_return: float = 0.01,
+                       range_scale: float = 1.0) -> pl.DataFrame:
+    rows = []
+    price = 100.0
+    log_range = abs(log_return) * math.sqrt(4.0 * math.log(2.0)) * range_scale
+    for _ in range(n_rows):
+        open_price = price
+        close_price = open_price * math.exp(log_return)
+        rows.append({
+            'open': open_price,
+            'high': open_price * math.exp(log_range),
+            'low': open_price,
+            'close': close_price,
+        })
+        price = close_price
+    return pl.DataFrame(rows)
+
+
+def _with_hourly_datetime(data: pl.DataFrame) -> pl.DataFrame:
+    return data.with_columns(
+        pl.datetime_range(
+            start=pl.datetime(2025, 1, 1, 0, 0, 0),
+            end=pl.datetime(2025, 1, 1, data.height - 1, 0, 0),
+            interval='1h',
+            eager=True,
+        ).alias('datetime')
+    ).select(['datetime', *data.columns])
 
 
 def test_quantile_binary_fits_cutoff_on_train() -> None:
@@ -114,6 +150,92 @@ def test_next_return_respects_scale() -> None:
     result_pct = t.transform(data, periods=1, scale=100.0)
     result_raw = t.transform(data, periods=1, scale=1.0)
     assert abs(result_pct['ret'][0] - result_raw['ret'][0] * 100.0) < 1e-9
+
+
+def test_next_bar_up_labels_next_close_above_current_close() -> None:
+    data = _close_series([100.0, 101.0, 100.0, 100.0])
+    t = NextBarUpTarget(data, 'next_bar_up')
+    result = t.transform(data)
+    assert result['next_bar_up'].to_list() == [1, 0, 0, None]
+
+
+def test_next_bar_down_labels_next_close_below_current_close() -> None:
+    data = _close_series([100.0, 101.0, 100.0, 100.0])
+    t = NextBarDownTarget(data, 'next_bar_down')
+    result = t.transform(data)
+    assert result['next_bar_down'].to_list() == [0, 1, 0, None]
+
+
+def test_vol_normalized_return_matches_unit_parkinson_ratio() -> None:
+    data = _constant_vol_bars(n_rows=6, log_return=0.01)
+    t = VolNormalizedReturnTarget(data, 'vol_normalized_return', halflife=2, min_periods=2)
+    result = t.transform(data)
+
+    assert result['vol_normalized_return'].to_list()[:2] == [None, None]
+    assert result['vol_normalized_return'].to_list()[2:] == pytest.approx([1.0, 1.0, 1.0, 1.0])
+
+
+def test_vol_normalized_return_uses_prior_sigma_for_current_return() -> None:
+    data = _constant_vol_bars(n_rows=6, log_return=0.01)
+    mutated_rows = data.to_dicts()
+    mutated_rows[2]['high'] *= 100.0
+    mutated = pl.DataFrame(mutated_rows)
+
+    t = VolNormalizedReturnTarget(data, 'vol_normalized_return', halflife=2, min_periods=2)
+    baseline = t.transform(data)['vol_normalized_return'].to_list()
+    changed = t.transform(mutated)['vol_normalized_return'].to_list()
+
+    assert changed[2] == pytest.approx(baseline[2])
+    assert changed[3] != pytest.approx(baseline[3])
+
+
+def test_vol_normalized_return_drops_dirty_ohlc_bars() -> None:
+    data = _constant_vol_bars(n_rows=6, log_return=0.01)
+    dirty_rows = data.to_dicts()
+    dirty_rows[2]['high'] = max(dirty_rows[2]['open'], dirty_rows[2]['close']) - 0.01
+    dirty_rows[4]['low'] = min(dirty_rows[4]['open'], dirty_rows[4]['close']) + 0.01
+    dirty = pl.DataFrame(dirty_rows)
+
+    t = VolNormalizedReturnTarget(data, 'vol_normalized_return', halflife=2, min_periods=1)
+    result = t.transform(dirty)
+
+    assert result.height == data.height - 2
+
+
+def test_vol_normalized_return_rejects_bad_training_sigma_ratio() -> None:
+    data = _constant_vol_bars(n_rows=6, log_return=0.01, range_scale=2.0)
+
+    with pytest.raises(ValueError, match='outside'):
+        VolNormalizedReturnTarget(data, 'vol_normalized_return', halflife=2, min_periods=2)
+
+
+def test_canonical_decoder_outcomes_run_through_manifest() -> None:
+    raw_up = _with_hourly_datetime(_constant_vol_bars(n_rows=12, log_return=0.01))
+    raw_down = _with_hourly_datetime(_constant_vol_bars(n_rows=12, log_return=-0.01))
+
+    up = (
+        MLManifest()
+        .set_split_config(6, 3, 3)
+        .with_target_label('next_bar_up', NextBarUpTarget)
+    ).prepare_data(raw_up, {'bar_type': 'base'})
+    down = (
+        MLManifest()
+        .set_split_config(6, 3, 3)
+        .with_target_label('next_bar_down', NextBarDownTarget)
+    ).prepare_data(raw_down, {'bar_type': 'base'})
+    normalized = (
+        MLManifest()
+        .set_split_config(6, 3, 3)
+        .with_target_label(
+            'vol_normalized_return',
+            VolNormalizedReturnTarget,
+            fit_params={'halflife': 2, 'min_periods': 1},
+        )
+    ).prepare_data(raw_up, {'bar_type': 'base'})
+
+    assert up['y_train'].to_list() == [1, 1, 1, 1, 1]
+    assert down['y_train'].to_list() == [1, 1, 1, 1, 1]
+    assert normalized['y_train'].to_list() == pytest.approx([1.0, 1.0, 1.0, 1.0, 1.0])
 
 
 def _make_split_data() -> list[pl.DataFrame]:
@@ -234,4 +356,3 @@ def test_risk_reward_ratio_target_uses_absolute_drawdown_with_epsilon_guard() ->
     assert result['risk_reward_ratio'].to_list() == pytest.approx([0.5 / 0.101, 1000.0])
     assert 'capturable_breakout' not in result.columns
     assert 'max_drawdown' not in result.columns
-


### PR DESCRIPTION
## Summary
- add canonical decoder outcome targets: `NextBarUpTarget`, `NextBarDownTarget`, and `VolNormalizedReturnTarget`
- export the targets through `limen.targets` and document manifest usage
- bump package version to `3.1.1` and update `CHANGELOG.md`

## Target Semantics
- `next_bar_up`: `1` when next close is above current close, else `0`; terminal row is null
- `next_bar_down`: `1` when next close is below current close, else `0`; terminal row is null
- `vol_normalized_return`: log return divided by prior-bar Parkinson sigma, with dirty OHLC rows dropped and zero sigma nulled

## Proof
- `git diff --cached --check`
- `.venv/bin/ruff check limen/targets tests/test_targets.py tests/run.py`
- `.venv/bin/python -m pytest tests/test_targets.py` — 28 passed
- `.venv/bin/python tests/run.py` — 591 passed, 0 failed
- GitHub PR checks — pass: Tests, Runtime, Coverage, Ruff, CodeQL, Workers, Publish Coverage Comment

## Notes
- Bucketing remains downstream-only: fit train `q33`/`q66` of `abs(z)`, persist boundaries, and never refit online.
