### PR TITLE
feat: replace snapshot backtest with metric ledger

### DIFF
--- a/docs/Backtest.md
+++ b/docs/Backtest.md
@@ -46,9 +46,8 @@ The current snapshot backtest is intentionally simple and opinionated:
 - continuation-bar return is based on `close_t / close_{t-1} - 1`
 - fee and slippage costs are applied multiplicatively on entry and exit fills
 - `trade_*` metrics are computed from compounded consecutive `1` runs
-- `trades_count` counts consecutive in-market runs, not in-market bars
-- `bars_total`, `bars_in_market_bps`, and `sharpe_per_bar` are computed on the tradable evaluation rows only
-- all ratio outputs use basis points, including bounded proportions (`0.5` is `5000.0` bps)
+- output metrics are quantiles over their declared substrate
+- return and ratio outputs are basis-point scaled
 
 This makes snapshot backtests fast and comparable across rounds, but it also means they are not trying to be a full execution simulator.
 
@@ -56,19 +55,14 @@ This makes snapshot backtests fast and comparable across rounds, but it also mea
 
 Snapshot backtests produce:
 
-- `trade_win_rate_bps`
-- `trade_expectancy_bps`
-- `max_drawdown_bps`
-- `total_return_gross_bps`
-- `total_return_net_bps`
-- `trade_return_mean_win_bps`
-- `trade_return_mean_loss_bps`
-- `mean_kelly_bps`
-- `bars_total`
-- `sharpe_per_bar`
-- `bars_in_market_bps`
-- `trades_count`
-- `cost_round_trip_bps`
+- `edge_per_signal_bps_p5`, `edge_per_signal_bps_p50`, `edge_per_signal_bps_p95`
+- `trade_pnl_net_bps_p5`, `trade_pnl_net_bps_p50`, `trade_pnl_net_bps_p95`
+- `cost_drag_bps_p5`, `cost_drag_bps_p50`, `cost_drag_bps_p95`
+- `rolling_return_net_bps_p5`, `rolling_return_net_bps_p50`, `rolling_return_net_bps_p95`
+- `return_on_exposure_p5`, `return_on_exposure_p50`, `return_on_exposure_p95`
+- `drawdown_depth_bps_p5`, `drawdown_depth_bps_p50`, `drawdown_depth_bps_p95`
+- `drawdown_duration_days_p5`, `drawdown_duration_days_p50`, `drawdown_duration_days_p95`
+- `cvar_95_return_bps`
 
 ### Typical use
 

--- a/docs/Backtest.md
+++ b/docs/Backtest.md
@@ -47,8 +47,8 @@ The current snapshot backtest is intentionally simple and opinionated:
 - fee and slippage costs are applied multiplicatively on entry and exit fills
 - `trade_*` metrics are computed from compounded consecutive `1` runs
 - `trades_count` counts consecutive in-market runs, not in-market bars
-- `bars_total`, `bars_in_market_pct`, and `sharpe_per_bar` are computed on the tradable evaluation rows only
-- outputs are reported in percent units
+- `bars_total`, `bars_in_market_bps`, and `sharpe_per_bar` are computed on the tradable evaluation rows only
+- ratio outputs are reported in basis points
 
 This makes snapshot backtests fast and comparable across rounds, but it also means they are not trying to be a full execution simulator.
 
@@ -56,16 +56,17 @@ This makes snapshot backtests fast and comparable across rounds, but it also mea
 
 Snapshot backtests produce:
 
-- `trade_win_rate_pct`
-- `trade_expectancy_pct`
-- `max_drawdown_pct`
-- `total_return_gross_pct`
-- `total_return_net_pct`
-- `trade_return_mean_win_pct`
-- `trade_return_mean_loss_pct`
+- `trade_win_rate_bps`
+- `trade_expectancy_bps`
+- `max_drawdown_bps`
+- `total_return_gross_bps`
+- `total_return_net_bps`
+- `trade_return_mean_win_bps`
+- `trade_return_mean_loss_bps`
+- `mean_kelly_bps`
 - `bars_total`
 - `sharpe_per_bar`
-- `bars_in_market_pct`
+- `bars_in_market_bps`
 - `trades_count`
 - `cost_round_trip_bps`
 

--- a/docs/Backtest.md
+++ b/docs/Backtest.md
@@ -48,7 +48,7 @@ The current snapshot backtest is intentionally simple and opinionated:
 - `trade_*` metrics are computed from compounded consecutive `1` runs
 - `trades_count` counts consecutive in-market runs, not in-market bars
 - `bars_total`, `bars_in_market_bps`, and `sharpe_per_bar` are computed on the tradable evaluation rows only
-- ratio outputs are reported in basis points
+- all ratio outputs use basis points, including bounded proportions (`0.5` is `5000.0` bps)
 
 This makes snapshot backtests fast and comparable across rounds, but it also means they are not trying to be a full execution simulator.
 

--- a/docs/Log.md
+++ b/docs/Log.md
@@ -174,6 +174,8 @@ uel.experiment_backtest_results
 
 The current summary columns are:
 
+All ratio columns use basis points, including bounded proportions (`0.5` is `5000.0` bps).
+
 - `trade_win_rate_bps`
 - `trade_expectancy_bps`
 - `max_drawdown_bps`

--- a/docs/Log.md
+++ b/docs/Log.md
@@ -174,16 +174,17 @@ uel.experiment_backtest_results
 
 The current summary columns are:
 
-- `trade_win_rate_pct`
-- `trade_expectancy_pct`
-- `max_drawdown_pct`
-- `total_return_gross_pct`
-- `total_return_net_pct`
-- `trade_return_mean_win_pct`
-- `trade_return_mean_loss_pct`
+- `trade_win_rate_bps`
+- `trade_expectancy_bps`
+- `max_drawdown_bps`
+- `total_return_gross_bps`
+- `total_return_net_bps`
+- `trade_return_mean_win_bps`
+- `trade_return_mean_loss_bps`
+- `mean_kelly_bps`
 - `bars_total`
 - `sharpe_per_bar`
-- `bars_in_market_pct`
+- `bars_in_market_bps`
 - `trades_count`
 - `cost_round_trip_bps`
 

--- a/docs/Log.md
+++ b/docs/Log.md
@@ -172,23 +172,16 @@ The same table is exposed directly on UEL as:
 uel.experiment_backtest_results
 ```
 
-The current summary columns are:
+The current summary columns are the 22 decoder-level backtest ledger fields:
 
-All ratio columns use basis points, including bounded proportions (`0.5` is `5000.0` bps).
-
-- `trade_win_rate_bps`
-- `trade_expectancy_bps`
-- `max_drawdown_bps`
-- `total_return_gross_bps`
-- `total_return_net_bps`
-- `trade_return_mean_win_bps`
-- `trade_return_mean_loss_bps`
-- `mean_kelly_bps`
-- `bars_total`
-- `sharpe_per_bar`
-- `bars_in_market_bps`
-- `trades_count`
-- `cost_round_trip_bps`
+- `edge_per_signal_bps_p5`, `edge_per_signal_bps_p50`, `edge_per_signal_bps_p95`
+- `trade_pnl_net_bps_p5`, `trade_pnl_net_bps_p50`, `trade_pnl_net_bps_p95`
+- `cost_drag_bps_p5`, `cost_drag_bps_p50`, `cost_drag_bps_p95`
+- `rolling_return_net_bps_p5`, `rolling_return_net_bps_p50`, `rolling_return_net_bps_p95`
+- `return_on_exposure_p5`, `return_on_exposure_p50`, `return_on_exposure_p95`
+- `drawdown_depth_bps_p5`, `drawdown_depth_bps_p50`, `drawdown_depth_bps_p95`
+- `drawdown_duration_days_p5`, `drawdown_duration_days_p50`, `drawdown_duration_days_p95`
+- `cvar_95_return_bps`
 
 Use this table to compare the trading-economics side of rounds after you have already inspected the benchmark layer.
 

--- a/docs/Reference-Architecture.md
+++ b/docs/Reference-Architecture.md
@@ -196,11 +196,11 @@ The strategy walks the boolean logic tree defined in `strategy['conditions']`, r
 
 - **Tier 1** — position stats: `num_trades_{split}`, `position_rate_{split}`
 - **Tier 2** — per-split backtest: all `backtest_snapshot` output columns suffixed with `_{split}` (e.g. `sharpe_per_bar_train`, `max_drawdown_bps_test`)
-- **Tier 3** — cross-split stability: `sharpe_std`, `drawdown_std`, `sharpe_degradation`, `is_stable`
+- **Tier 3** — cross-split stability: `sharpe_std`, `drawdown_std_bps`, `sharpe_degradation`, `is_stable`
 
 `is_stable` is `True` when `sharpe_std < sharpe_std_threshold` and `sharpe_degradation < sharpe_degradation_threshold`. Both thresholds are configurable parameters passed through the foundational SFD's `params()` domain.
 
-**NOTE:** Tier 2 and Tier 3 metrics require `open` and `close` columns in the split DataFrames to run the backtest. When those columns are absent, per-split backtest results are empty and the Tier 3 stability keys (`sharpe_std`, `drawdown_std`, `sharpe_degradation`) are returned as `None` with `is_stable` falling back to `False`.
+**NOTE:** Tier 2 and Tier 3 metrics require `open` and `close` columns in the split DataFrames to run the backtest. When those columns are absent, per-split backtest results are empty and the Tier 3 stability keys (`sharpe_std`, `drawdown_std_bps`, `sharpe_degradation`) are returned as `None` with `is_stable` falling back to `False`.
 
 `_preds` is present; `_probs` is intentionally absent (not applicable to rule-based strategies).
 

--- a/docs/Reference-Architecture.md
+++ b/docs/Reference-Architecture.md
@@ -107,9 +107,9 @@ With `inline_metrics=True`, `evaluate()` adds:
 
 On that same live local run, `LogRegBinary.evaluate(..., inline_metrics=True)` added keys such as:
 
-- `backtest_total_return_net_bps`
-- `backtest_max_drawdown_bps`
-- `backtest_sharpe_per_bar`
+- `backtest_edge_per_signal_bps_p50`
+- `backtest_trade_pnl_net_bps_p50`
+- `backtest_cvar_95_return_bps`
 - `confusion_tp`
 - `confusion_fp`
 - `confusion_precision`
@@ -195,12 +195,12 @@ The strategy walks the boolean logic tree defined in `strategy['conditions']`, r
 `evaluate()` returns a flat dict with three tiers:
 
 - **Tier 1** — position stats: `num_trades_{split}`, `position_rate_{split}`
-- **Tier 2** — per-split backtest: all `backtest_snapshot` output columns suffixed with `_{split}` (e.g. `sharpe_per_bar_train`, `max_drawdown_bps_test`)
-- **Tier 3** — cross-split stability: `sharpe_std`, `drawdown_std_bps`, `sharpe_degradation`, `is_stable`
+- **Tier 2** — per-split backtest: all `backtest_snapshot` output columns suffixed with `_{split}` (e.g. `trade_pnl_net_bps_p50_train`, `drawdown_depth_bps_p5_test`)
+- **Tier 3** — cross-split diagnostics: `drawdown_std_bps`, `is_stable`
 
-`is_stable` is `True` when `sharpe_std < sharpe_std_threshold` and `sharpe_degradation < sharpe_degradation_threshold`. Both thresholds are configurable parameters passed through the foundational SFD's `params()` domain.
+`is_stable` is `False` until a replacement stability rule is defined against the new decoder-level ledger.
 
-**NOTE:** Tier 2 and Tier 3 metrics require `open` and `close` columns in the split DataFrames to run the backtest. When those columns are absent, per-split backtest results are empty and the Tier 3 stability keys (`sharpe_std`, `drawdown_std_bps`, `sharpe_degradation`) are returned as `None` with `is_stable` falling back to `False`.
+**NOTE:** Tier 2 and Tier 3 metrics require `open` and `close` columns in the split DataFrames to run the backtest. When those columns are absent, per-split backtest results are empty and `drawdown_std_bps` is returned as `None` with `is_stable` falling back to `False`.
 
 `_preds` is present; `_probs` is intentionally absent (not applicable to rule-based strategies).
 

--- a/docs/Reference-Architecture.md
+++ b/docs/Reference-Architecture.md
@@ -107,8 +107,8 @@ With `inline_metrics=True`, `evaluate()` adds:
 
 On that same live local run, `LogRegBinary.evaluate(..., inline_metrics=True)` added keys such as:
 
-- `backtest_total_return_net_pct`
-- `backtest_max_drawdown_pct`
+- `backtest_total_return_net_bps`
+- `backtest_max_drawdown_bps`
 - `backtest_sharpe_per_bar`
 - `confusion_tp`
 - `confusion_fp`
@@ -195,7 +195,7 @@ The strategy walks the boolean logic tree defined in `strategy['conditions']`, r
 `evaluate()` returns a flat dict with three tiers:
 
 - **Tier 1** — position stats: `num_trades_{split}`, `position_rate_{split}`
-- **Tier 2** — per-split backtest: all `backtest_snapshot` output columns suffixed with `_{split}` (e.g. `sharpe_per_bar_train`, `max_drawdown_pct_test`)
+- **Tier 2** — per-split backtest: all `backtest_snapshot` output columns suffixed with `_{split}` (e.g. `sharpe_per_bar_train`, `max_drawdown_bps_test`)
 - **Tier 3** — cross-split stability: `sharpe_std`, `drawdown_std`, `sharpe_degradation`, `is_stable`
 
 `is_stable` is `True` when `sharpe_std < sharpe_std_threshold` and `sharpe_degradation < sharpe_degradation_threshold`. Both thresholds are configurable parameters passed through the foundational SFD's `params()` domain.

--- a/docs/Trainer.md
+++ b/docs/Trainer.md
@@ -215,9 +215,9 @@ In a live local logreg promotion run in this repo, the stored keys included:
 - `_preds`
 - `accuracy`
 - `auc`
-- `backtest_total_return_net_bps`
-- `backtest_max_drawdown_bps`
-- `backtest_sharpe_per_bar`
+- `backtest_edge_per_signal_bps_p50`
+- `backtest_trade_pnl_net_bps_p50`
+- `backtest_cvar_95_return_bps`
 
 When the promoted round used calibration, `results` also includes:
 

--- a/docs/Trainer.md
+++ b/docs/Trainer.md
@@ -215,8 +215,8 @@ In a live local logreg promotion run in this repo, the stored keys included:
 - `_preds`
 - `accuracy`
 - `auc`
-- `backtest_total_return_net_pct`
-- `backtest_max_drawdown_pct`
+- `backtest_total_return_net_bps`
+- `backtest_max_drawdown_bps`
 - `backtest_sharpe_per_bar`
 
 When the promoted round used calibration, `results` also includes:

--- a/limen/backtest/backtest_snapshot.py
+++ b/limen/backtest/backtest_snapshot.py
@@ -17,7 +17,8 @@ def backtest_snapshot(df: pd.DataFrame,
 
     '''
     Long-only, HOLD-WHILE-1 evaluation using pre-aligned intrabar returns.
-    All ratio fields are in basis points. Sharpe is per bar (unitless).
+    All ratio fields use basis points, including bounded proportions:
+    0.5 is reported as 5000.0 bps. Sharpe is per bar (unitless).
 
     Takes in output of log.permutation_prediction_performance and returns backtest results.
 

--- a/limen/backtest/backtest_snapshot.py
+++ b/limen/backtest/backtest_snapshot.py
@@ -4,6 +4,111 @@ import pandas as pd
 PRICE_CHANGE_RTOL = 1e-09
 PRICE_CHANGE_ATOL = 1e-12
 BPS_PER_UNIT = 10_000.0
+BACKTEST_SNAPSHOT_COLUMNS = [
+    'edge_per_signal_bps_p5',
+    'edge_per_signal_bps_p50',
+    'edge_per_signal_bps_p95',
+    'trade_pnl_net_bps_p5',
+    'trade_pnl_net_bps_p50',
+    'trade_pnl_net_bps_p95',
+    'cost_drag_bps_p5',
+    'cost_drag_bps_p50',
+    'cost_drag_bps_p95',
+    'rolling_return_net_bps_p5',
+    'rolling_return_net_bps_p50',
+    'rolling_return_net_bps_p95',
+    'return_on_exposure_p5',
+    'return_on_exposure_p50',
+    'return_on_exposure_p95',
+    'drawdown_depth_bps_p5',
+    'drawdown_depth_bps_p50',
+    'drawdown_depth_bps_p95',
+    'drawdown_duration_days_p5',
+    'drawdown_duration_days_p50',
+    'drawdown_duration_days_p95',
+    'cvar_95_return_bps',
+]
+
+
+def _finite_values(values: pd.Series | np.ndarray | list[float]) -> np.ndarray:
+    arr = pd.to_numeric(pd.Series(values), errors='coerce').to_numpy(dtype=float)
+    return arr[np.isfinite(arr)]
+
+
+def _quantiles(values: pd.Series | np.ndarray | list[float], decimals: int = 1) -> tuple[float, float, float]:
+    arr = _finite_values(values)
+    if arr.size == 0:
+        return (np.nan, np.nan, np.nan)
+    return tuple(round(float(np.quantile(arr, q)), decimals) for q in (0.05, 0.50, 0.95))
+
+
+def _clock_window_returns(
+        df: pd.DataFrame,
+        eval_mask: pd.Series,
+        pos: pd.Series,
+        R_net: pd.Series,
+        datetime_col: str,
+        clock_window: str) -> tuple[pd.Series, pd.Series]:
+
+    if datetime_col not in df:
+        return pd.Series(dtype=float), pd.Series(dtype=float)
+
+    dt = pd.to_datetime(df[datetime_col], errors='coerce')
+    mask = eval_mask & dt.notna()
+    if not mask.any():
+        return pd.Series(dtype=float), pd.Series(dtype=float)
+
+    windows = dt[mask].dt.floor(clock_window)
+    window_returns = (1.0 + R_net[mask]).groupby(windows).prod() - 1.0
+    exposure = pos[mask].astype(float).groupby(windows).mean()
+    return_on_exposure = (window_returns / exposure).where(exposure > 0) * BPS_PER_UNIT
+
+    return window_returns * BPS_PER_UNIT, return_on_exposure
+
+
+def _drawdown_episode_metrics(
+        eq_net: pd.Series,
+        eval_mask: pd.Series,
+        df: pd.DataFrame,
+        datetime_col: str) -> tuple[list[float], list[float]]:
+
+    eq = eq_net[eval_mask]
+    if eq.empty:
+        return [], []
+
+    drawdown = (eq / eq.cummax().clip(lower=1.0)) - 1.0
+    timestamps = (
+        pd.to_datetime(df.loc[eq.index, datetime_col], errors='coerce')
+        if datetime_col in df
+        else pd.Series(pd.NaT, index=eq.index)
+    )
+
+    depths_bps: list[float] = []
+    durations_days: list[float] = []
+    in_drawdown = False
+    start_time = pd.NaT
+    trough = 0.0
+
+    for idx, dd in drawdown.items():
+        ts = timestamps.loc[idx]
+        if dd < 0 and not in_drawdown:
+            in_drawdown = True
+            start_time = ts
+            trough = float(dd)
+        elif dd < 0:
+            trough = min(trough, float(dd))
+        elif in_drawdown:
+            depths_bps.append(trough * BPS_PER_UNIT)
+            if pd.notna(start_time) and pd.notna(ts):
+                durations_days.append(float((ts - start_time) / pd.Timedelta(days=1)))
+            in_drawdown = False
+            start_time = pd.NaT
+            trough = 0.0
+
+    if in_drawdown:
+        depths_bps.append(trough * BPS_PER_UNIT)
+
+    return depths_bps, durations_days
 
 def backtest_snapshot(df: pd.DataFrame,
                      *,
@@ -11,14 +116,16 @@ def backtest_snapshot(df: pd.DataFrame,
                      open_col: str = 'open',
                      close_col: str = 'close',
                      price_change_col: str = 'price_change',
+                     datetime_col: str = 'datetime',
                      execution_lag_bars: int = 1,
+                     clock_window: str = '1D',
                      fee_bps: float = 5.0,
                      slip_bps: float = 5.0) -> pd.DataFrame:
 
     '''
     Long-only, HOLD-WHILE-1 evaluation using pre-aligned intrabar returns.
-    All ratio fields use basis points, including bounded proportions:
-    0.5 is reported as 5000.0 bps. Sharpe is per bar (unitless).
+    Emits the decoder-level metric ledger used before market replay.
+    Return and ratio outputs are basis-point scaled.
 
     Takes in output of log.permutation_prediction_performance and returns backtest results.
 
@@ -33,21 +140,7 @@ def backtest_snapshot(df: pd.DataFrame,
     - Equity compounds over R_net; drawdown is computed from net equity.
 
     Returns a one-row DataFrame with columns (in order):
-      [
-        'trade_win_rate_bps',
-        'trade_expectancy_bps',
-        'max_drawdown_bps',
-        'total_return_gross_bps',
-        'total_return_net_bps',
-        'trade_return_mean_win_bps',
-        'trade_return_mean_loss_bps',
-        'mean_kelly_bps',
-        'bars_total',
-        'sharpe_per_bar',
-        'bars_in_market_bps',
-        'trades_count',
-        'cost_round_trip_bps',
-      ]
+      BACKTEST_SNAPSHOT_COLUMNS
     '''
 
     df = df.copy()
@@ -94,13 +187,8 @@ def backtest_snapshot(df: pd.DataFrame,
     eval_mask = execution_rows & tradable
     pos = (pred == 1) & eval_mask
 
-    bars_total = int(eval_mask.sum())
-    bars_in_market_bps = float((pos.sum() / bars_total) * BPS_PER_UNIT) if bars_total else np.nan
-
     entry_mask = pos & (~pos.shift(1, fill_value=False))
     cont_mask  = pos & ( pos.shift(1, fill_value=False))
-
-    trades_count = int(entry_mask.sum())
 
     r_entry = dpx / open_px
     r_cont  = (close_px / close_px.shift(1)) - 1.0
@@ -119,65 +207,49 @@ def backtest_snapshot(df: pd.DataFrame,
     cost_mult.loc[exit_mask] *= exit_mult
 
     R_net = (((1.0 + R_gross) * cost_mult) - 1.0).fillna(0.0)
-    eq_gross = (1.0 + R_gross).cumprod()
     eq_net = (1.0 + R_net).cumprod()
 
-    peak = eq_net.cummax().clip(lower=1.0)
-    max_drawdown_bps = float((eq_net / peak - 1.0).min() * BPS_PER_UNIT)
-
-    total_return_gross_bps = float((eq_gross.iloc[-1] - 1.0) * BPS_PER_UNIT)
-    total_return_net_bps = float((eq_net.iloc[-1]   - 1.0) * BPS_PER_UNIT)
-
     run_ids = entry_mask.cumsum()
-    trade_returns = (
+    trade_pnl_net = (
         (1.0 + R_net[pos]).groupby(run_ids[pos]).prod() - 1.0
     ) if entry_mask.any() else pd.Series(dtype=float)
+    trade_pnl_gross = (
+        (1.0 + R_gross[pos]).groupby(run_ids[pos]).prod() - 1.0
+    ) if entry_mask.any() else pd.Series(dtype=float)
 
-    if trade_returns.size:
-        wins = trade_returns[trade_returns > 0]
-        losses = trade_returns[trade_returns < 0]
-        trade_win_rate_bps = float((wins.size / trade_returns.size) * BPS_PER_UNIT)
-        trade_expectancy_bps = float(trade_returns.mean() * BPS_PER_UNIT)
-        trade_return_mean_win_bps = float(wins.mean() * BPS_PER_UNIT) if wins.size else np.nan
-        trade_return_mean_loss_bps = float(losses.mean() * BPS_PER_UNIT) if losses.size else np.nan
+    edge_per_signal = R_gross[pos] * BPS_PER_UNIT
+    trade_pnl_net_bps = trade_pnl_net * BPS_PER_UNIT
+    cost_drag_bps = (trade_pnl_gross - trade_pnl_net) * BPS_PER_UNIT
+    rolling_return_net_bps, return_on_exposure = _clock_window_returns(
+        df, eval_mask, pos, R_net, datetime_col, clock_window
+    )
+    drawdown_depth_bps, drawdown_duration_days = _drawdown_episode_metrics(
+        eq_net, eval_mask, df, datetime_col
+    )
+
+    cvar_values = _finite_values(rolling_return_net_bps)
+    if cvar_values.size:
+        cvar_cutoff = np.quantile(cvar_values, 0.05)
+        cvar_95_return_bps = round(float(cvar_values[cvar_values <= cvar_cutoff].mean()), 1)
     else:
-        trade_win_rate_bps = trade_expectancy_bps = np.nan
-        trade_return_mean_win_bps = trade_return_mean_loss_bps = np.nan
+        cvar_95_return_bps = np.nan
 
-    kelly_returns = trade_returns
+    data: dict[str, float] = {}
+    for prefix, values, decimals in [
+        ('edge_per_signal_bps', edge_per_signal, 1),
+        ('trade_pnl_net_bps', trade_pnl_net_bps, 1),
+        ('cost_drag_bps', cost_drag_bps, 1),
+        ('rolling_return_net_bps', rolling_return_net_bps, 1),
+        ('return_on_exposure', return_on_exposure, 1),
+        ('drawdown_depth_bps', drawdown_depth_bps, 1),
+        ('drawdown_duration_days', drawdown_duration_days, 3),
+    ]:
+        p5, p50, p95 = _quantiles(values, decimals)
+        data[f'{prefix}_p5'] = p5
+        data[f'{prefix}_p50'] = p50
+        data[f'{prefix}_p95'] = p95
 
-    kelly_wins = kelly_returns[kelly_returns > 0]
-    kelly_losses = kelly_returns[kelly_returns < 0]
-    if kelly_wins.size and kelly_losses.size:
-        win_rate = float(kelly_wins.size / kelly_returns.size)
-        loss_rate = float(kelly_losses.size / kelly_returns.size)
-        avg_win = float(kelly_wins.mean())
-        avg_loss = abs(float(kelly_losses.mean()))
-        payout_ratio = avg_win / avg_loss if avg_loss > 0 else np.nan
-        mean_kelly_bps = float((win_rate - (loss_rate / payout_ratio)) * BPS_PER_UNIT) if payout_ratio > 0 else np.nan
-    else:
-        mean_kelly_bps = np.nan
+    data['cvar_95_return_bps'] = cvar_95_return_bps
+    data = {col: data[col] for col in BACKTEST_SNAPSHOT_COLUMNS}
 
-    eval_returns = R_net[eval_mask]
-    mu = float(eval_returns.mean()) if eval_returns.size else np.nan
-    sd = float(eval_returns.std(ddof=1)) if eval_returns.size > 1 else np.nan
-
-    sharpe_per_bar = float(mu / sd) if sd > 0 else np.nan
-
-    data = pd.DataFrame.from_records([{
-        'trade_win_rate_bps': round(trade_win_rate_bps, 1),
-        'trade_expectancy_bps': round(trade_expectancy_bps, 1),
-        'max_drawdown_bps': round(max_drawdown_bps, 1),
-        'total_return_gross_bps': round(total_return_gross_bps, 1),
-        'total_return_net_bps': round(total_return_net_bps, 1),
-        'trade_return_mean_win_bps': round(trade_return_mean_win_bps, 1),
-        'trade_return_mean_loss_bps': round(trade_return_mean_loss_bps, 1),
-        'mean_kelly_bps': round(mean_kelly_bps, 1),
-        'bars_total': int(bars_total),
-        'sharpe_per_bar': round(sharpe_per_bar, 2),
-        'bars_in_market_bps': round(bars_in_market_bps, 1),
-        'trades_count': int(trades_count),
-        'cost_round_trip_bps': round((1.0 - (entry_mult * exit_mult)) * BPS_PER_UNIT),
-    }])
-
-    return data
+    return pd.DataFrame.from_records([data])

--- a/limen/backtest/backtest_snapshot.py
+++ b/limen/backtest/backtest_snapshot.py
@@ -3,6 +3,7 @@ import pandas as pd
 
 PRICE_CHANGE_RTOL = 1e-09
 PRICE_CHANGE_ATOL = 1e-12
+BPS_PER_UNIT = 10_000.0
 
 def backtest_snapshot(df: pd.DataFrame,
                      *,
@@ -16,7 +17,7 @@ def backtest_snapshot(df: pd.DataFrame,
 
     '''
     Long-only, HOLD-WHILE-1 evaluation using pre-aligned intrabar returns.
-    All percentage fields are in % units (not fractions). Sharpe is per bar (unitless).
+    All ratio fields are in basis points. Sharpe is per bar (unitless).
 
     Takes in output of log.permutation_prediction_performance and returns backtest results.
 
@@ -32,17 +33,17 @@ def backtest_snapshot(df: pd.DataFrame,
 
     Returns a one-row DataFrame with columns (in order):
       [
-        'trade_win_rate_pct',
-        'trade_expectancy_pct',
-        'max_drawdown_pct',
-        'total_return_gross_pct',
-        'total_return_net_pct',
-        'trade_return_mean_win_pct',
-        'trade_return_mean_loss_pct',
-        'mean_kelly_pct',
+        'trade_win_rate_bps',
+        'trade_expectancy_bps',
+        'max_drawdown_bps',
+        'total_return_gross_bps',
+        'total_return_net_bps',
+        'trade_return_mean_win_bps',
+        'trade_return_mean_loss_bps',
+        'mean_kelly_bps',
         'bars_total',
         'sharpe_per_bar',
-        'bars_in_market_pct',
+        'bars_in_market_bps',
         'trades_count',
         'cost_round_trip_bps',
       ]
@@ -93,7 +94,7 @@ def backtest_snapshot(df: pd.DataFrame,
     pos = (pred == 1) & eval_mask
 
     bars_total = int(eval_mask.sum())
-    bars_in_market_pct = float((pos.sum() / bars_total) * 100.0) if bars_total else np.nan
+    bars_in_market_bps = float((pos.sum() / bars_total) * BPS_PER_UNIT) if bars_total else np.nan
 
     entry_mask = pos & (~pos.shift(1, fill_value=False))
     cont_mask  = pos & ( pos.shift(1, fill_value=False))
@@ -106,8 +107,8 @@ def backtest_snapshot(df: pd.DataFrame,
     R_gross = np.where(entry_mask, r_entry, 0.0) + np.where(cont_mask, r_cont, 0.0)
     R_gross = pd.Series(R_gross, index=df.index).fillna(0.0)
 
-    fee = fee_bps / 10_000.0
-    slip = slip_bps / 10_000.0
+    fee = fee_bps / BPS_PER_UNIT
+    slip = slip_bps / BPS_PER_UNIT
     entry_mult = (1.0 - fee) / (1.0 + slip)
     exit_mult = (1.0 - fee) * (1.0 - slip)
 
@@ -121,10 +122,10 @@ def backtest_snapshot(df: pd.DataFrame,
     eq_net = (1.0 + R_net).cumprod()
 
     peak = eq_net.cummax().clip(lower=1.0)
-    max_drawdown_pct = float((eq_net / peak - 1.0).min() * 100.0)
+    max_drawdown_bps = float((eq_net / peak - 1.0).min() * BPS_PER_UNIT)
 
-    total_return_gross_pct = float((eq_gross.iloc[-1] - 1.0) * 100.0)
-    total_return_net_pct = float((eq_net.iloc[-1]   - 1.0) * 100.0)
+    total_return_gross_bps = float((eq_gross.iloc[-1] - 1.0) * BPS_PER_UNIT)
+    total_return_net_bps = float((eq_net.iloc[-1]   - 1.0) * BPS_PER_UNIT)
 
     run_ids = entry_mask.cumsum()
     trade_returns = (
@@ -134,13 +135,13 @@ def backtest_snapshot(df: pd.DataFrame,
     if trade_returns.size:
         wins = trade_returns[trade_returns > 0]
         losses = trade_returns[trade_returns < 0]
-        trade_win_rate_pct = float((wins.size / trade_returns.size) * 100.0)
-        trade_expectancy_pct = float(trade_returns.mean() * 100.0)
-        trade_return_mean_win_pct = float(wins.mean() * 100.0) if wins.size else np.nan
-        trade_return_mean_loss_pct = float(losses.mean() * 100.0) if losses.size else np.nan
+        trade_win_rate_bps = float((wins.size / trade_returns.size) * BPS_PER_UNIT)
+        trade_expectancy_bps = float(trade_returns.mean() * BPS_PER_UNIT)
+        trade_return_mean_win_bps = float(wins.mean() * BPS_PER_UNIT) if wins.size else np.nan
+        trade_return_mean_loss_bps = float(losses.mean() * BPS_PER_UNIT) if losses.size else np.nan
     else:
-        trade_win_rate_pct = trade_expectancy_pct = np.nan
-        trade_return_mean_win_pct = trade_return_mean_loss_pct = np.nan
+        trade_win_rate_bps = trade_expectancy_bps = np.nan
+        trade_return_mean_win_bps = trade_return_mean_loss_bps = np.nan
 
     kelly_returns = trade_returns
 
@@ -152,9 +153,9 @@ def backtest_snapshot(df: pd.DataFrame,
         avg_win = float(kelly_wins.mean())
         avg_loss = abs(float(kelly_losses.mean()))
         payout_ratio = avg_win / avg_loss if avg_loss > 0 else np.nan
-        mean_kelly_pct = float((win_rate - (loss_rate / payout_ratio)) * 100.0) if payout_ratio > 0 else np.nan
+        mean_kelly_bps = float((win_rate - (loss_rate / payout_ratio)) * BPS_PER_UNIT) if payout_ratio > 0 else np.nan
     else:
-        mean_kelly_pct = np.nan
+        mean_kelly_bps = np.nan
 
     eval_returns = R_net[eval_mask]
     mu = float(eval_returns.mean()) if eval_returns.size else np.nan
@@ -163,19 +164,19 @@ def backtest_snapshot(df: pd.DataFrame,
     sharpe_per_bar = float(mu / sd) if sd > 0 else np.nan
 
     data = pd.DataFrame.from_records([{
-        'trade_win_rate_pct': round(trade_win_rate_pct, 1),
-        'trade_expectancy_pct': round(trade_expectancy_pct, 3),
-        'max_drawdown_pct': round(max_drawdown_pct, 1),
-        'total_return_gross_pct': round(total_return_gross_pct, 1),
-        'total_return_net_pct': round(total_return_net_pct, 1),
-        'trade_return_mean_win_pct': round(trade_return_mean_win_pct, 1),
-        'trade_return_mean_loss_pct': round(trade_return_mean_loss_pct, 1),
-        'mean_kelly_pct': round(mean_kelly_pct, 3),
+        'trade_win_rate_bps': round(trade_win_rate_bps, 1),
+        'trade_expectancy_bps': round(trade_expectancy_bps, 1),
+        'max_drawdown_bps': round(max_drawdown_bps, 1),
+        'total_return_gross_bps': round(total_return_gross_bps, 1),
+        'total_return_net_bps': round(total_return_net_bps, 1),
+        'trade_return_mean_win_bps': round(trade_return_mean_win_bps, 1),
+        'trade_return_mean_loss_bps': round(trade_return_mean_loss_bps, 1),
+        'mean_kelly_bps': round(mean_kelly_bps, 1),
         'bars_total': int(bars_total),
         'sharpe_per_bar': round(sharpe_per_bar, 2),
-        'bars_in_market_pct': round(bars_in_market_pct, 1),
+        'bars_in_market_bps': round(bars_in_market_bps, 1),
         'trades_count': int(trades_count),
-        'cost_round_trip_bps': round((1.0 - (entry_mult * exit_mult)) * 10_000),
+        'cost_round_trip_bps': round((1.0 - (entry_mult * exit_mult)) * BPS_PER_UNIT),
     }])
 
     return data

--- a/limen/log/_experiment_backtest_results.py
+++ b/limen/log/_experiment_backtest_results.py
@@ -88,8 +88,8 @@ def _experiment_backtest_results(self: Any, disable_progress_bar: bool = False) 
                       'trade_expectancy_bps', 'max_drawdown_bps',
                       'total_return_gross_bps', 'total_return_net_bps',
                       'trade_return_mean_win_bps', 'trade_return_mean_loss_bps',
-                      'bars_total', 'sharpe_per_bar', 'bars_in_market_bps',
-                      'trades_count', 'cost_round_trip_bps'
+                      'mean_kelly_bps', 'bars_total', 'sharpe_per_bar',
+                      'bars_in_market_bps', 'trades_count', 'cost_round_trip_bps'
     '''
 
     all_rows = []

--- a/limen/log/_experiment_backtest_results.py
+++ b/limen/log/_experiment_backtest_results.py
@@ -84,11 +84,11 @@ def _experiment_backtest_results(self: Any, disable_progress_bar: bool = False) 
         disable_progress_bar (bool): Whether to disable the progress bar
 
     Returns:
-        pd.DataFrame: One-row-per-round table with columns 'trade_win_rate_pct',
-                      'trade_expectancy_pct', 'max_drawdown_pct',
-                      'total_return_gross_pct', 'total_return_net_pct',
-                      'trade_return_mean_win_pct', 'trade_return_mean_loss_pct',
-                      'bars_total', 'sharpe_per_bar', 'bars_in_market_pct',
+        pd.DataFrame: One-row-per-round table with columns 'trade_win_rate_bps',
+                      'trade_expectancy_bps', 'max_drawdown_bps',
+                      'total_return_gross_bps', 'total_return_net_bps',
+                      'trade_return_mean_win_bps', 'trade_return_mean_loss_bps',
+                      'bars_total', 'sharpe_per_bar', 'bars_in_market_bps',
                       'trades_count', 'cost_round_trip_bps'
     '''
 

--- a/limen/log/_experiment_backtest_results.py
+++ b/limen/log/_experiment_backtest_results.py
@@ -84,12 +84,7 @@ def _experiment_backtest_results(self: Any, disable_progress_bar: bool = False) 
         disable_progress_bar (bool): Whether to disable the progress bar
 
     Returns:
-        pd.DataFrame: One-row-per-round table with columns 'trade_win_rate_bps',
-                      'trade_expectancy_bps', 'max_drawdown_bps',
-                      'total_return_gross_bps', 'total_return_net_bps',
-                      'trade_return_mean_win_bps', 'trade_return_mean_loss_bps',
-                      'mean_kelly_bps', 'bars_total', 'sharpe_per_bar',
-                      'bars_in_market_bps', 'trades_count', 'cost_round_trip_bps'
+        pd.DataFrame: One-row-per-round table with BACKTEST_SNAPSHOT_COLUMNS
     '''
 
     all_rows = []

--- a/limen/log/_permutation_prediction_performance.py
+++ b/limen/log/_permutation_prediction_performance.py
@@ -12,7 +12,7 @@ def _permutation_prediction_performance(self: Any,
         round_id (int): Round ID (i.e. nth permutation in an experiment)
 
     Returns:
-        pd.DataFrame: Table with columns 'predictions', 'actuals', 'hit', 'miss', 'open', 'close', 'price_change'
+        pd.DataFrame: Table with predictions, actuals, hit/miss, datetime, open, close, and price_change
     '''
 
     try:
@@ -31,6 +31,8 @@ def _permutation_prediction_performance(self: Any,
     perf_df['miss'] = perf_df['predictions'] != perf_df['actuals']
 
     price_df = self._get_test_data_with_all_cols(round_id)
+    if 'datetime' in price_df.columns:
+        perf_df['datetime'] = price_df['datetime']
     perf_df['open'] = price_df['open']
     perf_df['close'] = price_df['close']
     perf_df['price_change'] = price_df['close'] - price_df['open']

--- a/limen/metrics/rule_based_metrics.py
+++ b/limen/metrics/rule_based_metrics.py
@@ -48,7 +48,7 @@ def rule_based_metrics(positions: dict,
             results[f'{k}_{split}'] = v
 
     sharpes = [split_bt[s].get('sharpe_per_bar') for s in _SPLITS]
-    drawdowns = [split_bt[s].get('max_drawdown_pct') for s in _SPLITS]
+    drawdowns = [split_bt[s].get('max_drawdown_bps') for s in _SPLITS]
 
     valid_sharpes = [s for s in sharpes if s is not None and not np.isnan(s)]
     valid_drawdowns = [d for d in drawdowns if d is not None and not np.isnan(d)]

--- a/limen/metrics/rule_based_metrics.py
+++ b/limen/metrics/rule_based_metrics.py
@@ -28,12 +28,14 @@ def rule_based_metrics(positions: dict,
     Args:
         positions (dict): Per-split position arrays (0/1) keyed by 'train', 'val', 'test'
         backtest_results (dict): Per-split backtest metric dicts keyed by 'train', 'val', 'test'
-        sharpe_std_threshold (float): Max sharpe_std for is_stable to be True
-        sharpe_degradation_threshold (float): Max sharpe_degradation for is_stable to be True
+        sharpe_std_threshold (float): Legacy parameter retained for call compatibility
+        sharpe_degradation_threshold (float): Legacy parameter retained for call compatibility
 
     Returns:
         dict: Tier 1 position stats, Tier 2 backtest metrics per split, Tier 3 stability metrics
     '''
+
+    _ = (sharpe_std_threshold, sharpe_degradation_threshold)
 
     results: dict[str, Any] = {}
     split_bt: dict[str, dict] = {}
@@ -47,28 +49,13 @@ def rule_based_metrics(positions: dict,
         for k, v in bt.items():
             results[f'{k}_{split}'] = v
 
-    sharpes = [split_bt[s].get('sharpe_per_bar') for s in _SPLITS]
-    drawdowns = [split_bt[s].get('max_drawdown_bps') for s in _SPLITS]
+    drawdowns = [split_bt[s].get('drawdown_depth_bps_p5') for s in _SPLITS]
 
-    valid_sharpes = [s for s in sharpes if s is not None and not np.isnan(s)]
     valid_drawdowns = [d for d in drawdowns if d is not None and not np.isnan(d)]
 
-    sharpe_std = float(np.std(valid_sharpes, ddof=1)) if len(valid_sharpes) >= _MIN_SPLITS else float('nan')
     drawdown_std_bps = float(np.std(valid_drawdowns, ddof=1)) if len(valid_drawdowns) >= _MIN_SPLITS else float('nan')
 
-    sharpe_train, sharpe_test = sharpes[0], sharpes[2]
-    if (sharpe_train is not None and sharpe_test is not None
-            and not np.isnan(sharpe_train) and abs(sharpe_train) > 0):
-        sharpe_degradation = (sharpe_train - sharpe_test) / abs(sharpe_train)
-    else:
-        sharpe_degradation = float('nan')
-
-    results['sharpe_std'] = _round_or_none(sharpe_std)
     results['drawdown_std_bps'] = _round_or_none(drawdown_std_bps)
-    results['sharpe_degradation'] = _round_or_none(sharpe_degradation)
-    results['is_stable'] = (
-        not np.isnan(sharpe_std) and sharpe_std < sharpe_std_threshold
-        and not np.isnan(sharpe_degradation) and sharpe_degradation < sharpe_degradation_threshold
-    )
+    results['is_stable'] = False
 
     return results

--- a/limen/metrics/rule_based_metrics.py
+++ b/limen/metrics/rule_based_metrics.py
@@ -54,7 +54,7 @@ def rule_based_metrics(positions: dict,
     valid_drawdowns = [d for d in drawdowns if d is not None and not np.isnan(d)]
 
     sharpe_std = float(np.std(valid_sharpes, ddof=1)) if len(valid_sharpes) >= _MIN_SPLITS else float('nan')
-    drawdown_std = float(np.std(valid_drawdowns, ddof=1)) if len(valid_drawdowns) >= _MIN_SPLITS else float('nan')
+    drawdown_std_bps = float(np.std(valid_drawdowns, ddof=1)) if len(valid_drawdowns) >= _MIN_SPLITS else float('nan')
 
     sharpe_train, sharpe_test = sharpes[0], sharpes[2]
     if (sharpe_train is not None and sharpe_test is not None
@@ -64,7 +64,7 @@ def rule_based_metrics(positions: dict,
         sharpe_degradation = float('nan')
 
     results['sharpe_std'] = _round_or_none(sharpe_std)
-    results['drawdown_std'] = _round_or_none(drawdown_std)
+    results['drawdown_std_bps'] = _round_or_none(drawdown_std_bps)
     results['sharpe_degradation'] = _round_or_none(sharpe_degradation)
     results['is_stable'] = (
         not np.isnan(sharpe_std) and sharpe_std < sharpe_std_threshold

--- a/limen/sfd/reference_architecture/base.py
+++ b/limen/sfd/reference_architecture/base.py
@@ -140,12 +140,16 @@ class ReferenceModel(ABC):
 
         price_pd = self._price_data_to_pandas(data['price_data_for_backtest'])
 
-        bt_input = pd.DataFrame({
+        bt_input_data = {
             'predictions': np.asarray(preds).astype(int),
             'open': price_pd['open'].values,
             'close': price_pd['close'].values,
             'price_change': (price_pd['close'] - price_pd['open']).values,
-        })
+        }
+        if 'datetime' in price_pd:
+            bt_input_data['datetime'] = price_pd['datetime'].values
+
+        bt_input = pd.DataFrame(bt_input_data)
 
         bt_result = backtest_snapshot(bt_input, execution_lag_bars=1)
 

--- a/limen/sfd/reference_architecture/rule_based.py
+++ b/limen/sfd/reference_architecture/rule_based.py
@@ -113,12 +113,16 @@ class RuleBasedStrategy(ReferenceModel):
             return {}
         open_arr = df['open'].to_numpy().astype(float)
         close_arr = df['close'].to_numpy().astype(float)
-        bt_input = pd.DataFrame({
+        bt_input_data = {
             'predictions': positions,
             'open': open_arr,
             'close': close_arr,
             'price_change': close_arr - open_arr,
-        })
+        }
+        if 'datetime' in df.columns:
+            bt_input_data['datetime'] = df['datetime'].to_numpy()
+
+        bt_input = pd.DataFrame(bt_input_data)
         bt_result = backtest_snapshot(bt_input, execution_lag_bars=1)
         if bt_result.empty:
             return {}

--- a/tests/run.py
+++ b/tests/run.py
@@ -181,7 +181,7 @@ from tests.test_splits import test_split_by_dates_rejects_non_date_bounds
 from tests.test_rule_based_metrics import test_num_trades_counts_entries_not_bars
 from tests.test_rule_based_metrics import test_position_rate
 from tests.test_rule_based_metrics import test_backtest_metrics_flattened_with_split_suffix
-from tests.test_rule_based_metrics import test_sharpe_std_and_drawdown_std
+from tests.test_rule_based_metrics import test_sharpe_std_and_drawdown_std_bps
 from tests.test_rule_based_metrics import test_sharpe_degradation
 from tests.test_rule_based_metrics import test_is_stable_true_when_within_thresholds
 from tests.test_rule_based_metrics import test_is_stable_false_when_sharpe_std_exceeds_threshold
@@ -751,7 +751,7 @@ tests = [
     test_num_trades_counts_entries_not_bars,
     test_position_rate,
     test_backtest_metrics_flattened_with_split_suffix,
-    test_sharpe_std_and_drawdown_std,
+    test_sharpe_std_and_drawdown_std_bps,
     test_sharpe_degradation,
     test_is_stable_true_when_within_thresholds,
     test_is_stable_false_when_sharpe_std_exceeds_threshold,

--- a/tests/run.py
+++ b/tests/run.py
@@ -181,10 +181,8 @@ from tests.test_splits import test_split_by_dates_rejects_non_date_bounds
 from tests.test_rule_based_metrics import test_num_trades_counts_entries_not_bars
 from tests.test_rule_based_metrics import test_position_rate
 from tests.test_rule_based_metrics import test_backtest_metrics_flattened_with_split_suffix
-from tests.test_rule_based_metrics import test_sharpe_std_and_drawdown_std_bps
-from tests.test_rule_based_metrics import test_sharpe_degradation
-from tests.test_rule_based_metrics import test_is_stable_true_when_within_thresholds
-from tests.test_rule_based_metrics import test_is_stable_false_when_sharpe_std_exceeds_threshold
+from tests.test_rule_based_metrics import test_drawdown_std_bps
+from tests.test_rule_based_metrics import test_is_stable_false_without_legacy_sharpe_surface
 from tests.test_rule_based_metrics import test_missing_backtest_results_degrade_gracefully
 from tests.test_manifest_rule_based import test_with_strategy_sets_sentinel_and_returns_self
 from tests.test_manifest_rule_based import test_prepare_data_rule_based_returns_split_dataframes
@@ -333,6 +331,7 @@ from tests.test_manifest_prepare_data import test_pca_compression_rejects_nonnum
 from tests.test_inline_metrics import test_inline_and_post_experiment_metrics
 from tests.test_inline_metrics import test_logreg_inline_and_post_confusion_metrics_match
 from tests.test_inline_metrics import test_xgboost_inline_and_post_backtest_metrics_match
+from tests.test_metrics_and_log_helpers import test_backtest_snapshot_emits_metric_ledger_columns
 from tests.test_metrics_and_log_helpers import test_backtest_snapshot_executes_on_next_bar
 from tests.test_metrics_and_log_helpers import test_backtest_snapshot_preserves_shifted_hold_while_one_continuation
 from tests.test_metrics_and_log_helpers import test_backtest_snapshot_applies_costs_multiplicatively_per_fill
@@ -751,10 +750,8 @@ tests = [
     test_num_trades_counts_entries_not_bars,
     test_position_rate,
     test_backtest_metrics_flattened_with_split_suffix,
-    test_sharpe_std_and_drawdown_std_bps,
-    test_sharpe_degradation,
-    test_is_stable_true_when_within_thresholds,
-    test_is_stable_false_when_sharpe_std_exceeds_threshold,
+    test_drawdown_std_bps,
+    test_is_stable_false_without_legacy_sharpe_surface,
     test_missing_backtest_results_degrade_gracefully,
     test_with_strategy_sets_sentinel_and_returns_self,
     test_prepare_data_rule_based_returns_split_dataframes,
@@ -944,6 +941,7 @@ tests = [
     test_inline_and_post_experiment_metrics,
     test_logreg_inline_and_post_confusion_metrics_match,
     test_xgboost_inline_and_post_backtest_metrics_match,
+    test_backtest_snapshot_emits_metric_ledger_columns,
     test_backtest_snapshot_executes_on_next_bar,
     test_backtest_snapshot_preserves_shifted_hold_while_one_continuation,
     test_backtest_snapshot_applies_costs_multiplicatively_per_fill,

--- a/tests/test_foundational_sfd.py
+++ b/tests/test_foundational_sfd.py
@@ -62,7 +62,7 @@ def test_foundational_sfd():
                     log = uel.experiment_log
                     assert log is not None, 'experiment_log is None'
                     assert 'num_trades_test' in log.columns, 'num_trades_test missing from log'
-                    assert 'sharpe_per_bar_test' in log.columns, 'sharpe_per_bar_test missing from log'
+                    assert 'trade_pnl_net_bps_p50_test' in log.columns, 'trade_pnl_net_bps_p50_test missing from log'
                     assert 'is_stable' in log.columns, 'is_stable missing from log'
                     assert uel.experiment_confusion_metrics is None, 'experiment_confusion_metrics should be None for rule-based'
                     assert uel.experiment_backtest_results is None, 'experiment_backtest_results should be None for rule-based'

--- a/tests/test_inline_metrics.py
+++ b/tests/test_inline_metrics.py
@@ -49,12 +49,12 @@ def test_inline_and_post_experiment_metrics() -> None:
                 'confusion_tn_mean_return_pct', 'confusion_fn_mean_return_pct']:
         assert col in log_cols, f"Missing inline confusion return column: {col}"
 
-    for col in ['backtest_trade_win_rate_pct', 'backtest_max_drawdown_pct',
-                'backtest_total_return_net_pct', 'backtest_sharpe_per_bar']:
+    for col in ['backtest_trade_win_rate_bps', 'backtest_max_drawdown_bps',
+                'backtest_total_return_net_bps', 'backtest_sharpe_per_bar']:
         assert col in log_cols, f"Missing inline backtest column: {col}"
         assert uel.experiment_log[col].null_count() == 0, f"Null values in {col}"
 
-    assert 'backtest_mean_kelly_pct' in log_cols
+    assert 'backtest_mean_kelly_bps' in log_cols
 
     assert uel.experiment_confusion_metrics is not None
     assert len(uel.experiment_confusion_metrics) > 0
@@ -62,10 +62,10 @@ def test_inline_and_post_experiment_metrics() -> None:
         assert col in uel.experiment_confusion_metrics.columns, f"Missing confusion metric column: {col}"
     assert uel.experiment_backtest_results is not None
     assert len(uel.experiment_backtest_results) > 0
-    assert 'mean_kelly_pct' in uel.experiment_backtest_results.columns
+    assert 'mean_kelly_bps' in uel.experiment_backtest_results.columns
 
-    assert uel.experiment_log['backtest_total_return_net_pct'].to_list() == \
-        uel.experiment_backtest_results['total_return_net_pct'].tolist()
+    assert uel.experiment_log['backtest_total_return_net_bps'].to_list() == \
+        uel.experiment_backtest_results['total_return_net_bps'].tolist()
 
 
 def test_logreg_inline_and_post_confusion_metrics_match() -> None:
@@ -93,5 +93,5 @@ def test_xgboost_inline_and_post_backtest_metrics_match() -> None:
 
     uel = _run_uel(sfd_module=xgboost_sfd, n_permutations=1)
 
-    assert uel.experiment_log['backtest_total_return_net_pct'].to_list() == \
-        uel.experiment_backtest_results['total_return_net_pct'].tolist()
+    assert uel.experiment_log['backtest_total_return_net_bps'].to_list() == \
+        uel.experiment_backtest_results['total_return_net_bps'].tolist()

--- a/tests/test_inline_metrics.py
+++ b/tests/test_inline_metrics.py
@@ -3,6 +3,7 @@ from tempfile import TemporaryDirectory
 
 import math
 
+from limen.backtest.backtest_snapshot import BACKTEST_SNAPSHOT_COLUMNS
 from limen.experiment.experiment_core import UniversalExperimentLoop
 from limen.experiment.param_domain import ParamDomain
 from limen.sfd.foundational_sfd import logreg_binary as logreg_binary_sfd
@@ -49,12 +50,10 @@ def test_inline_and_post_experiment_metrics() -> None:
                 'confusion_tn_mean_return_pct', 'confusion_fn_mean_return_pct']:
         assert col in log_cols, f"Missing inline confusion return column: {col}"
 
-    for col in ['backtest_trade_win_rate_bps', 'backtest_max_drawdown_bps',
-                'backtest_total_return_net_bps', 'backtest_sharpe_per_bar']:
+    for metric_col in BACKTEST_SNAPSHOT_COLUMNS:
+        col = f'backtest_{metric_col}'
         assert col in log_cols, f"Missing inline backtest column: {col}"
         assert uel.experiment_log[col].null_count() == 0, f"Null values in {col}"
-
-    assert 'backtest_mean_kelly_bps' in log_cols
 
     assert uel.experiment_confusion_metrics is not None
     assert len(uel.experiment_confusion_metrics) > 0
@@ -62,10 +61,10 @@ def test_inline_and_post_experiment_metrics() -> None:
         assert col in uel.experiment_confusion_metrics.columns, f"Missing confusion metric column: {col}"
     assert uel.experiment_backtest_results is not None
     assert len(uel.experiment_backtest_results) > 0
-    assert 'mean_kelly_bps' in uel.experiment_backtest_results.columns
+    assert uel.experiment_backtest_results.columns.tolist() == BACKTEST_SNAPSHOT_COLUMNS
 
-    assert uel.experiment_log['backtest_total_return_net_bps'].to_list() == \
-        uel.experiment_backtest_results['total_return_net_bps'].tolist()
+    assert uel.experiment_log['backtest_trade_pnl_net_bps_p50'].to_list() == \
+        uel.experiment_backtest_results['trade_pnl_net_bps_p50'].tolist()
 
 
 def test_logreg_inline_and_post_confusion_metrics_match() -> None:
@@ -93,5 +92,5 @@ def test_xgboost_inline_and_post_backtest_metrics_match() -> None:
 
     uel = _run_uel(sfd_module=xgboost_sfd, n_permutations=1)
 
-    assert uel.experiment_log['backtest_total_return_net_bps'].to_list() == \
-        uel.experiment_backtest_results['total_return_net_bps'].tolist()
+    assert uel.experiment_log['backtest_trade_pnl_net_bps_p50'].to_list() == \
+        uel.experiment_backtest_results['trade_pnl_net_bps_p50'].tolist()

--- a/tests/test_metrics_and_log_helpers.py
+++ b/tests/test_metrics_and_log_helpers.py
@@ -5,6 +5,7 @@ import pytest
 from sklearn.metrics import accuracy_score, precision_score, recall_score
 from typing import ClassVar
 
+from limen.backtest.backtest_snapshot import BACKTEST_SNAPSHOT_COLUMNS
 from limen.backtest.backtest_snapshot import backtest_snapshot
 from limen.log._experiment_backtest_results import _experiment_backtest_results
 from limen.log._experiment_backtest_results import _prepare_snapshot_backtest_input
@@ -235,10 +236,11 @@ def test_permutation_confusion_metrics_keeps_mean_returns_on_unfiltered_rows() -
     assert result['fn_mean_return_pct'] == 5.0
 
 
-def test_backtest_snapshot_adds_mean_kelly_bps() -> None:
+def test_backtest_snapshot_emits_metric_ledger_columns() -> None:
     result = backtest_snapshot(
         pd.DataFrame({
             'predictions': [1, 0, 1, 0],
+            'datetime': pd.date_range('2025-01-01', periods=4, freq='D'),
             'open': [100.0, 100.0, 100.0, 100.0],
             'close': [120.0, 100.0, 90.0, 100.0],
             'price_change': [20.0, 0.0, -10.0, 0.0],
@@ -248,13 +250,17 @@ def test_backtest_snapshot_adds_mean_kelly_bps() -> None:
         slip_bps=0.0,
     ).iloc[0]
 
-    assert result['mean_kelly_bps'] == 2500.0
+    assert result.index.tolist() == BACKTEST_SNAPSHOT_COLUMNS
+    assert result['edge_per_signal_bps_p50'] == 500.0
+    assert result['trade_pnl_net_bps_p50'] == 500.0
+    assert result['cvar_95_return_bps'] == -1000.0
 
 
 def test_backtest_snapshot_executes_on_next_bar() -> None:
     result = backtest_snapshot(
         pd.DataFrame({
             'predictions': [1, 0, 0],
+            'datetime': pd.date_range('2025-01-01', periods=3, freq='D'),
             'open': [100.0, 100.0, 100.0],
             'close': [110.0, 90.0, 100.0],
             'price_change': [10.0, -10.0, 0.0],
@@ -263,16 +269,16 @@ def test_backtest_snapshot_executes_on_next_bar() -> None:
         slip_bps=0.0,
     ).iloc[0]
 
-    assert result['bars_total'] == 2
-    assert result['trades_count'] == 1
-    assert result['bars_in_market_bps'] == 5000.0
-    assert result['total_return_net_bps'] == -1000.0
+    assert result['edge_per_signal_bps_p50'] == -1000.0
+    assert result['trade_pnl_net_bps_p50'] == -1000.0
+    assert result['rolling_return_net_bps_p50'] == -500.0
 
 
 def test_backtest_snapshot_preserves_shifted_hold_while_one_continuation() -> None:
     result = backtest_snapshot(
         pd.DataFrame({
             'predictions': [1, 1, 0],
+            'datetime': pd.date_range('2025-01-01', periods=3, freq='D'),
             'open': [100.0, 100.0, 110.0],
             'close': [100.0, 110.0, 121.0],
             'price_change': [0.0, 10.0, 11.0],
@@ -281,12 +287,9 @@ def test_backtest_snapshot_preserves_shifted_hold_while_one_continuation() -> No
         slip_bps=0.0,
     ).iloc[0]
 
-    assert result['trades_count'] == 1
-    assert result['total_return_gross_bps'] == 2100.0
-    assert result['total_return_net_bps'] == 2100.0
-    assert result['trade_win_rate_bps'] == 10000.0
-    assert result['trade_expectancy_bps'] == 2100.0
-    assert result['trade_return_mean_win_bps'] == 2100.0
+    assert result['edge_per_signal_bps_p50'] == 1000.0
+    assert result['trade_pnl_net_bps_p50'] == 2100.0
+    assert result['cost_drag_bps_p50'] == 0.0
 
 
 def test_backtest_snapshot_rejects_empty_input() -> None:
@@ -353,6 +356,7 @@ def test_backtest_snapshot_applies_costs_multiplicatively_per_fill() -> None:
     result = backtest_snapshot(
         pd.DataFrame({
             'predictions': [1],
+            'datetime': pd.date_range('2025-01-01', periods=1, freq='D'),
             'open': [100.0],
             'close': [100.0],
             'price_change': [0.0],
@@ -362,14 +366,15 @@ def test_backtest_snapshot_applies_costs_multiplicatively_per_fill() -> None:
         slip_bps=50.0,
     ).iloc[0]
 
-    assert result['cost_round_trip_bps'] == 198
-    assert result['trade_expectancy_bps'] == -198.3
+    assert result['cost_drag_bps_p50'] == 198.3
+    assert result['trade_pnl_net_bps_p50'] == -198.3
 
 
 def test_backtest_snapshot_drawdown_includes_starting_equity_peak() -> None:
     result = backtest_snapshot(
         pd.DataFrame({
             'predictions': [1],
+            'datetime': pd.date_range('2025-01-01', periods=1, freq='D'),
             'open': [100.0],
             'close': [90.0],
             'price_change': [-10.0],
@@ -379,13 +384,14 @@ def test_backtest_snapshot_drawdown_includes_starting_equity_peak() -> None:
         slip_bps=0.0,
     ).iloc[0]
 
-    assert result['max_drawdown_bps'] == -1000.0
+    assert result['drawdown_depth_bps_p50'] == -1000.0
 
 
 def test_backtest_snapshot_drops_predictions_without_immediate_next_execution_bar() -> None:
     result = backtest_snapshot(
         pd.DataFrame({
             'predictions': [1, 0, 0],
+            'datetime': pd.date_range('2025-01-01', periods=3, freq='D'),
             'open': [100.0, np.nan, 100.0],
             'close': [100.0, np.nan, 100.0],
             'price_change': [0.0, np.nan, 0.0],
@@ -394,9 +400,9 @@ def test_backtest_snapshot_drops_predictions_without_immediate_next_execution_ba
         slip_bps=0.0,
     ).iloc[0]
 
-    assert result['bars_total'] == 1
-    assert result['trades_count'] == 0
-    assert result['total_return_net_bps'] == 0.0
+    assert np.isnan(result['edge_per_signal_bps_p50'])
+    assert np.isnan(result['trade_pnl_net_bps_p50'])
+    assert result['rolling_return_net_bps_p50'] == 0.0
 
 
 def test_completed_bar_signal_proves_next_bar_alignment() -> None:
@@ -415,8 +421,8 @@ def test_completed_bar_signal_proves_next_bar_alignment() -> None:
         slip_bps=0.0,
     ).iloc[0]
 
-    assert same_row['total_return_net_bps'] == 2100.0
-    assert next_bar['total_return_net_bps'] == -1900.0
+    assert same_row['trade_pnl_net_bps_p50'] == 1000.0
+    assert next_bar['trade_pnl_net_bps_p50'] == -1000.0
 
 
 def test_experiment_backtest_results_directionalizes_regression_predictions() -> None:
@@ -435,7 +441,7 @@ def test_experiment_backtest_results_directionalizes_regression_predictions() ->
         execution_lag_bars=1,
     ).iloc[0]
 
-    assert result['total_return_net_bps'] == expected['total_return_net_bps']
+    assert result['trade_pnl_net_bps_p50'] == expected['trade_pnl_net_bps_p50']
 
 
 def test_prepare_snapshot_backtest_input_rejects_multiclass() -> None:

--- a/tests/test_metrics_and_log_helpers.py
+++ b/tests/test_metrics_and_log_helpers.py
@@ -235,7 +235,7 @@ def test_permutation_confusion_metrics_keeps_mean_returns_on_unfiltered_rows() -
     assert result['fn_mean_return_pct'] == 5.0
 
 
-def test_backtest_snapshot_adds_mean_kelly_pct() -> None:
+def test_backtest_snapshot_adds_mean_kelly_bps() -> None:
     result = backtest_snapshot(
         pd.DataFrame({
             'predictions': [1, 0, 1, 0],
@@ -248,7 +248,7 @@ def test_backtest_snapshot_adds_mean_kelly_pct() -> None:
         slip_bps=0.0,
     ).iloc[0]
 
-    assert result['mean_kelly_pct'] == 25.0
+    assert result['mean_kelly_bps'] == 2500.0
 
 
 def test_backtest_snapshot_executes_on_next_bar() -> None:
@@ -265,8 +265,8 @@ def test_backtest_snapshot_executes_on_next_bar() -> None:
 
     assert result['bars_total'] == 2
     assert result['trades_count'] == 1
-    assert result['bars_in_market_pct'] == 50.0
-    assert result['total_return_net_pct'] == -10.0
+    assert result['bars_in_market_bps'] == 5000.0
+    assert result['total_return_net_bps'] == -1000.0
 
 
 def test_backtest_snapshot_preserves_shifted_hold_while_one_continuation() -> None:
@@ -282,11 +282,11 @@ def test_backtest_snapshot_preserves_shifted_hold_while_one_continuation() -> No
     ).iloc[0]
 
     assert result['trades_count'] == 1
-    assert result['total_return_gross_pct'] == 21.0
-    assert result['total_return_net_pct'] == 21.0
-    assert result['trade_win_rate_pct'] == 100.0
-    assert result['trade_expectancy_pct'] == 21.0
-    assert result['trade_return_mean_win_pct'] == 21.0
+    assert result['total_return_gross_bps'] == 2100.0
+    assert result['total_return_net_bps'] == 2100.0
+    assert result['trade_win_rate_bps'] == 10000.0
+    assert result['trade_expectancy_bps'] == 2100.0
+    assert result['trade_return_mean_win_bps'] == 2100.0
 
 
 def test_backtest_snapshot_rejects_empty_input() -> None:
@@ -363,7 +363,7 @@ def test_backtest_snapshot_applies_costs_multiplicatively_per_fill() -> None:
     ).iloc[0]
 
     assert result['cost_round_trip_bps'] == 198
-    assert result['trade_expectancy_pct'] == -1.983
+    assert result['trade_expectancy_bps'] == -198.3
 
 
 def test_backtest_snapshot_drawdown_includes_starting_equity_peak() -> None:
@@ -379,7 +379,7 @@ def test_backtest_snapshot_drawdown_includes_starting_equity_peak() -> None:
         slip_bps=0.0,
     ).iloc[0]
 
-    assert result['max_drawdown_pct'] == -10.0
+    assert result['max_drawdown_bps'] == -1000.0
 
 
 def test_backtest_snapshot_drops_predictions_without_immediate_next_execution_bar() -> None:
@@ -396,7 +396,7 @@ def test_backtest_snapshot_drops_predictions_without_immediate_next_execution_ba
 
     assert result['bars_total'] == 1
     assert result['trades_count'] == 0
-    assert result['total_return_net_pct'] == 0.0
+    assert result['total_return_net_bps'] == 0.0
 
 
 def test_completed_bar_signal_proves_next_bar_alignment() -> None:
@@ -415,8 +415,8 @@ def test_completed_bar_signal_proves_next_bar_alignment() -> None:
         slip_bps=0.0,
     ).iloc[0]
 
-    assert same_row['total_return_net_pct'] == 21.0
-    assert next_bar['total_return_net_pct'] == -19.0
+    assert same_row['total_return_net_bps'] == 2100.0
+    assert next_bar['total_return_net_bps'] == -1900.0
 
 
 def test_experiment_backtest_results_directionalizes_regression_predictions() -> None:
@@ -435,7 +435,7 @@ def test_experiment_backtest_results_directionalizes_regression_predictions() ->
         execution_lag_bars=1,
     ).iloc[0]
 
-    assert result['total_return_net_pct'] == expected['total_return_net_pct']
+    assert result['total_return_net_bps'] == expected['total_return_net_bps']
 
 
 def test_prepare_snapshot_backtest_input_rejects_multiclass() -> None:

--- a/tests/test_reference_architecture.py
+++ b/tests/test_reference_architecture.py
@@ -76,9 +76,9 @@ def test_xgboost_evaluate_returns_all_metric_types():
                 'confusion_tn_mean_return_pct', 'confusion_fn_mean_return_pct']:
         assert key in results, f"Missing confusion key: {key}"
 
-    for key in ['backtest_trade_win_rate_pct', 'backtest_max_drawdown_pct',
-                'backtest_total_return_net_pct', 'backtest_sharpe_per_bar',
-                'backtest_mean_kelly_pct']:
+    for key in ['backtest_trade_win_rate_bps', 'backtest_max_drawdown_bps',
+                'backtest_total_return_net_bps', 'backtest_sharpe_per_bar',
+                'backtest_mean_kelly_bps']:
         assert key in results, f"Missing backtest key: {key}"
 
     assert '_preds' in results

--- a/tests/test_reference_architecture.py
+++ b/tests/test_reference_architecture.py
@@ -206,7 +206,7 @@ def test_rule_based_evaluate_returns_expected_metrics():
         assert 0.0 <= rate <= 1.0
 
     assert isinstance(results['sharpe_std'], float)
-    assert isinstance(results['drawdown_std'], float)
+    assert isinstance(results['drawdown_std_bps'], float)
     assert isinstance(results['sharpe_degradation'], float)
     assert isinstance(results['is_stable'], bool)
 

--- a/tests/test_reference_architecture.py
+++ b/tests/test_reference_architecture.py
@@ -2,6 +2,7 @@ import numpy as np
 import pandas as pd
 import polars as pl
 
+from limen.backtest.backtest_snapshot import BACKTEST_SNAPSHOT_COLUMNS
 from limen.calibration import grid_threshold_optimizer
 from limen.calibration import sklearn_probability_calibrator
 from limen.experiment import CalibrationConfig
@@ -76,9 +77,8 @@ def test_xgboost_evaluate_returns_all_metric_types():
                 'confusion_tn_mean_return_pct', 'confusion_fn_mean_return_pct']:
         assert key in results, f"Missing confusion key: {key}"
 
-    for key in ['backtest_trade_win_rate_bps', 'backtest_max_drawdown_bps',
-                'backtest_total_return_net_bps', 'backtest_sharpe_per_bar',
-                'backtest_mean_kelly_bps']:
+    for metric_col in BACKTEST_SNAPSHOT_COLUMNS:
+        key = f'backtest_{metric_col}'
         assert key in results, f"Missing backtest key: {key}"
 
     assert '_preds' in results
@@ -205,9 +205,7 @@ def test_rule_based_evaluate_returns_expected_metrics():
         rate = results[f'position_rate_{split}']
         assert 0.0 <= rate <= 1.0
 
-    assert isinstance(results['sharpe_std'], float)
-    assert isinstance(results['drawdown_std_bps'], float)
-    assert isinstance(results['sharpe_degradation'], float)
+    assert results['drawdown_std_bps'] is None
     assert isinstance(results['is_stable'], bool)
 
     assert isinstance(results['_preds'], np.ndarray)
@@ -220,7 +218,7 @@ def test_rule_based_is_stable_respects_thresholds():
     results_loose = RuleBasedStrategy(sharpe_std_threshold=999.0,
                                       sharpe_degradation_threshold=999.0).train(data).evaluate(data)
     assert results_tight['is_stable'] is False
-    assert results_loose['is_stable'] is True
+    assert results_loose['is_stable'] is False
 
 
 def test_rule_based_function_returns_flat_dict():

--- a/tests/test_rule_based_metrics.py
+++ b/tests/test_rule_based_metrics.py
@@ -11,12 +11,11 @@ def _make_positions(train, val, test):
     }
 
 
-def _make_backtest(sharpe_train, sharpe_val, sharpe_test,
-                   drawdown_train, drawdown_val, drawdown_test):
+def _make_backtest(drawdown_train, drawdown_val, drawdown_test):
     return {
-        'train': {'sharpe_per_bar': sharpe_train, 'max_drawdown_bps': drawdown_train},
-        'val':   {'sharpe_per_bar': sharpe_val,   'max_drawdown_bps': drawdown_val},
-        'test':  {'sharpe_per_bar': sharpe_test,  'max_drawdown_bps': drawdown_test},
+        'train': {'drawdown_depth_bps_p5': drawdown_train},
+        'val':   {'drawdown_depth_bps_p5': drawdown_val},
+        'test':  {'drawdown_depth_bps_p5': drawdown_test},
     }
 
 
@@ -38,48 +37,27 @@ def test_position_rate() -> None:
 
 def test_backtest_metrics_flattened_with_split_suffix() -> None:
     positions = _make_positions([1], [1], [1])
-    bt = _make_backtest(1.0, 0.8, 0.6, -5.0, -6.0, -8.0)
+    bt = _make_backtest(-5.0, -6.0, -8.0)
     result = rule_based_metrics(positions, bt)
-    assert 'sharpe_per_bar_train' in result
-    assert 'sharpe_per_bar_val' in result
-    assert 'sharpe_per_bar_test' in result
-    assert result['sharpe_per_bar_train'] == 1.0
-    assert result['max_drawdown_bps_test'] == -8.0
+    assert result['drawdown_depth_bps_p5_test'] == -8.0
 
 
-def test_sharpe_std_and_drawdown_std_bps() -> None:
+def test_drawdown_std_bps() -> None:
     positions = _make_positions([1], [1], [1])
-    bt = _make_backtest(1.0, 1.0, 1.0, -5.0, -5.0, -5.0)
+    bt = _make_backtest(-5.0, -5.0, -5.0)
     result = rule_based_metrics(positions, bt)
-    assert result['sharpe_std'] == 0.0
     assert result['drawdown_std_bps'] == 0.0
 
 
-def test_sharpe_degradation() -> None:
+def test_is_stable_false_without_legacy_sharpe_surface() -> None:
     positions = _make_positions([1], [1], [1])
-    bt = _make_backtest(1.0, 0.8, 0.5, -5.0, -5.0, -5.0)
+    bt = _make_backtest(-5.0, -5.0, -5.0)
     result = rule_based_metrics(positions, bt)
-    assert result['sharpe_degradation'] == 0.5
-
-
-def test_is_stable_true_when_within_thresholds() -> None:
-    positions = _make_positions([1], [1], [1])
-    bt = _make_backtest(1.0, 1.0, 1.0, -5.0, -5.0, -5.0)
-    result = rule_based_metrics(positions, bt, sharpe_std_threshold=0.5, sharpe_degradation_threshold=0.3)
-    assert result['is_stable'] is True
-
-
-def test_is_stable_false_when_sharpe_std_exceeds_threshold() -> None:
-    positions = _make_positions([1], [1], [1])
-    bt = _make_backtest(2.0, 0.0, -1.0, -5.0, -5.0, -5.0)
-    result = rule_based_metrics(positions, bt, sharpe_std_threshold=0.5, sharpe_degradation_threshold=0.3)
     assert result['is_stable'] is False
 
 
 def test_missing_backtest_results_degrade_gracefully() -> None:
     positions = _make_positions([1], [1], [1])
     result = rule_based_metrics(positions, {})
-    assert result['sharpe_std'] is None
     assert result['drawdown_std_bps'] is None
-    assert result['sharpe_degradation'] is None
     assert result['is_stable'] is False

--- a/tests/test_rule_based_metrics.py
+++ b/tests/test_rule_based_metrics.py
@@ -14,9 +14,9 @@ def _make_positions(train, val, test):
 def _make_backtest(sharpe_train, sharpe_val, sharpe_test,
                    drawdown_train, drawdown_val, drawdown_test):
     return {
-        'train': {'sharpe_per_bar': sharpe_train, 'max_drawdown_pct': drawdown_train},
-        'val':   {'sharpe_per_bar': sharpe_val,   'max_drawdown_pct': drawdown_val},
-        'test':  {'sharpe_per_bar': sharpe_test,  'max_drawdown_pct': drawdown_test},
+        'train': {'sharpe_per_bar': sharpe_train, 'max_drawdown_bps': drawdown_train},
+        'val':   {'sharpe_per_bar': sharpe_val,   'max_drawdown_bps': drawdown_val},
+        'test':  {'sharpe_per_bar': sharpe_test,  'max_drawdown_bps': drawdown_test},
     }
 
 
@@ -44,7 +44,7 @@ def test_backtest_metrics_flattened_with_split_suffix() -> None:
     assert 'sharpe_per_bar_val' in result
     assert 'sharpe_per_bar_test' in result
     assert result['sharpe_per_bar_train'] == 1.0
-    assert result['max_drawdown_pct_test'] == -8.0
+    assert result['max_drawdown_bps_test'] == -8.0
 
 
 def test_sharpe_std_and_drawdown_std() -> None:

--- a/tests/test_rule_based_metrics.py
+++ b/tests/test_rule_based_metrics.py
@@ -47,12 +47,12 @@ def test_backtest_metrics_flattened_with_split_suffix() -> None:
     assert result['max_drawdown_bps_test'] == -8.0
 
 
-def test_sharpe_std_and_drawdown_std() -> None:
+def test_sharpe_std_and_drawdown_std_bps() -> None:
     positions = _make_positions([1], [1], [1])
     bt = _make_backtest(1.0, 1.0, 1.0, -5.0, -5.0, -5.0)
     result = rule_based_metrics(positions, bt)
     assert result['sharpe_std'] == 0.0
-    assert result['drawdown_std'] == 0.0
+    assert result['drawdown_std_bps'] == 0.0
 
 
 def test_sharpe_degradation() -> None:
@@ -80,6 +80,6 @@ def test_missing_backtest_results_degrade_gracefully() -> None:
     positions = _make_positions([1], [1], [1])
     result = rule_based_metrics(positions, {})
     assert result['sharpe_std'] is None
-    assert result['drawdown_std'] is None
+    assert result['drawdown_std_bps'] is None
     assert result['sharpe_degradation'] is None
     assert result['is_stable'] is False


### PR DESCRIPTION
## Summary

Replaces the snapshot backtest output surface with the agreed decoder-level metric ledger from #501.

Core output is now exactly 22 columns:
- seven distribution metrics with `p5`, `p50`, `p95`
- one scalar `cvar_95_return_bps`

The old scalar backtest surface is removed from the post table and inline `backtest_*` output.

## Scope Control

Mechanics preserved:
- prediction lag
- tradability filtering
- hold-while-1 position construction
- entry / continuation gross returns
- fee / slippage cost application
- net return compounding
- closed-trade compounding

Mainline runtime files touched:
- `limen/backtest/backtest_snapshot.py`
- `limen/log/_permutation_prediction_performance.py`
- `limen/log/_experiment_backtest_results.py`
- `limen/sfd/reference_architecture/base.py`
- `limen/sfd/reference_architecture/rule_based.py`
- `limen/metrics/rule_based_metrics.py`

## Validation

Local exact-head gates before push:
- `python -m compileall -q ...` passed
- `python -m ruff check ...` passed
- `python -m pytest tests/test_metrics_and_log_helpers.py tests/test_rule_based_metrics.py tests/test_reference_architecture.py tests/test_inline_metrics.py tests/test_foundational_sfd.py` passed: 50/50

Refs #501