### PR TITLE
feat: add manifest pca compression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -890,3 +890,10 @@ Note: add all new changelog entries to the bottom of this file.
 ## v3.2.0 on 17th of May, 2026
 
 - Add `Manifest.set_split_dates(train_start, train_end, val_start, val_end, test_start, test_end)` and `limen.data.utils.split_by_dates` for absolute-date train/val/test splits. When `split_dates` is set it takes precedence over `split_config` in both `_run_prepare_setup` (used by `MLManifest.prepare_data` and `RuleBasedManifest.prepare_data`) and `Manifest.compute_test_bars`; otherwise the existing ratio-based `split_sequential` path runs unchanged. Windows are half-open `[start, end)` and the setter validates non-decreasing ordering (`train_start <= train_end <= val_start <= val_end <= test_start <= test_end`) so non-overlap is mechanical; gaps between adjacent windows are allowed and any rows in those gaps are intentionally excluded from all three splits. Use this when temporal split boundaries must land on specific datetimes (e.g. honouring a deployment date), in preference to ratio-based splits whose absolute boundary depends on the input row count. `with_params_override(split_config=...)` clears any previously-pinned `split_dates` so a downstream ratio override (e.g. `Trainer.train_sensors` retraining on all data via `(1, 0, 0)`) is never silently shadowed by an earlier date pin. Both `set_split_dates` and `split_by_dates` validate that every bound is a `date` / `datetime` instance at the API boundary; non-datetime values raise `TypeError` rather than failing later inside Polars.
+
+## v3.2.1 on 17th of May, 2026
+
+- Add optional `MLManifest.set_pca_compression(...)` for manifest-level PCA feature compression after existing scaling and split-column alignment
+- When enabled, PCA requires a fitted `RobustScaler`, fits on train only, projects validation and test with the frozen rotation, and replaces `x_train`/`x_val`/`x_test` with `pc_*` columns
+- Preserve current behavior when PCA is not configured or when its enable flag is absent or false
+- Store only fitted PCA transform state and feature-name audit metadata; no parallel raw-feature dataset is retained

--- a/docs/Experiment-Manifest.md
+++ b/docs/Experiment-Manifest.md
@@ -466,6 +466,34 @@ Then in `params()`:
 
 Use this when scaler choice is itself part of the search space.
 
+## PCA Compression
+
+### `set_pca_compression(enabled_param='auto_pca', n_components_param='pca_k', scaler_param_name='_scaler', component_prefix='pc_')`
+
+Configure optional PCA feature compression for ML manifests.
+
+```python
+from limen.scalers import RobustScaler
+
+manifest = (
+    MLManifest()
+    .set_scaler(RobustScaler)
+    .set_pca_compression()
+)
+```
+
+When `round_params[enabled_param]` is absent or `False`, the manifest uses the
+current scaled feature surface unchanged.
+
+When it is `True`, `round_params[n_components_param]` must be an integer. The
+manifest fits full-SVD PCA on the train split only, then applies that frozen
+rotation to validation and test. `x_train`, `x_val`, and `x_test` are replaced
+with `pc_*` columns; no parallel raw-feature dataset is retained.
+
+PCA compression requires the configured fitted scaler to be `RobustScaler`.
+The PCA input is assumed to be stationary upstream. Limen does not run
+stationarity shims or tests in this path.
+
 ## Rule-Based Strategy
 
 Use `with_strategy()` when the strategy is expressed as boolean predicate logic over indicator columns — no Python model code required. This path is for rule-based SFDs only and produces a different `data_dict` shape than the ML path.

--- a/limen/experiment/manifest_core.py
+++ b/limen/experiment/manifest_core.py
@@ -15,12 +15,15 @@ from limen.calibration.pipeline import ThresholdOptimizerProtocol
 if TYPE_CHECKING:
     from limen.sfd.rule_based.config import RuleBasedConfig
 
+import numpy as np
 import polars as pl
+from sklearn.decomposition import PCA
 
 from limen.data.utils import split_by_dates
 from limen.data.utils import split_data_to_prep_output
 from limen.data.utils import split_data_to_rule_based_prep_output
 from limen.data.utils import split_sequential
+from limen.scalers.robust_scaler import RobustScaler
 from limen.scalers.registry import SCALER_REGISTRY
 logger = logging.getLogger(__name__)
 
@@ -48,6 +51,18 @@ class AblationConfig:
 
     drop_count_key: str
     seed_key: str
+
+
+@dataclass
+class PCACompressionConfig:
+
+    '''Configuration for optional manifest-level PCA feature compression.'''
+
+    enabled_param: str
+    n_components_param: str
+    scaler_param_name: str
+    component_prefix: str
+
 
 FittedTransformEntry = tuple[
     list[FittedParamsComputationEntry],
@@ -759,6 +774,7 @@ class MLManifest(Manifest):
 
     scaler: FittedTransformEntry = None
     ablation_config: AblationConfig | None = None
+    pca_compression_config: PCACompressionConfig | None = None
     data_dict_extension: Callable = None
     prediction_calibration_config: CalibrationConfig | None = None
 
@@ -846,6 +862,43 @@ class MLManifest(Manifest):
         return self
 
 
+    def set_pca_compression(self,
+                            enabled_param: str = 'auto_pca',
+                            n_components_param: str = 'pca_k',
+                            scaler_param_name: str = '_scaler',
+                            component_prefix: str = 'pc_') -> 'MLManifest':
+
+        '''
+        Configure optional PCA compression over the finalized feature surface.
+
+        Args:
+            enabled_param (str): round_params key that enables PCA when True
+            n_components_param (str): round_params key for PCA component count
+            scaler_param_name (str): fitted RobustScaler key in data_dict
+            component_prefix (str): Prefix for emitted component columns
+
+        Returns:
+            MLManifest: Self for method chaining
+        '''
+
+        for name, value in {
+            'enabled_param': enabled_param,
+            'n_components_param': n_components_param,
+            'scaler_param_name': scaler_param_name,
+            'component_prefix': component_prefix,
+        }.items():
+            if not isinstance(value, str) or not value:
+                raise TypeError(f'{name} must be a non-empty string')
+
+        self.pca_compression_config = PCACompressionConfig(
+            enabled_param=enabled_param,
+            n_components_param=n_components_param,
+            scaler_param_name=scaler_param_name,
+            component_prefix=component_prefix,
+        )
+        return self
+
+
     def add_to_data_dict(self, func: Callable) -> 'MLManifest':
 
         '''
@@ -920,6 +973,9 @@ class MLManifest(Manifest):
             split_data[i] = data.fill_nan(None).drop_nulls()
 
         split_data = _align_split_columns(split_data)
+        split_data, all_fitted_params = _apply_pca_compression(
+            self, split_data, round_params, all_fitted_params
+        )
 
         if price_data_for_backtest is not None:
             final_datetimes = split_data[2].select('datetime')
@@ -1372,6 +1428,126 @@ def _apply_scaler(
             data = data.with_columns(target_data)
 
     return data, all_fitted_params
+
+
+def _apply_pca_compression(
+        manifest: 'MLManifest',
+        split_data: list[pl.DataFrame],
+        round_params: dict[str, Any],
+        all_fitted_params: dict[str, Any],
+) -> tuple[list[pl.DataFrame], dict[str, Any]]:
+
+    config = manifest.pca_compression_config
+    if config is None:
+        return split_data, all_fitted_params
+
+    enabled = round_params.get(config.enabled_param, False)
+    if not isinstance(enabled, bool):
+        raise TypeError(
+            f"round_params['{config.enabled_param}'] must be a bool, got {enabled!r}"
+        )
+    if not enabled:
+        return split_data, all_fitted_params
+
+    if config.n_components_param not in round_params:
+        raise ValueError(
+            f"round_params['{config.n_components_param}'] is required when "
+            f"round_params['{config.enabled_param}'] is True"
+        )
+
+    scaler = all_fitted_params.get(config.scaler_param_name)
+    if not isinstance(scaler, RobustScaler):
+        raise ValueError(
+            'PCA compression requires a fitted limen.scalers.RobustScaler. '
+            'Configure .set_scaler(RobustScaler) or use scaler_type="robust".'
+        )
+
+    target_col = manifest.target_column
+    excluded_cols = {'datetime', target_col}
+    feature_cols = [col for col in split_data[0].columns if col not in excluded_cols]
+    _validate_pca_feature_columns(split_data, feature_cols)
+
+    k = round_params[config.n_components_param]
+    if not isinstance(k, int) or isinstance(k, bool):
+        raise ValueError(
+            f"round_params['{config.n_components_param}'] must be an int, got {k!r}"
+        )
+    if k < 1 or k > len(feature_cols):
+        raise ValueError(
+            f"round_params['{config.n_components_param}'] must be between 1 "
+            f"and the feature count ({len(feature_cols)}), got {k}"
+        )
+    if k > split_data[0].height:
+        raise ValueError(
+            f"round_params['{config.n_components_param}'] must be no larger than "
+            f'the train row count ({split_data[0].height}), got {k}'
+        )
+
+    pca = PCA(n_components=k, svd_solver='full', whiten=False)
+    component_cols = [f'{config.component_prefix}{i}' for i in range(k)]
+    train_components = pca.fit_transform(split_data[0].select(feature_cols).to_numpy())
+
+    transformed_splits = [
+        _build_pca_split(
+            split_data[0], train_components, component_cols, target_col
+        )
+    ]
+    for split in split_data[1:]:
+        if split.height == 0:
+            components = np.empty((0, k))
+        else:
+            components = pca.transform(split.select(feature_cols).to_numpy())
+        transformed_splits.append(
+            _build_pca_split(split, components, component_cols, target_col)
+        )
+
+    all_fitted_params['_pca'] = pca
+    all_fitted_params['_pca_input_feature_names'] = feature_cols
+    all_fitted_params['_pca_feature_names'] = component_cols
+    all_fitted_params['_pca_n_components'] = k
+
+    return transformed_splits, all_fitted_params
+
+
+def _validate_pca_feature_columns(
+        split_data: list[pl.DataFrame],
+        feature_cols: list[str],
+) -> None:
+
+    if not feature_cols:
+        raise ValueError('PCA compression requires at least one feature column')
+
+    for split_idx, split in enumerate(split_data):
+        if split.height == 0:
+            continue
+        non_numeric = [
+            col for col in feature_cols
+            if not split[col].dtype.is_numeric()
+        ]
+        if non_numeric:
+            raise ValueError(
+                f'PCA compression requires numeric feature columns; '
+                f'split {split_idx} has non-numeric columns: {non_numeric}'
+            )
+
+
+def _build_pca_split(
+        source: pl.DataFrame,
+        components: Any,
+        component_cols: list[str],
+        target_col: str | None,
+) -> pl.DataFrame:
+
+    component_data = {
+        col: components[:, idx]
+        for idx, col in enumerate(component_cols)
+    }
+    out = source.select('datetime').hstack(pl.DataFrame(component_data))
+
+    if target_col and target_col in source.columns:
+        out = out.with_columns(source[target_col])
+
+    return out
 
 
 def _run_prepare_setup(

--- a/limen/experiment/manifest_core.py
+++ b/limen/experiment/manifest_core.py
@@ -9,9 +9,6 @@ from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
-from limen.calibration.pipeline import CalibratorProtocol
-from limen.calibration.pipeline import ThresholdOptimizerProtocol
-
 if TYPE_CHECKING:
     from limen.sfd.rule_based.config import RuleBasedConfig
 
@@ -19,6 +16,8 @@ import numpy as np
 import polars as pl
 from sklearn.decomposition import PCA
 
+from limen.calibration.pipeline import CalibratorProtocol
+from limen.calibration.pipeline import ThresholdOptimizerProtocol
 from limen.data.utils import split_by_dates
 from limen.data.utils import split_data_to_prep_output
 from limen.data.utils import split_data_to_rule_based_prep_output
@@ -1456,10 +1455,18 @@ def _apply_pca_compression(
         )
 
     scaler = all_fitted_params.get(config.scaler_param_name)
+    if scaler is None:
+        raise ValueError(
+            'PCA compression could not find a fitted scaler at '
+            f"all_fitted_params['{config.scaler_param_name}']. "
+            'Configure .set_scaler(RobustScaler), or pass a matching '
+            'scaler_param_name to .set_pca_compression().'
+        )
     if not isinstance(scaler, RobustScaler):
         raise ValueError(
-            'PCA compression requires a fitted limen.scalers.RobustScaler. '
-            'Configure .set_scaler(RobustScaler) or use scaler_type="robust".'
+            'PCA compression requires a fitted RobustScaler at '
+            f"all_fitted_params['{config.scaler_param_name}'], got "
+            f'{type(scaler).__name__}.'
         )
 
     target_col = manifest.target_column

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaquum_limen"
-version = "3.2.0"
+version = "3.2.1"
 description = "Bitcoin-first research and trading platform."
 readme = "README.md"
 authors = [

--- a/tests/run.py
+++ b/tests/run.py
@@ -321,6 +321,13 @@ from tests.test_manifest_prepare_data import test_override_data_source_param
 from tests.test_manifest_prepare_data import test_override_multiple_params
 from tests.test_manifest_prepare_data import test_override_param_not_in_original_but_in_signature
 from tests.test_manifest_prepare_data import test_unknown_override_key_raises
+from tests.test_manifest_prepare_data import test_pca_compression_flag_off_matches_current_scaled_output
+from tests.test_manifest_prepare_data import test_pca_compression_replaces_feature_surface_when_enabled
+from tests.test_manifest_prepare_data import test_pca_compression_allows_empty_future_splits
+from tests.test_manifest_prepare_data import test_pca_compression_fits_on_train_only
+from tests.test_manifest_prepare_data import test_pca_compression_requires_robust_scaler
+from tests.test_manifest_prepare_data import test_pca_compression_rejects_invalid_k
+from tests.test_manifest_prepare_data import test_pca_compression_rejects_nonnumeric_features
 from tests.test_inline_metrics import test_inline_and_post_experiment_metrics
 from tests.test_inline_metrics import test_logreg_inline_and_post_confusion_metrics_match
 from tests.test_inline_metrics import test_xgboost_inline_and_post_backtest_metrics_match
@@ -1177,6 +1184,13 @@ tests = [
     test_find_min_d_small_data_skips,
     test_split_validation_rejects_invalid,
     test_column_consistency_drops_mismatched_columns,
+    test_pca_compression_flag_off_matches_current_scaled_output,
+    test_pca_compression_replaces_feature_surface_when_enabled,
+    test_pca_compression_allows_empty_future_splits,
+    test_pca_compression_fits_on_train_only,
+    test_pca_compression_requires_robust_scaler,
+    test_pca_compression_rejects_invalid_k,
+    test_pca_compression_rejects_nonnumeric_features,
     test_fractional_diff_manifest_integration,
     test_trainer_end_to_end,
     test_reconstruction_error_stochastic,

--- a/tests/run.py
+++ b/tests/run.py
@@ -326,6 +326,8 @@ from tests.test_manifest_prepare_data import test_pca_compression_replaces_featu
 from tests.test_manifest_prepare_data import test_pca_compression_allows_empty_future_splits
 from tests.test_manifest_prepare_data import test_pca_compression_fits_on_train_only
 from tests.test_manifest_prepare_data import test_pca_compression_requires_robust_scaler
+from tests.test_manifest_prepare_data import test_pca_compression_requires_configured_scaler
+from tests.test_manifest_prepare_data import test_pca_compression_reports_scaler_param_mismatch
 from tests.test_manifest_prepare_data import test_pca_compression_rejects_invalid_k
 from tests.test_manifest_prepare_data import test_pca_compression_rejects_nonnumeric_features
 from tests.test_inline_metrics import test_inline_and_post_experiment_metrics
@@ -1189,6 +1191,8 @@ tests = [
     test_pca_compression_allows_empty_future_splits,
     test_pca_compression_fits_on_train_only,
     test_pca_compression_requires_robust_scaler,
+    test_pca_compression_requires_configured_scaler,
+    test_pca_compression_reports_scaler_param_mismatch,
     test_pca_compression_rejects_invalid_k,
     test_pca_compression_rejects_nonnumeric_features,
     test_fractional_diff_manifest_integration,

--- a/tests/test_manifest_prepare_data.py
+++ b/tests/test_manifest_prepare_data.py
@@ -388,6 +388,49 @@ def test_pca_compression_requires_robust_scaler() -> None:
         assert 'RobustScaler' in str(e)
 
 
+def test_pca_compression_requires_configured_scaler() -> None:
+
+    manifest = (MLManifest()
+        .set_split_config(3, 1, 1)
+        .set_pca_compression()
+        .with_target_label(
+            'target',
+            ThresholdBinaryTarget,
+            fit_params={'source_column': 'close', 'threshold': 108.0},
+            transform_params={'shift': 0},
+        )
+    )
+
+    try:
+        manifest.prepare_data(_make_pca_raw_data(), {'auto_pca': True, 'pca_k': 2})
+        assert False, 'Expected ValueError'
+    except ValueError as e:
+        assert "all_fitted_params['_scaler']" in str(e)
+        assert 'set_scaler(RobustScaler)' in str(e)
+
+
+def test_pca_compression_reports_scaler_param_mismatch() -> None:
+
+    manifest = (MLManifest()
+        .set_split_config(3, 1, 1)
+        .set_scaler(RobustScaler, param_name='custom_scaler')
+        .set_pca_compression()
+        .with_target_label(
+            'target',
+            ThresholdBinaryTarget,
+            fit_params={'source_column': 'close', 'threshold': 108.0},
+            transform_params={'shift': 0},
+        )
+    )
+
+    try:
+        manifest.prepare_data(_make_pca_raw_data(), {'auto_pca': True, 'pca_k': 2})
+        assert False, 'Expected ValueError'
+    except ValueError as e:
+        assert "all_fitted_params['_scaler']" in str(e)
+        assert 'scaler_param_name' in str(e)
+
+
 def test_pca_compression_rejects_invalid_k() -> None:
 
     manifest = _make_pca_manifest()

--- a/tests/test_manifest_prepare_data.py
+++ b/tests/test_manifest_prepare_data.py
@@ -3,6 +3,8 @@ import polars as pl
 
 from limen.data import HistoricalData
 from limen.experiment import MLManifest
+from limen.scalers.linear_scaler import LinearScaler
+from limen.scalers.robust_scaler import RobustScaler
 from limen.sfd.foundational_sfd import logreg_binary as logreg_sfd
 from limen.targets import RandomBinaryTarget
 from limen.targets import ThresholdBinaryTarget
@@ -47,6 +49,41 @@ def _make_shifted_target_manifest() -> MLManifest:
             fit_params={'source_column': 'close_minus_open', 'threshold': 0.0},
             transform_params={'shift': -1})
     )
+
+
+def _make_pca_manifest() -> MLManifest:
+
+    return (MLManifest()
+        .set_split_config(3, 1, 1)
+        .set_scaler(RobustScaler)
+        .set_pca_compression()
+        .with_target_label(
+            'target',
+            ThresholdBinaryTarget,
+            fit_params={'source_column': 'close', 'threshold': 108.0},
+            transform_params={'shift': 0},
+        )
+    )
+
+
+def _make_pca_raw_data(n: int = 40) -> pl.DataFrame:
+
+    idx = np.arange(n, dtype=float)
+    close = 100.0 + idx * 0.7 + np.sin(idx / 3.0)
+    open_ = close - 0.3
+    return pl.DataFrame({
+        'datetime': pl.datetime_range(
+            start=pl.datetime(2025, 1, 1, 0, 0, 0),
+            end=pl.datetime(2025, 1, 2, 15, 0, 0),
+            interval='1h',
+            eager=True,
+        )[:n],
+        'open': open_,
+        'high': close + 1.0,
+        'low': open_ - 1.0,
+        'close': close,
+        'volume': 1000.0 + idx * 10.0,
+    })
 
 
 def test_price_data_for_backtest_has_ohlc_columns() -> None:
@@ -253,3 +290,125 @@ def test_column_consistency_drops_mismatched_columns() -> None:
     test_cols = set(data['x_test'].columns)
     assert train_cols == val_cols == test_cols
     assert 'big_split_col' not in train_cols
+
+
+def test_pca_compression_flag_off_matches_current_scaled_output() -> None:
+
+    raw_data = _make_pca_raw_data()
+    base_manifest = (MLManifest()
+        .set_split_config(3, 1, 1)
+        .set_scaler(RobustScaler)
+        .with_target_label(
+            'target',
+            ThresholdBinaryTarget,
+            fit_params={'source_column': 'close', 'threshold': 108.0},
+            transform_params={'shift': 0},
+        )
+    )
+    pca_manifest = _make_pca_manifest()
+
+    expected = base_manifest.prepare_data(raw_data, {})
+    actual = pca_manifest.prepare_data(raw_data, {})
+
+    assert actual['x_train'].equals(expected['x_train'])
+    assert actual['x_val'].equals(expected['x_val'])
+    assert actual['x_test'].equals(expected['x_test'])
+    assert '_pca' not in actual
+
+
+def test_pca_compression_replaces_feature_surface_when_enabled() -> None:
+
+    data = _make_pca_manifest().prepare_data(
+        _make_pca_raw_data(),
+        {'auto_pca': True, 'pca_k': 2},
+    )
+
+    assert data['x_train'].columns == ['pc_0', 'pc_1']
+    assert data['x_val'].columns == ['pc_0', 'pc_1']
+    assert data['x_test'].columns == ['pc_0', 'pc_1']
+    assert data['_pca_input_feature_names'] == [
+        'open', 'high', 'low', 'close', 'volume'
+    ]
+    assert data['_pca_feature_names'] == ['pc_0', 'pc_1']
+    assert data['_pca_n_components'] == 2
+
+
+def test_pca_compression_allows_empty_future_splits() -> None:
+
+    manifest = _make_pca_manifest().set_split_config(1, 0, 0)
+    data = manifest.prepare_data(
+        _make_pca_raw_data(),
+        {'auto_pca': True, 'pca_k': 2},
+    )
+
+    assert data['x_train'].columns == ['pc_0', 'pc_1']
+    assert data['x_val'].columns == ['pc_0', 'pc_1']
+    assert data['x_test'].columns == ['pc_0', 'pc_1']
+    assert data['x_val'].height == 0
+    assert data['x_test'].height == 0
+
+
+def test_pca_compression_fits_on_train_only() -> None:
+
+    base = _make_pca_raw_data()
+    shifted_future = base.with_columns(
+        pl.when(pl.arange(0, base.height) >= 24)
+        .then(pl.col('close') * 10.0)
+        .otherwise(pl.col('close'))
+        .alias('close')
+    )
+
+    manifest_a = _make_pca_manifest()
+    manifest_b = _make_pca_manifest()
+    data_a = manifest_a.prepare_data(base, {'auto_pca': True, 'pca_k': 2})
+    data_b = manifest_b.prepare_data(shifted_future, {'auto_pca': True, 'pca_k': 2})
+
+    assert np.allclose(data_a['_pca'].components_, data_b['_pca'].components_)
+    assert data_a['x_train'].equals(data_b['x_train'])
+
+
+def test_pca_compression_requires_robust_scaler() -> None:
+
+    manifest = (MLManifest()
+        .set_split_config(3, 1, 1)
+        .set_scaler(LinearScaler)
+        .set_pca_compression()
+        .with_target_label(
+            'target',
+            ThresholdBinaryTarget,
+            fit_params={'source_column': 'close', 'threshold': 108.0},
+            transform_params={'shift': 0},
+        )
+    )
+
+    try:
+        manifest.prepare_data(_make_pca_raw_data(), {'auto_pca': True, 'pca_k': 2})
+        assert False, 'Expected ValueError'
+    except ValueError as e:
+        assert 'RobustScaler' in str(e)
+
+
+def test_pca_compression_rejects_invalid_k() -> None:
+
+    manifest = _make_pca_manifest()
+    raw_data = _make_pca_raw_data()
+
+    for bad_k in [True, 0, 6]:
+        try:
+            manifest.prepare_data(raw_data, {'auto_pca': True, 'pca_k': bad_k})
+            assert False, f'Expected ValueError for {bad_k!r}'
+        except ValueError as e:
+            assert 'pca_k' in str(e)
+
+
+def test_pca_compression_rejects_nonnumeric_features() -> None:
+
+    manifest = (_make_pca_manifest()
+        .add_feature(lambda df: df.with_columns(pl.lit('x').alias('symbol')))
+    )
+
+    try:
+        manifest.prepare_data(_make_pca_raw_data(), {'auto_pca': True, 'pca_k': 2})
+        assert False, 'Expected ValueError'
+    except ValueError as e:
+        assert 'non-numeric' in str(e)


### PR DESCRIPTION
## Summary
- add optional MLManifest.set_pca_compression() after scaling and split-column alignment
- replace x_train/x_val/x_test with pc_* columns only when auto_pca is true
- require fitted RobustScaler, train-only PCA fit, frozen validation/test projection
- split PCA scaler diagnostics for missing scaler, scaler-param mismatch, and wrong scaler type
- update docs, changelog, and version to 3.2.1

## Proof
- .venv/bin/ruff check limen/experiment/manifest_core.py tests/test_manifest_prepare_data.py tests/run.py
- git ls-files "*.py" | xargs .venv/bin/ruff check
- .venv/bin/python -m pytest tests/test_manifest_prepare_data.py -k pca_compression -q
- .venv/bin/python -m pytest tests/test_manifest_prepare_data.py tests/test_scalers.py -q
- GitHub PR checks: Ruff, Tests, Runtime, Coverage, CodeQL, Workers all passing

## Notes
- no parallel raw-feature dataset is retained
- .claude/ and rust/ are pre-existing untracked local files and are not part of this PR