### PR TITLE
feat: expose logreg model parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -932,3 +932,9 @@ Note: add all new changelog entries to the bottom of this file.
 
 - Add `tabpfn_binary.yaml`, `xgboost_regressor.yaml`, and `rule_based.yaml` YAML experiment templates
 - Rule-based YAML manifests now support `indicators` — wired into `RuleBasedManifest.feature_transforms` at compile time
+
+## v3.6.0 on 21st of May, 2026
+
+- Expose the full sklearn `LogisticRegression` constructor surface through the `logreg_binary` reference-architecture wrapper
+- Add the same LogReg model parameters to the foundational SFD `params()` and `logreg_binary.yaml` template so Python and YAML manifests stay aligned
+- Preserve the legacy numeric `class_weight` shorthand while allowing sklearn-native string and dict values

--- a/docs/Built-In-SFDs.md
+++ b/docs/Built-In-SFDs.md
@@ -48,6 +48,8 @@ It currently combines:
 - the `LogRegBinary` reference model
 - `CalibrationBuilder` with `sklearn_probability_calibrator` and `grid_threshold_optimizer`
 
+The classifier parameter surface mirrors the sklearn `LogisticRegression` constructor through manifest params: `solver`, `penalty`, `dual`, `tol`, `C`, `fit_intercept`, `intercept_scaling`, `class_weight`, `random_state`, `max_iter`, `multi_class`, `verbose`, `warm_start`, `n_jobs`, and `l1_ratio`.
+
 The calibration search space includes `use_calibration`, `use_threshold`, `cal_method`, `threshold_min`, `threshold_max`, and `threshold_step`, giving a full grid of calibration modes within a single experiment run.
 
 On a live local smoke run over the bundled test dataset in this repo, it prepared:

--- a/docs/Experiment-Manifest.md
+++ b/docs/Experiment-Manifest.md
@@ -631,6 +631,8 @@ def logreg_binary(data, C=1.0, class_weight=None, max_iter=100, solver='lbfgs'):
 
 then manifest execution will automatically pull `C`, `class_weight`, `max_iter`, and `solver` from the current round when those keys exist in `round_params`.
 
+The built-in `logreg_binary` SFD uses this same path for the full sklearn logistic-regression constructor surface, so model tuning stays in `params()` rather than hidden inside the architecture.
+
 Required model parameters with no defaults must be present in the round params or Limen will raise.
 
 ## Calibration

--- a/docs/Reference-Architecture.md
+++ b/docs/Reference-Architecture.md
@@ -49,7 +49,7 @@ Not every model needs every key, but this is the standard Limen shape that the c
 
 | Class | Task shape | Deterministic | Notes |
 |---|---|---|---|
-| `LogRegBinary` | binary classification | yes | sklearn logistic regression wrapper |
+| `LogRegBinary` | binary classification | yes | sklearn logistic regression wrapper; manifest wrapper exposes constructor params |
 | `RandomBinary` | binary baseline | no | intentionally stochastic |
 | `XGBoostRegressor` | regression | no | requires `xgboost` |
 | `TabPFNBinary` | binary classification | no | optional, requires `tabpfn` |

--- a/limen/sfd/foundational_sfd/logreg_binary.py
+++ b/limen/sfd/foundational_sfd/logreg_binary.py
@@ -23,7 +23,6 @@ def params() -> dict:
         'shift': [-1, -2, -3, -4, -5],
         'q': [0.35, 0.38, 0.41, 0.44, 0.47, 0.50, 0.53],
         'roc_period': [1, 4, 12, 24, 144],
-        'penalty': ['l2'],
         # view perturbation
         'scaler_type': ['logreg', 'robust', 'rank_gauss'],
         # feature perturbation
@@ -36,11 +35,21 @@ def params() -> dict:
         'threshold_max': [0.60, 0.65, 0.70],
         'threshold_step': [0.05, 0.10],
         # classifier parameters
-        'class_weight': [0.45, 0.55, 0.65, 0.75, 0.85],
-        'C': [0.01, 0.1, 0.5, 1.0, 2.0, 5.0, 10.0],
-        'max_iter': [30, 60, 90, 120, 180, 240],
         'solver': ['lbfgs', 'newton-cg', 'liblinear', 'sag', 'newton-cholesky'],
+        'penalty': ['l2'],
+        'dual': [False],
         'tol': [0.001, 0.01, 0.03, 0.1, 0.3],
+        'C': [0.01, 0.1, 0.5, 1.0, 2.0, 5.0, 10.0],
+        'fit_intercept': [True, False],
+        'intercept_scaling': [1.0],
+        'class_weight': [0.45, 0.55, 0.65, 0.75, 0.85],
+        'random_state': [42],
+        'max_iter': [30, 60, 90, 120, 180, 240],
+        'multi_class': ['deprecated'],
+        'verbose': [0],
+        'warm_start': [False],
+        'n_jobs': [-1],
+        'l1_ratio': [None],
     }
 
 

--- a/limen/sfd/reference_architecture/logreg_binary.py
+++ b/limen/sfd/reference_architecture/logreg_binary.py
@@ -1,3 +1,4 @@
+import inspect
 from typing import TYPE_CHECKING, Any
 
 from sklearn.linear_model import LogisticRegression
@@ -8,6 +9,26 @@ from limen.sfd.reference_architecture.base import ReferenceModel
 
 if TYPE_CHECKING:
     from limen.experiment.manifest_core import CalibrationConfig
+
+
+def _resolve_class_weight(class_weight: Any) -> Any:
+
+    '''Preserve legacy numeric shorthand while allowing sklearn-native values.'''
+
+    if isinstance(class_weight, (int, float)) and not isinstance(class_weight, bool):
+        return {0: class_weight, 1: 1}
+    return class_weight
+
+
+def _drop_removed_sklearn_params(params: dict[str, Any]) -> dict[str, Any]:
+
+    '''Drop compatibility params removed by the installed sklearn version.'''
+
+    supported = set(inspect.signature(LogisticRegression).parameters)
+    cleaned = dict(params)
+    for name in {'multi_class'} - supported:
+        cleaned.pop(name, None)
+    return cleaned
 
 
 class LogRegBinary(ReferenceModel):
@@ -38,10 +59,10 @@ class LogRegBinary(ReferenceModel):
         if prediction_calibration_config is not None:
             self.prediction_calibration_config = prediction_calibration_config
 
-        class_weight = params.pop('class_weight', None)
-        if class_weight is not None:
-            params['class_weight'] = {0: class_weight, 1: 1}
+        if 'class_weight' in params:
+            params['class_weight'] = _resolve_class_weight(params['class_weight'])
 
+        params = _drop_removed_sklearn_params(params)
         self.model = LogisticRegression(**params)
         self.model.fit(data['x_train'], data['y_train'])
 
@@ -106,12 +127,14 @@ def logreg_binary(data: dict,
                   C: float = 1.0,
                   fit_intercept: bool = True,
                   intercept_scaling: float = 1,
-                  class_weight: str | dict | None = None,
+                  class_weight: float | str | dict | None = None,
                   random_state: int = 42,
                   max_iter: int = 100,
+                  multi_class: str = 'deprecated',
                   verbose: int = 0,
                   warm_start: bool = False,
                   n_jobs: int = -1,
+                  l1_ratio: float | None = None,
                   prediction_calibration_config: 'CalibrationConfig | None' = None) -> dict:
 
     '''
@@ -126,12 +149,15 @@ def logreg_binary(data: dict,
         C (float): Inverse of regularization strength
         fit_intercept (bool): Whether to fit intercept
         intercept_scaling (float): Intercept scaling
-        class_weight (str or dict): Class weights
+        class_weight (float, str, or dict): Class weights. Numeric values keep the
+            legacy `{0: value, 1: 1}` shorthand; strings/dicts pass through to sklearn.
         random_state (int): Random seed
         max_iter (int): Maximum iterations
+        multi_class (str): Multiclass handling passthrough
         verbose (int): Verbosity level
         warm_start (bool): Whether to reuse previous solution
         n_jobs (int): Number of parallel jobs
+        l1_ratio (float | None): Elastic-net mixing parameter
         prediction_calibration_config (CalibrationConfig | None): Optional calibration config
 
     Returns:
@@ -151,9 +177,11 @@ def logreg_binary(data: dict,
         class_weight=class_weight,
         random_state=random_state,
         max_iter=max_iter,
+        multi_class=multi_class,
         verbose=verbose,
         warm_start=warm_start,
         n_jobs=n_jobs,
+        l1_ratio=l1_ratio,
     )
 
     return model.evaluate(data, inline_metrics=True)

--- a/limen/yaml/templates/logreg_binary.yaml
+++ b/limen/yaml/templates/logreg_binary.yaml
@@ -2,7 +2,7 @@ schema_version: "1.0"
 
 metadata:
   name: logreg_binary_experiment
-  limen_version: "3.5.0"
+  limen_version: "3.6.0"
   mode: development
   description: Logistic regression binary classifier with calibration and feature perturbation
 

--- a/limen/yaml/templates/logreg_binary.yaml
+++ b/limen/yaml/templates/logreg_binary.yaml
@@ -93,7 +93,6 @@ sfd:
     shift: [-1, -2, -3, -4, -5]
     q: [0.35, 0.38, 0.41, 0.44, 0.47, 0.50, 0.53]
     roc_period: [1, 4, 12, 24, 144]
-    penalty: [l2]
     # view perturbation
     scaler_type: [logreg, robust, rank_gauss]
     # feature perturbation
@@ -108,11 +107,21 @@ sfd:
     threshold_max: [0.60, 0.65, 0.70]
     threshold_step: [0.05, 0.10]
     # classifier
-    class_weight: [0.45, 0.55, 0.65, 0.75, 0.85]
-    C: [0.01, 0.1, 0.5, 1.0, 2.0, 5.0, 10.0]
-    max_iter: [30, 60, 90, 120, 180, 240]
     solver: [lbfgs, newton-cg, liblinear, sag, newton-cholesky]
+    penalty: [l2]
+    dual: [false]
     tol: [0.001, 0.01, 0.03, 0.1, 0.3]
+    C: [0.01, 0.1, 0.5, 1.0, 2.0, 5.0, 10.0]
+    fit_intercept: [true, false]
+    intercept_scaling: [1.0]
+    class_weight: [0.45, 0.55, 0.65, 0.75, 0.85]
+    random_state: [42]
+    max_iter: [30, 60, 90, 120, 180, 240]
+    multi_class: [deprecated]
+    verbose: [0]
+    warm_start: [false]
+    n_jobs: [-1]
+    l1_ratio: [null]
 
 uel:
   n_permutations: 50

--- a/limen/yaml/templates/rule_based.yaml
+++ b/limen/yaml/templates/rule_based.yaml
@@ -2,7 +2,7 @@ schema_version: "1.0"
 
 metadata:
   name: rule_based_experiment
-  limen_version: "3.5.2"
+  limen_version: "3.6.0"
   mode: development
   description: Rule-based strategy using RSI oversold and EMA trend filter
 

--- a/limen/yaml/templates/tabpfn_binary.yaml
+++ b/limen/yaml/templates/tabpfn_binary.yaml
@@ -2,7 +2,7 @@ schema_version: "1.0"
 
 metadata:
   name: tabpfn_binary_experiment
-  limen_version: "3.5.2"
+  limen_version: "3.6.0"
   mode: development
   description: TabPFN binary classifier with calibration, feature ablation, and explicit scaler
 

--- a/limen/yaml/templates/xgboost_regressor.yaml
+++ b/limen/yaml/templates/xgboost_regressor.yaml
@@ -2,7 +2,7 @@ schema_version: "1.0"
 
 metadata:
   name: xgboost_regressor_experiment
-  limen_version: "3.5.2"
+  limen_version: "3.6.0"
   mode: development
   description: XGBoost regressor predicting next-period return with feature perturbation
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaquum_limen"
-version = "3.5.2"
+version = "3.6.0"
 description = "Bitcoin-first research and trading platform."
 readme = "README.md"
 authors = [

--- a/tests/test_reference_architecture.py
+++ b/tests/test_reference_architecture.py
@@ -1,16 +1,21 @@
+import inspect
+
 import numpy as np
 import pandas as pd
 import polars as pl
+from sklearn.linear_model import LogisticRegression
 
 from limen.backtest.backtest_snapshot import BACKTEST_SNAPSHOT_COLUMNS
 from limen.calibration import grid_threshold_optimizer
 from limen.calibration import sklearn_probability_calibrator
 from limen.experiment import CalibrationConfig
+from limen.sfd.foundational_sfd import logreg_binary as foundational_logreg_binary
 from limen.sfd.reference_architecture import LogRegBinary
 from limen.sfd.reference_architecture import RandomBinary
 from limen.sfd.reference_architecture import RuleBasedStrategy
 from limen.sfd.reference_architecture import TabPFNBinary
 from limen.sfd.reference_architecture import XGBoostRegressor
+from limen.sfd.reference_architecture import logreg_binary
 from limen.sfd.reference_architecture.rule_based import rule_based
 
 
@@ -100,6 +105,43 @@ def test_logreg_train_evaluate_end_to_end():
     assert results['confusion_fp'] + results['confusion_tn'] == int((data['y_test'] == 0).sum())
 
     assert '_preds' in results
+
+
+def test_logreg_wrapper_exposes_sklearn_constructor_params():
+
+    sklearn_params = set(inspect.signature(LogisticRegression).parameters)
+    wrapper_params = set(inspect.signature(logreg_binary).parameters) - {
+        'data',
+        'prediction_calibration_config',
+    }
+
+    assert sklearn_params <= wrapper_params
+
+
+def test_logreg_foundational_params_cover_wrapper_model_surface():
+
+    model_params = set(inspect.signature(logreg_binary).parameters) - {
+        'data',
+        'prediction_calibration_config',
+    }
+
+    assert model_params <= set(foundational_logreg_binary.params())
+
+
+def test_logreg_numeric_class_weight_preserves_legacy_shorthand():
+
+    data = _make_data(binary=True, with_price=False)
+    model = LogRegBinary().train(data, solver='lbfgs', max_iter=200, class_weight=0.45)
+
+    assert model.model.class_weight == {0: 0.45, 1: 1}
+
+
+def test_logreg_class_weight_accepts_sklearn_native_values():
+
+    data = _make_data(binary=True, with_price=False)
+    model = LogRegBinary().train(data, solver='lbfgs', max_iter=200, class_weight='balanced')
+
+    assert model.model.class_weight == 'balanced'
 
 
 def test_random_binary_train_evaluate_end_to_end():

--- a/tests/test_yaml.py
+++ b/tests/test_yaml.py
@@ -1,4 +1,6 @@
+import inspect
 from datetime import date
+from pathlib import Path
 from textwrap import dedent
 
 from limen.calibration import grid_threshold_optimizer
@@ -89,12 +91,21 @@ _MINIMAL_ML_YAML = dedent('''\
         threshold_min: [0.20]
         threshold_max: [0.70]
         threshold_step: [0.05]
-        penalty: [l2]
-        class_weight: [0.5]
-        C: [1.0]
-        max_iter: [100]
         solver: [lbfgs]
+        penalty: [l2]
+        dual: [false]
         tol: [0.01]
+        C: [1.0]
+        fit_intercept: [true]
+        intercept_scaling: [1.0]
+        class_weight: [0.5]
+        random_state: [42]
+        max_iter: [100]
+        multi_class: [deprecated]
+        verbose: [0]
+        warm_start: [false]
+        n_jobs: [-1]
+        l1_ratio: [null]
     uel:
       n_permutations: 5
       search_strategy:
@@ -240,6 +251,23 @@ def test_validate_passes_valid_ml_yaml() -> None:
     result = validate(yaml_dict)
     assert result.valid
     assert result.errors == []
+
+
+def test_logreg_yaml_template_exposes_full_architecture_surface() -> None:
+    template = Path(__file__).resolve().parents[1] / 'limen/yaml/templates/logreg_binary.yaml'
+    yaml_dict, errors = parse(template.read_text())
+    assert errors == []
+
+    result = validate(yaml_dict)
+    assert result.valid, [e.message for e in result.errors]
+
+    arch = resolve(yaml_dict['sfd']['manifest']['reference_architecture'])
+    model_params = set(inspect.signature(arch).parameters) - {
+        'data',
+        'prediction_calibration_config',
+    }
+
+    assert model_params <= set(yaml_dict['sfd']['params'])
 
 
 def test_validate_passes_valid_rule_based_yaml() -> None:


### PR DESCRIPTION
## Summary
- Expose the complete sklearn `LogisticRegression` constructor surface through the LogReg reference wrapper.
- Add the same model parameters to the foundational LogReg `params()` and YAML template.
- Preserve legacy numeric `class_weight` shorthand while allowing sklearn-native values.

## Validation
- `git diff --cached --check`
- `.venv/bin/python -m compileall -q limen tests`
- Focused local tests were run before the final commit; full local suite is running after PR creation per operator instruction.
