### PR TITLE
feat: use native kline interval datasets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -904,3 +904,8 @@ Note: add all new changelog entries to the bottom of this file.
 - Report return and risk outputs in basis points and carry `datetime` through prediction-performance and reference-architecture backtest inputs for clock-window metrics
 - Update rule-based stability output to use `drawdown_std_bps`, with legacy Sharpe thresholds retained only for call compatibility
 - Update backtest, log, reference-architecture, and trainer docs plus regression coverage for the new ledger surface
+
+## v3.4.0 on 19th of May, 2026
+
+- Use the native Hugging Face BTCUSDT 15m, 30m, 1h, 2h, and 4h kline datasets for matching `HistoricalData.get_spot_klines(kline_size=...)` calls
+- Preserve the existing 1m-source aggregation path for all other `kline_size` values and for custom `DEFAULT_SPOT_KLINES_DATASET_REPO` overrides

--- a/docs/Historical-Data.md
+++ b/docs/Historical-Data.md
@@ -25,15 +25,15 @@ assert data is historical.data
 
 | Method | Backend | Returns | Typical use |
 |---|---|---|---|
-| `get_spot_klines()` | Hugging Face BTCUSDT 1m parquet dataset | BTCUSDT spot klines as `pl.DataFrame` | most common experiment input |
+| `get_spot_klines()` | Hugging Face BTCUSDT parquet datasets | BTCUSDT spot klines as `pl.DataFrame` | most common experiment input |
 | `get_binance_file()` | direct Binance ZIP/CSV archive | normalized Binance file contents as `pl.DataFrame` | source-native Binance trade files |
 | `get_any_file()` | local path or URL (`.parquet`, `.csv`, `.zip`) | loaded file contents as `pl.DataFrame` | test fixtures, local research files, remote datasets |
 
 ## `get_spot_klines()`
 
-`get_spot_klines()` reads from the BTCUSDT 1-minute dataset published at [vaquum/binance_btcusdt_1m_klines](https://huggingface.co/datasets/vaquum/binance_btcusdt_1m_klines).
+`get_spot_klines()` reads from the BTCUSDT datasets published on Hugging Face.
 
-By default it reads that dataset and aggregates upward when you request a larger interval.
+By default it reads native [15m](https://huggingface.co/datasets/vaquum/binance_btcusdt_15m_klines), [30m](https://huggingface.co/datasets/vaquum/binance_btcusdt_30m_klines), [1h](https://huggingface.co/datasets/vaquum/binance_btcusdt_1h_klines), [2h](https://huggingface.co/datasets/vaquum/binance_btcusdt_2h_klines), or [4h](https://huggingface.co/datasets/vaquum/binance_btcusdt_4h_klines) datasets for matching `kline_size` values, and otherwise the [1m](https://huggingface.co/datasets/vaquum/binance_btcusdt_1m_klines) dataset before aggregating upward.
 
 ```python
 from limen.data import HistoricalData

--- a/limen/data/historical_data.py
+++ b/limen/data/historical_data.py
@@ -20,6 +20,13 @@ _SUPPORTED_DATETIME_FORMATS: Final[tuple[str, ...]] = (
 )
 _REMOTE_TIMEOUT_SECONDS: Final[int] = 60
 _DEFAULT_SPOT_DATASET_REPO: Final[str] = 'vaquum/binance_btcusdt_1m_klines'
+_SPOT_DATASET_REPOS_BY_KLINE_SIZE: Final[dict[int, str]] = {
+    900: 'vaquum/binance_btcusdt_15m_klines',
+    1800: 'vaquum/binance_btcusdt_30m_klines',
+    3600: 'vaquum/binance_btcusdt_1h_klines',
+    7200: 'vaquum/binance_btcusdt_2h_klines',
+    14400: 'vaquum/binance_btcusdt_4h_klines',
+}
 _HUGGINGFACE_DATASET_REPO_PART_COUNT: Final[int] = 3
 _MIN_ROWS_TO_INFER_INTERVAL: Final[int] = 2
 
@@ -167,14 +174,24 @@ def _repo_id_from_huggingface_url(file_path_or_url: str) -> str | None:
 
 
 def _resolve_file_path_or_url(file_path_or_url: str) -> str:
-    if file_path_or_url == _DEFAULT_SPOT_DATASET_REPO:
-        return _resolve_huggingface_latest_file(_DEFAULT_SPOT_DATASET_REPO)
+    if (
+        file_path_or_url == _DEFAULT_SPOT_DATASET_REPO
+        or file_path_or_url in _SPOT_DATASET_REPOS_BY_KLINE_SIZE.values()
+    ):
+        return _resolve_huggingface_latest_file(file_path_or_url)
 
     repo_id = _repo_id_from_huggingface_url(file_path_or_url)
     if repo_id is not None:
         return _resolve_huggingface_latest_file(repo_id)
 
     return file_path_or_url
+
+
+def _spot_dataset_repo_for_kline_size(kline_size: int, configured_repo: str) -> str:
+    if configured_repo != _DEFAULT_SPOT_DATASET_REPO:
+        return configured_repo
+
+    return _SPOT_DATASET_REPOS_BY_KLINE_SIZE.get(kline_size, configured_repo)
 
 
 def _read_any_file(
@@ -497,9 +514,10 @@ class HistoricalData:
 
         '''Load BTCUSDT spot klines from a file and aggregate upward when needed.
 
-        By default this resolves the latest daily snapshot from the Hugging Face
-        dataset repo `vaquum/binance_btcusdt_1m_klines`. Row limits return the
-        latest rows. `n_rows` is accepted as a legacy alias.
+        By default this resolves the latest snapshot from the Hugging Face
+        BTCUSDT 15m, 30m, 1h, 2h, or 4h kline dataset when `kline_size` matches.
+        Other intervals use the 1m dataset and aggregate upward. Row limits
+        return the latest rows. `n_rows` is accepted as a legacy alias.
         '''
 
         row_count_limit = _resolve_row_count_limit(row_count_limit, n_rows)
@@ -520,7 +538,11 @@ class HistoricalData:
                 'and end_date_limit are set.'
             )
 
-        base_data = _read_any_file(self.DEFAULT_SPOT_KLINES_DATASET_REPO, has_header=True)
+        dataset_repo = _spot_dataset_repo_for_kline_size(
+            kline_size,
+            self.DEFAULT_SPOT_KLINES_DATASET_REPO,
+        )
+        base_data = _read_any_file(dataset_repo, has_header=True)
         base_data = _normalize_generic_frame(base_data)
 
         if start_date_limit is not None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaquum_limen"
-version = "3.3.0"
+version = "3.4.0"
 description = "Bitcoin-first research and trading platform."
 readme = "README.md"
 authors = [

--- a/tests/run.py
+++ b/tests/run.py
@@ -52,6 +52,7 @@ from tests.test_regime_pools_helpers import test_rdop_online_pipeline_attaches_p
 from tests.test_historical_data import test_get_any_file_loads_local_csv
 from tests.test_historical_data import test_get_spot_klines_reaggregates_latest_dataset
 from tests.test_historical_data import test_get_spot_klines_row_count_limit_returns_latest_rows
+from tests.test_historical_data import test_get_spot_klines_uses_native_huggingface_sources
 from tests.test_historical_data import test_get_spot_klines_rejects_sub_base_intervals
 from tests.test_historical_data import test_resolve_file_path_or_url_expands_huggingface_references
 from tests.test_historical_data import test_get_any_file_loads_zipped_csv_and_derives_datetime_from_timestamp
@@ -905,6 +906,7 @@ tests = [
     test_get_any_file_loads_local_csv,
     test_get_spot_klines_reaggregates_latest_dataset,
     test_get_spot_klines_row_count_limit_returns_latest_rows,
+    test_get_spot_klines_uses_native_huggingface_sources,
     test_get_spot_klines_rejects_sub_base_intervals,
     test_resolve_file_path_or_url_expands_huggingface_references,
     test_get_any_file_loads_zipped_csv_and_derives_datetime_from_timestamp,

--- a/tests/test_historical_data.py
+++ b/tests/test_historical_data.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timedelta, timezone
 from math import isclose, sqrt
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -11,6 +12,32 @@ from limen.data import HistoricalData
 
 
 TEST_FILE = str(Path(__file__).parent / 'fixtures' / 'historical_data_spot_2h.csv')
+
+
+def _spot_frame(interval_seconds: int) -> pl.DataFrame:
+    start = datetime(2020, 1, 1, tzinfo=timezone.utc)
+    return pl.DataFrame({
+        'datetime': [
+            start,
+            start + timedelta(seconds=interval_seconds),
+        ],
+        'open': [1.0, 2.0],
+        'high': [2.0, 3.0],
+        'low': [0.5, 1.5],
+        'close': [1.5, 2.5],
+        'mean': [1.25, 2.25],
+        'std': [0.1, 0.2],
+        'volume': [10.0, 20.0],
+        'maker_ratio': [0.4, 0.6],
+        'no_of_trades': [2, 4],
+        'open_liquidity': [100.0, 200.0],
+        'high_liquidity': [110.0, 210.0],
+        'low_liquidity': [90.0, 190.0],
+        'close_liquidity': [105.0, 205.0],
+        'liquidity_sum': [1000.0, 2000.0],
+        'maker_volume': [4.0, 12.0],
+        'maker_liquidity': [400.0, 1200.0],
+    })
 
 
 def test_get_any_file_loads_local_csv() -> None:
@@ -100,6 +127,60 @@ def test_get_spot_klines_row_count_limit_returns_latest_rows() -> None:
     assert legacy_limited["datetime"].to_list() == full_data["datetime"].tail(2).to_list()
 
 
+def test_get_spot_klines_uses_native_huggingface_sources() -> None:
+    resolved_repos: list[str] = []
+
+    with TemporaryDirectory() as tmpdir:
+        paths = {
+            HistoricalData.DEFAULT_SPOT_KLINES_DATASET_REPO: Path(tmpdir) / '1m.parquet',
+            'vaquum/binance_btcusdt_15m_klines': Path(tmpdir) / '15m.parquet',
+            'vaquum/binance_btcusdt_30m_klines': Path(tmpdir) / '30m.parquet',
+            'vaquum/binance_btcusdt_1h_klines': Path(tmpdir) / '1h.parquet',
+            'vaquum/binance_btcusdt_2h_klines': Path(tmpdir) / '2h.parquet',
+            'vaquum/binance_btcusdt_4h_klines': Path(tmpdir) / '4h.parquet',
+        }
+        _spot_frame(60).write_parquet(paths[HistoricalData.DEFAULT_SPOT_KLINES_DATASET_REPO])
+        _spot_frame(900).write_parquet(paths['vaquum/binance_btcusdt_15m_klines'])
+        _spot_frame(1800).write_parquet(paths['vaquum/binance_btcusdt_30m_klines'])
+        _spot_frame(3600).write_parquet(paths['vaquum/binance_btcusdt_1h_klines'])
+        _spot_frame(7200).write_parquet(paths['vaquum/binance_btcusdt_2h_klines'])
+        _spot_frame(14400).write_parquet(paths['vaquum/binance_btcusdt_4h_klines'])
+
+        def fake_resolve_latest(repo_id: str) -> str:
+            resolved_repos.append(repo_id)
+            return str(paths[repo_id])
+
+        historical = HistoricalData()
+        with pytest.MonkeyPatch.context() as monkeypatch:
+            monkeypatch.setattr(
+                historical_module,
+                '_resolve_huggingface_latest_file',
+                fake_resolve_latest,
+            )
+
+            quarter_hour = historical.get_spot_klines(kline_size=900)
+            half_hour = historical.get_spot_klines(kline_size=1800)
+            one_hour = historical.get_spot_klines(kline_size=3600)
+            two_hour = historical.get_spot_klines(kline_size=7200)
+            four_hour = historical.get_spot_klines(kline_size=14400)
+            fallback = historical.get_spot_klines(kline_size=300)
+
+    assert resolved_repos == [
+        'vaquum/binance_btcusdt_15m_klines',
+        'vaquum/binance_btcusdt_30m_klines',
+        'vaquum/binance_btcusdt_1h_klines',
+        'vaquum/binance_btcusdt_2h_klines',
+        'vaquum/binance_btcusdt_4h_klines',
+        HistoricalData.DEFAULT_SPOT_KLINES_DATASET_REPO,
+    ]
+    assert quarter_hour.height == 2
+    assert half_hour.height == 2
+    assert one_hour.height == 2
+    assert two_hour.height == 2
+    assert four_hour.height == 2
+    assert fallback.height == 1
+
+
 def test_get_spot_klines_rejects_sub_base_intervals() -> None:
     historical = HistoricalData()
 
@@ -120,6 +201,21 @@ def test_resolve_file_path_or_url_expands_huggingface_references() -> None:
         assert historical_module._resolve_file_path_or_url(
             HistoricalData.DEFAULT_SPOT_KLINES_DATASET_REPO
         ) == 'https://example.com/vaquum/binance_btcusdt_1m_klines/latest.parquet'
+        assert historical_module._resolve_file_path_or_url(
+            'vaquum/binance_btcusdt_15m_klines'
+        ) == 'https://example.com/vaquum/binance_btcusdt_15m_klines/latest.parquet'
+        assert historical_module._resolve_file_path_or_url(
+            'vaquum/binance_btcusdt_30m_klines'
+        ) == 'https://example.com/vaquum/binance_btcusdt_30m_klines/latest.parquet'
+        assert historical_module._resolve_file_path_or_url(
+            'vaquum/binance_btcusdt_1h_klines'
+        ) == 'https://example.com/vaquum/binance_btcusdt_1h_klines/latest.parquet'
+        assert historical_module._resolve_file_path_or_url(
+            'vaquum/binance_btcusdt_2h_klines'
+        ) == 'https://example.com/vaquum/binance_btcusdt_2h_klines/latest.parquet'
+        assert historical_module._resolve_file_path_or_url(
+            'vaquum/binance_btcusdt_4h_klines'
+        ) == 'https://example.com/vaquum/binance_btcusdt_4h_klines/latest.parquet'
         assert historical_module._resolve_file_path_or_url(
             'https://huggingface.co/datasets/foo/bar'
         ) == 'https://example.com/foo/bar/latest.parquet'


### PR DESCRIPTION
## What does this PR change?

Adds native Hugging Face source selection for `HistoricalData.get_spot_klines`:

- `kline_size=900` reads `vaquum/binance_btcusdt_15m_klines`
- `kline_size=1800` reads `vaquum/binance_btcusdt_30m_klines`
- `kline_size=3600` reads `vaquum/binance_btcusdt_1h_klines`
- `kline_size=7200` reads `vaquum/binance_btcusdt_2h_klines`
- `kline_size=14400` reads `vaquum/binance_btcusdt_4h_klines`
- all other intervals keep the existing 1m-source aggregation path
- custom `DEFAULT_SPOT_KLINES_DATASET_REPO` overrides keep current behavior

Also updates docs, tests, `CHANGELOG.md`, and bumps the package version to `3.4.0`.

## HF dataset scan

Visible under the `vaquum` account: `1m`, `15m`, `30m`, `1h`, `2h`, and `4h` BTCUSDT kline datasets. The 15m dataset latest snapshot is `btcusdt_15m_kline_20200101_to_20260518.parquet`.

## Review follow-up

- bare native interval dataset repo IDs resolve through HF `latest.json` before `_read_any_file()` checks file suffixes
- regression tests exercise the real resolver/read path instead of monkeypatching `_read_any_file()`
- resolver coverage explicitly asserts native repo expansion

## Validation

- `.venv/bin/python -m pytest tests/test_historical_data.py` passed: 11/11
- `.venv/bin/python -m ruff check limen/data/historical_data.py tests/test_historical_data.py tests/run.py` passed
- `.venv/bin/python -m compileall -q limen tests` passed
- `git diff --cached --check` passed
- live `HistoricalData().get_spot_klines(kline_size=900, row_count_limit=2)` returned current HF parquet rows
- `python3 -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])"` returned `3.4.0`
