### PR TITLE
feat: add tabpfn_binary, xgboost_regressor, and rule_based YAML templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -927,3 +927,9 @@ Note: add all new changelog entries to the bottom of this file.
 - Add `include_if` support on indicators and features in YAML manifests — a round_params key name that gates feature inclusion at runtime
 - YAML validator type-checks `uel.feedback_interval` and `uel.checkpoint_interval` as integers
 - `UniversalExperimentLoop` accepts `yaml_reference` dict and stores it in `metadata.json` for reproducibility; wired automatically by `limen run`
+
+## v3.5.2 on 20th of May, 2026
+
+- Add `tabpfn_binary.yaml`, `xgboost_regressor.yaml`, and `rule_based.yaml` YAML experiment templates
+- Rule-based YAML manifests now support `indicators` — wired into `RuleBasedManifest.feature_transforms` at compile time
+- Fix `body_pct` registered as indicator (not feature) in the `xgboost_regressor` foundational SFD

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -932,4 +932,3 @@ Note: add all new changelog entries to the bottom of this file.
 
 - Add `tabpfn_binary.yaml`, `xgboost_regressor.yaml`, and `rule_based.yaml` YAML experiment templates
 - Rule-based YAML manifests now support `indicators` — wired into `RuleBasedManifest.feature_transforms` at compile time
-- Fix `body_pct` registered as indicator (not feature) in the `xgboost_regressor` foundational SFD

--- a/limen/sfd/foundational_sfd/xgboost_regressor.py
+++ b/limen/sfd/foundational_sfd/xgboost_regressor.py
@@ -54,7 +54,7 @@ def manifest() -> Manifest:
         .add_indicator(sma, column='maker_ratio', period=10)
         .add_indicator(sma, column='no_of_trades', period=20)
         .add_indicator(stochastic_oscillator)
-        .add_feature(body_pct)
+        .add_indicator(body_pct)
         .add_feature(range_pct)
         .add_feature(volume_ratio, period=20)
         .add_feature(sma_ratios, periods=[10, 50], price_col='close')

--- a/limen/yaml/compiler.py
+++ b/limen/yaml/compiler.py
@@ -90,6 +90,12 @@ def _build_rule_based_manifest(m: dict[str, Any]) -> RuleBasedManifest:
 
     manifest = RuleBasedManifest()
     _apply_base(manifest, m)
+    for item in m.get('indicators') or []:
+        manifest.add_indicator(
+            resolve(item['func']),
+            include_if=item.get('include_if'),
+            **_resolve_func_params(dict(item.get('params') or {})),
+        )
     strat = m['strategy']
     manifest.with_strategy(
         conditions=[dict(c) for c in strat['conditions']],

--- a/limen/yaml/compiler.py
+++ b/limen/yaml/compiler.py
@@ -90,12 +90,7 @@ def _build_rule_based_manifest(m: dict[str, Any]) -> RuleBasedManifest:
 
     manifest = RuleBasedManifest()
     _apply_base(manifest, m)
-    for item in m.get('indicators') or []:
-        manifest.add_indicator(
-            resolve(item['func']),
-            include_if=item.get('include_if'),
-            **_resolve_func_params(dict(item.get('params') or {})),
-        )
+    _apply_indicators(manifest, m)
     strat = m['strategy']
     manifest.with_strategy(
         conditions=[dict(c) for c in strat['conditions']],
@@ -103,6 +98,16 @@ def _build_rule_based_manifest(m: dict[str, Any]) -> RuleBasedManifest:
     )
     manifest.with_reference_architecture(resolve(m['reference_architecture']))
     return manifest
+
+
+def _apply_indicators(manifest: Manifest, m: dict[str, Any]) -> None:
+
+    for item in m.get('indicators') or []:
+        manifest.add_indicator(
+            resolve(item['func']),
+            include_if=item.get('include_if'),
+            **_resolve_func_params(dict(item.get('params') or {})),
+        )
 
 
 def _apply_base(manifest: Manifest, m: dict[str, Any]) -> None:
@@ -156,12 +161,7 @@ def _apply_transforms(manifest: MLManifest, m: dict[str, Any]) -> None:
             **_resolve_func_params(dict(bf.get('params') or {})),
         )
 
-    for item in m.get('indicators') or []:
-        manifest.add_indicator(
-            resolve(item['func']),
-            include_if=item.get('include_if'),
-            **_resolve_func_params(dict(item.get('params') or {})),
-        )
+    _apply_indicators(manifest, m)
 
     for item in m.get('features') or []:
         manifest.add_feature(

--- a/limen/yaml/schema.py
+++ b/limen/yaml/schema.py
@@ -13,13 +13,12 @@ METADATA_OPTIONAL = {'author', 'created_at', 'description', 'tags', 'limen_versi
 SFD_REQUIRED = {'manifest', 'params'}
 
 MANIFEST_REQUIRED = {'type', 'data_source', 'reference_architecture'}
-MANIFEST_OPTIONAL_SHARED = {'test_data_source', 'required_columns', 'split_config', 'split_dates'}
+MANIFEST_OPTIONAL_SHARED = {'test_data_source', 'required_columns', 'split_config', 'split_dates', 'indicators'}
 
 ML_MANIFEST_REQUIRED = {'target'}
 ML_MANIFEST_OPTIONAL = {
     'pre_split_data_selector',
     'bar_formation',
-    'indicators',
     'features',
     'scaler',
     'feature_ablation',

--- a/limen/yaml/templates/rule_based.yaml
+++ b/limen/yaml/templates/rule_based.yaml
@@ -2,7 +2,7 @@ schema_version: "1.0"
 
 metadata:
   name: rule_based_experiment
-  limen_version: "3.5.1"
+  limen_version: "3.5.2"
   mode: development
   description: Rule-based strategy using RSI oversold and EMA trend filter
 

--- a/limen/yaml/templates/rule_based.yaml
+++ b/limen/yaml/templates/rule_based.yaml
@@ -1,0 +1,74 @@
+schema_version: "1.0"
+
+metadata:
+  name: rule_based_experiment
+  limen_version: "3.5.1"
+  mode: development
+  description: Rule-based strategy using RSI oversold and EMA trend filter
+
+sfd:
+  manifest:
+    type: rule_based
+
+    data_source:
+      method: limen.data.HistoricalData.get_spot_klines
+      params:
+        kline_size: 3600
+        start_date_limit: "2025-01-01"
+
+    test_data_source:
+      method: limen.data.HistoricalData.get_spot_klines
+      params:
+        kline_size: 7200
+        n_rows: 5000
+
+    split_config:
+      train: 8
+      val: 1
+      test: 2
+
+    indicators:
+      - func: limen.indicators.wilder_rsi
+        params:
+          period: "{rsi_period}"
+          group: momentum
+      - func: limen.indicators.ema
+        params:
+          period: "{ema_period}"
+          group: trend
+
+    strategy:
+      conditions:
+        - id: rsi_oversold
+          name: RSI oversold
+          type: threshold
+          column: "wilder_rsi_{rsi_period}"
+          operator: "<"
+          value: "{rsi_threshold}"
+        - id: above_ema
+          name: Price above EMA
+          type: relative
+          column: close
+          operator: ">"
+          other_column: "ema_{ema_period}"
+        - id: entry
+          name: Entry signal
+          operator: and
+          operands:
+            - rsi_oversold
+            - above_ema
+      entry: entry
+
+    reference_architecture: limen.sfd.reference_architecture.rule_based
+
+  params:
+    rsi_period: [7, 14, 21]
+    rsi_threshold: [20, 25, 30, 35]
+    ema_period: [50, 100, 200]
+
+uel:
+  n_permutations: 50
+  search_strategy:
+    type: random
+  prep_each_round: true
+  output_format: csv

--- a/limen/yaml/templates/tabpfn_binary.yaml
+++ b/limen/yaml/templates/tabpfn_binary.yaml
@@ -1,0 +1,127 @@
+schema_version: "1.0"
+
+metadata:
+  name: tabpfn_binary_experiment
+  limen_version: "3.5.1"
+  mode: development
+  description: TabPFN binary classifier with calibration, feature ablation, and explicit scaler
+
+sfd:
+  manifest:
+    type: ml
+
+    data_source:
+      method: limen.data.HistoricalData.get_spot_klines
+      params:
+        kline_size: 3600
+        start_date_limit: "2025-01-01"
+
+    test_data_source:
+      method: limen.data.HistoricalData.get_spot_klines
+      params:
+        kline_size: 7200
+        n_rows: 1000
+
+    split_config:
+      train: 50
+      val: 20
+      test: 30
+
+    indicators:
+      - func: limen.indicators.roc
+        params:
+          period: 1
+          group: momentum
+      - func: limen.indicators.roc
+        params:
+          period: 4
+          group: momentum
+      - func: limen.indicators.roc
+        params:
+          period: 12
+          group: momentum
+      - func: limen.indicators.rolling_volatility
+        params:
+          column: close
+          window: 12
+          group: volatility
+      - func: limen.indicators.wilder_rsi
+        params:
+          period: "{rsi_period}"
+          group: momentum
+      - func: limen.indicators.bollinger_bands
+        params:
+          price_col: close
+          window: "{bb_window}"
+          num_std: "{bb_std}"
+          group: volatility
+      - func: limen.indicators.bollinger_position
+        params:
+          group: volatility
+
+    features:
+      - func: limen.features.fractional_diff
+        params:
+          d: 0.5
+          cols:
+            - close
+
+    target:
+      name: forward_breakout
+      class: limen.targets.ForwardBreakoutTarget
+      transform_params:
+        forward_periods: "{forward_periods}"
+        threshold: "{threshold_pct}"
+        shift: -1
+
+    scaler:
+      class: limen.scalers.RobustScaler
+
+    feature_ablation:
+      drop_count_key: feature_drop_count
+      seed_key: feature_drop_seed
+
+    reference_architecture: limen.sfd.reference_architecture.tabpfn_binary
+
+    calibration:
+      probability_calibration:
+        func: limen.calibration.sklearn_probability_calibrator
+        params:
+          method: "{cal_method}"
+      threshold_function:
+        func: limen.calibration.grid_threshold_optimizer
+        params:
+          metric: limen.metrics.balanced_metric.balanced_metric
+          threshold_min: "{threshold_min}"
+          threshold_max: "{threshold_max}"
+          threshold_step: "{threshold_step}"
+
+  params:
+    # target
+    forward_periods: [2, 4, 6, 8, 12, 24]
+    threshold_pct: [0.005, 0.0075, 0.01, 0.015, 0.02, 0.03]
+    # indicators
+    rsi_period: [7, 14, 21]
+    bb_window: [10, 20, 30]
+    bb_std: [1.5, 2.0, 2.5]
+    # feature perturbation
+    feature_groups: [all, momentum, volatility, "momentum|volatility"]
+    feature_drop_count: [0]
+    feature_drop_seed: [42]
+    # calibration
+    use_calibration: [true, false]
+    use_threshold: [true, false]
+    cal_method: [isotonic, sigmoid]
+    threshold_min: [0.20, 0.25, 0.30]
+    threshold_max: [0.60, 0.65, 0.70]
+    threshold_step: [0.05]
+    # model
+    n_ensemble_configurations: [4, 8, 16]
+    device: [cpu]
+
+uel:
+  n_permutations: 50
+  search_strategy:
+    type: random
+  prep_each_round: true
+  output_format: csv

--- a/limen/yaml/templates/tabpfn_binary.yaml
+++ b/limen/yaml/templates/tabpfn_binary.yaml
@@ -2,7 +2,7 @@ schema_version: "1.0"
 
 metadata:
   name: tabpfn_binary_experiment
-  limen_version: "3.5.1"
+  limen_version: "3.5.2"
   mode: development
   description: TabPFN binary classifier with calibration, feature ablation, and explicit scaler
 

--- a/limen/yaml/templates/xgboost_regressor.yaml
+++ b/limen/yaml/templates/xgboost_regressor.yaml
@@ -2,7 +2,7 @@ schema_version: "1.0"
 
 metadata:
   name: xgboost_regressor_experiment
-  limen_version: "3.5.1"
+  limen_version: "3.5.2"
   mode: development
   description: XGBoost regressor predicting next-period return with feature perturbation
 

--- a/limen/yaml/templates/xgboost_regressor.yaml
+++ b/limen/yaml/templates/xgboost_regressor.yaml
@@ -1,0 +1,114 @@
+schema_version: "1.0"
+
+metadata:
+  name: xgboost_regressor_experiment
+  limen_version: "3.5.1"
+  mode: development
+  description: XGBoost regressor predicting next-period return with feature perturbation
+
+sfd:
+  manifest:
+    type: ml
+
+    data_source:
+      method: limen.data.HistoricalData.get_spot_klines
+      params:
+        kline_size: 3600
+        start_date_limit: "2025-01-01"
+
+    test_data_source:
+      method: limen.data.HistoricalData.get_spot_klines
+      params:
+        kline_size: 7200
+        n_rows: 5000
+
+    split_config:
+      train: 8
+      val: 1
+      test: 2
+
+    indicators:
+      - func: limen.indicators.window_return
+        params:
+          period: 1
+          group: momentum
+      - func: limen.indicators.window_return
+        params:
+          period: 5
+          group: momentum
+      - func: limen.indicators.window_return
+        params:
+          period: 20
+          group: momentum
+      - func: limen.indicators.rolling_volatility
+        params:
+          column: close
+          window: 20
+          group: volatility
+      - func: limen.indicators.sma
+        params:
+          column: volume
+          period: 20
+          group: volume
+      - func: limen.indicators.stochastic_oscillator
+        params:
+          group: momentum
+      - func: limen.indicators.body_pct
+        params:
+          group: structure
+
+    features:
+      - func: limen.features.range_pct
+        params:
+          group: structure
+      - func: limen.features.volume_ratio.volume_ratio
+        params:
+          period: 20
+          group: volume
+      - func: limen.features.sma_ratios.sma_ratios
+        params:
+          periods: [10, 50]
+          price_col: close
+          group: trend
+
+    target:
+      name: next_return
+      class: limen.targets.NextReturnTarget
+      transform_params:
+        periods: 1
+        scale: 100.0
+
+    scaler:
+      class: limen.scalers.RobustScaler
+
+    feature_ablation:
+      drop_count_key: feature_drop_count
+      seed_key: feature_drop_seed
+
+    reference_architecture: limen.sfd.reference_architecture.xgboost_regressor
+
+  params:
+    # feature perturbation
+    feature_groups: [all, momentum, volatility, "momentum|volume", "momentum|volume|structure"]
+    feature_drop_count: [0]
+    feature_drop_seed: [42]
+    # model
+    learning_rate: [0.01, 0.02, 0.03]
+    max_depth: [2, 3, 4]
+    n_estimators: [300, 500, 700]
+    min_child_weight: [5, 10, 20]
+    subsample: [0.5, 0.6, 0.7]
+    colsample_bytree: [0.5, 0.6, 0.7]
+    gamma: [0.1, 0.5, 1.0]
+    reg_alpha: [0.1, 0.5, 1.0]
+    reg_lambda: [1.0, 5.0, 10.0]
+    objective: [reg:squarederror]
+    booster: [gbtree]
+    early_stopping_rounds: [50]
+
+uel:
+  n_permutations: 50
+  search_strategy:
+    type: random
+  prep_each_round: true
+  output_format: csv

--- a/limen/yaml/templates/xgboost_regressor.yaml
+++ b/limen/yaml/templates/xgboost_regressor.yaml
@@ -102,7 +102,7 @@ sfd:
     gamma: [0.1, 0.5, 1.0]
     reg_alpha: [0.1, 0.5, 1.0]
     reg_lambda: [1.0, 5.0, 10.0]
-    objective: [reg:squarederror]
+    objective: ["reg:squarederror"]
     booster: [gbtree]
     early_stopping_rounds: [50]
 

--- a/limen/yaml/validator.py
+++ b/limen/yaml/validator.py
@@ -146,6 +146,7 @@ _MAIN_ENGINE = RuleEngine([
         Required('sfd.manifest.strategy.conditions', list),
         Required('sfd.manifest.strategy.entry', str),
         ConditionsList(),
+        FuncList('sfd.manifest.indicators'),
         NoUnknownKeys('sfd.manifest.strategy', STRATEGY_REQUIRED),
         WarnIfPresent(
             'sfd.manifest',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaquum_limen"
-version = "3.5.1"
+version = "3.5.2"
 description = "Bitcoin-first research and trading platform."
 readme = "README.md"
 authors = [

--- a/tests/test_yaml.py
+++ b/tests/test_yaml.py
@@ -869,6 +869,52 @@ def test_build_manifest_rule_based_strategy_and_architecture_wired() -> None:
     assert callable(manifest.architecture_function)
 
 
+def test_build_manifest_rule_based_indicators_wired() -> None:
+    from limen.indicators import wilder_rsi
+    yaml = dedent('''\
+        schema_version: "1.0"
+        metadata:
+          name: rule_exp
+          mode: development
+        sfd:
+          manifest:
+            type: rule_based
+            data_source:
+              method: limen.data.HistoricalData.get_spot_klines
+              params:
+                kline_size: 3600
+            split_config:
+              train: 8
+              val: 1
+              test: 2
+            indicators:
+              - func: limen.indicators.wilder_rsi
+                params:
+                  period: 14
+            strategy:
+              conditions:
+                - id: rsi_low
+                  name: rsi_low
+                  type: threshold
+                  column: wilder_rsi_14
+                  operator: lt
+                  value: 30
+              entry: rsi_low
+            reference_architecture: limen.sfd.reference_architecture.rule_based
+          params:
+            dummy_param: [1, 2]
+        uel:
+          n_permutations: 2
+          search_strategy:
+            type: random
+          output_format: csv
+    ''')
+    yaml_dict, _ = parse(yaml)
+    manifest = build_manifest(yaml_dict)
+    assert len(manifest.feature_transforms) == 1
+    assert manifest.feature_transforms[0].func is wilder_rsi
+
+
 def test_compiled_sfd_name_is_yaml_prefixed() -> None:
     yaml_dict, _ = parse(_MINIMAL_ML_YAML)
     assert CompiledSFD(yaml_dict).__name__ == 'yaml:test_exp'

--- a/tests/test_yaml.py
+++ b/tests/test_yaml.py
@@ -124,7 +124,7 @@ _MINIMAL_RULE_BASED_YAML = dedent('''\
               name: rsi_low
               type: threshold
               column: rsi
-              operator: lt
+              operator: "<"
               value: 30
           entry: rsi_low
         reference_architecture: limen.sfd.reference_architecture.rule_based
@@ -247,6 +247,16 @@ def test_validate_passes_valid_rule_based_yaml() -> None:
     result = validate(yaml_dict)
     assert result.valid
     assert result.errors == []
+
+
+def test_validate_error_for_invalid_indicator_func_in_rule_based_manifest() -> None:
+    yaml_dict, _ = parse(_MINIMAL_RULE_BASED_YAML)
+    yaml_dict['sfd']['manifest']['indicators'] = [
+        {'func': 'limen.indicators.does_not_exist', 'params': {'period': 14}},
+    ]
+    result = validate(yaml_dict)
+    assert not result.valid
+    assert any('does_not_exist' in e.message for e in result.errors)
 
 
 def test_validate_passes_valid_yaml_with_split_dates() -> None:
@@ -897,7 +907,7 @@ def test_build_manifest_rule_based_indicators_wired() -> None:
                   name: rsi_low
                   type: threshold
                   column: wilder_rsi_14
-                  operator: lt
+                  operator: "<"
                   value: 30
               entry: rsi_low
             reference_architecture: limen.sfd.reference_architecture.rule_based


### PR DESCRIPTION
**NOTE:** The author must always **first review the PR themselves**, before requesting review from others, that means carefully having reviewed the full diff in GitHub.

## What does this PR change?
- Add `tabpfn_binary.yaml`, `xgboost_regressor.yaml`, and `rule_based.yaml` YAML experiment templates
- Rule-based YAML manifests now support `indicators` — wired into `RuleBasedManifest.feature_transforms` at compile time

Implememnts yaml experiment templates for foundations SFDs #506 

## Checklist

- [x] I have reviewed full diff in “Files changed”
- [x] I left no unnecessary files in the changes
- [x] I ran `python tests/run.py` locally without errors (where applicable)
- [ ] I updated `/docs` (if behavior/API/config/user/etc changed)
- [x] I added and/or updated docstrings as per [Writing Docstrings](https://github.com/Vaquum/Limen/blob/main/docs/Developer/Writing-Docstrings.md) (for any changed public functions/classes)
- [x] I updated CHANGELOG.md (unless only docs or other non-code aspect was changed)
- [x] I updated pyproject.toml (unless only docs or other non-code aspect was changed)
- [x] I added and/or updated tests (if behavior changed or new code paths added)
- [x] I validated changes manually
- [x] I validated changes with LLM
- [x] I removed any extraneous examples/comments
- [x] I linked issue to auto-close on merge (e.g., “Fixes #123”) when applicable
