### PR TITLE
feat(scalers): add CausalRollingRobustScaler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -932,3 +932,8 @@ Note: add all new changelog entries to the bottom of this file.
 
 - Add `tabpfn_binary.yaml`, `xgboost_regressor.yaml`, and `rule_based.yaml` YAML experiment templates
 - Rule-based YAML manifests now support `indicators` — wired into `RuleBasedManifest.feature_transforms` at compile time
+
+## v3.5.3 on 21st of May, 2026
+
+- Add `CausalRollingRobustScaler` to `limen.scalers` — a robust scaler that computes each row's median and IQR from a strictly trailing rolling window (`.shift(1)`, no look-ahead) and falls back to train-fitted statistics during warmup
+- Register the new scaler in `SCALER_REGISTRY` under the key `causal_rolling_robust`

--- a/docs/Scalers.md
+++ b/docs/Scalers.md
@@ -23,6 +23,7 @@ That is why scalers live separately from the stateless helpers in [Transforms](T
 | `LogRegScaler` | the reference logistic-regression style feature sets used in foundational flows | yes | Uses a fixed per-column rule map. Columns outside the rule map are left alone. |
 | `LinearScaler` | mixed feature sets where regex-based scaling rules are useful | yes | The most flexible built-in scaler. Supports `standard`, `log_standard`, `divide_100`, and `none`. |
 | `RobustScaler` | outlier-heavy numeric features | yes | Uses median and IQR instead of mean and standard deviation. |
+| `CausalRollingRobustScaler` | non-stationary features whose scale drifts over time | no | Median and IQR from a strictly trailing rolling window, so no look-ahead. Not row-wise invertible from the fitted scaler. |
 | `RankGaussScaler` | numeric features that benefit from a Gaussianized shape | approximate | The inverse is only approximate because rank-based transforms are lossy. |
 
 ## Manifest Usage
@@ -53,6 +54,7 @@ The built-in registry currently maps:
 | `'logreg'` | `LogRegScaler` |
 | `'robust'` | `RobustScaler` |
 | `'rank_gauss'` | `RankGaussScaler` |
+| `'causal_rolling_robust'` | `CausalRollingRobustScaler` |
 
 The registry itself is also a public export:
 
@@ -111,6 +113,20 @@ It skips datetime and non-numeric columns automatically and is usually the safes
 
 Use it when relative ordering matters more than preserving original spacing. Its inverse transform is approximate, not exact.
 
+### CausalRollingRobustScaler
+
+`CausalRollingRobustScaler(x_train, window=1000, quantile_range=(0.25, 0.75), clip=8.0, min_samples=50)` applies:
+
+```python
+(x - rolling_median) / rolling_IQR
+```
+
+The median and IQR for each row are taken from the `window` rows strictly before it (`.shift(1)`), so the transform never reads the current row or any future row. That makes it suited to non-stationary series whose scale drifts over time.
+
+Rows with fewer than `min_samples` of trailing history fall back to the median and IQR fitted on `x_train`, so during warmup it degrades to plain `RobustScaler` behavior. The scaled output is clipped to `+/- clip`.
+
+It skips datetime and non-numeric columns automatically. It provides no inverse transform: each row's scaling factors are derived from the data itself, so the transform is not row-wise invertible from the fitted scaler alone.
+
 ## Custom Scaler Contract
 
 All custom scalers should follow the same interface:
@@ -135,7 +151,7 @@ That contract is what makes the scaler usable from `Manifest.set_scaler()` and c
 
 ## Practical Notes
 
-- `RobustScaler` and `RankGaussScaler` automatically skip datetime and non-numeric columns.
+- `RobustScaler`, `CausalRollingRobustScaler`, and `RankGaussScaler` automatically skip datetime and non-numeric columns.
 - `LogRegScaler` and `LinearScaler` are rule-driven, so only columns matched by their rule sets are transformed.
 - `LinearScaler` is the better choice when new feature names are expected to appear frequently.
 - If a prediction post-processing step needs original scale values, prefer a scaler with a meaningful inverse path.

--- a/limen/scalers/README.md
+++ b/limen/scalers/README.md
@@ -19,6 +19,7 @@ Does **not** own raw feature creation or the experiment loop itself.
 | `LinearScaler` | You want rule-based scaling over mixed market-data columns | Exported at the package root |
 | `LogRegScaler` | You want the standard scaler used by logistic-regression SFDs | Exported at the package root |
 | `RobustScaler` | You want median and IQR scaling for outlier-heavy data | Exported at the package root |
+| `CausalRollingRobustScaler` | You want robust scaling that adapts to drift, with no look-ahead | Exported at the package root |
 | `RankGaussScaler` | You want rank-based Gaussianization | Exported at the package root |
 | `SCALER_REGISTRY` | You want to resolve scalers by manifest parameter name | Used by `set_scaler_from_params()` |
 | `build_rules`, `inverse_transform` | You need to customize or interpret `LinearScaler` behavior | Available from the module-level implementations |
@@ -33,11 +34,12 @@ Does **not** own raw feature creation or the experiment loop itself.
 
 ```text
 scalers/
-├── linear_scaler.py       # LinearScaler, rule helpers, inverse transform
-├── logreg_scaler.py       # Logistic-regression tuned scaling
-├── robust_scaler.py       # Median and IQR scaling
-├── rank_gauss_scaler.py   # Rank-based Gaussianization
-└── registry.py            # SCALER_REGISTRY
+├── linear_scaler.py                 # LinearScaler, rule helpers, inverse transform
+├── logreg_scaler.py                 # Logistic-regression tuned scaling
+├── robust_scaler.py                 # Median and IQR scaling
+├── causal_rolling_robust_scaler.py  # Causal trailing-window median and IQR scaling
+├── rank_gauss_scaler.py             # Rank-based Gaussianization
+└── registry.py                      # SCALER_REGISTRY
 ```
 
 ## Things to know

--- a/limen/scalers/__init__.py
+++ b/limen/scalers/__init__.py
@@ -1,3 +1,4 @@
+from limen.scalers.causal_rolling_robust_scaler import CausalRollingRobustScaler
 from limen.scalers.linear_scaler import LinearScaler
 from limen.scalers.logreg_scaler import LogRegScaler
 from limen.scalers.rank_gauss_scaler import RankGaussScaler
@@ -6,6 +7,7 @@ from limen.scalers.robust_scaler import RobustScaler
 
 __all__ = [
     'SCALER_REGISTRY',
+    'CausalRollingRobustScaler',
     'LinearScaler',
     'LogRegScaler',
     'RankGaussScaler',

--- a/limen/scalers/causal_rolling_robust_scaler.py
+++ b/limen/scalers/causal_rolling_robust_scaler.py
@@ -1,0 +1,116 @@
+import polars as pl
+
+
+class CausalRollingRobustScaler:
+
+    '''Causal trailing-window median and IQR scaling, with no look-ahead.'''
+
+    def __init__(self,
+                 x_train: pl.DataFrame,
+                 window: int = 1000,
+                 quantile_range: tuple[float, float] = (0.25, 0.75),
+                 clip: float = 8.0,
+                 min_samples: int = 50) -> None:
+
+        '''
+        Fit fallback median and IQR statistics on training data.
+
+        The fitted statistics are not applied directly. They are the warmup
+        fallback used for rows whose trailing window holds fewer than
+        `min_samples` observations, where this scaler degrades gracefully to
+        plain median and IQR scaling.
+
+        Args:
+            x_train (pl.DataFrame): Training data
+            window (int): Trailing window length, in rows, for rolling statistics
+            quantile_range (tuple[float, float]): Lower and upper quantiles for IQR
+            clip (float): Symmetric bound applied to the scaled output
+            min_samples (int): Minimum trailing observations before a rolling statistic is used
+
+        '''
+
+        q_low, q_high = quantile_range
+        if not (0 <= q_low < q_high <= 1):
+            raise ValueError(
+                f"quantile_range must satisfy 0 <= low < high <= 1, "
+                f"got ({q_low}, {q_high})"
+            )
+        if window <= 1:
+            raise ValueError(f"window must be >= 2, got {window}")
+        if clip <= 0:
+            raise ValueError(f"clip must be > 0, got {clip}")
+
+        self.window = window
+        self.quantile_range = quantile_range
+        self.clip = clip
+        self.min_samples = max(1, min(min_samples, window))
+
+        self.medians: dict[str, float] = {}
+        self.iqrs: dict[str, float] = {}
+
+        for col in x_train.columns:
+            if x_train[col].dtype == pl.Datetime or not x_train[col].dtype.is_numeric():
+                continue
+
+            median = x_train[col].median()
+            q_lo = x_train[col].quantile(q_low)
+            q_hi = x_train[col].quantile(q_high)
+
+            if median is None or q_lo is None or q_hi is None:
+                continue
+
+            iqr = q_hi - q_lo
+
+            self.medians[col] = median
+            self.iqrs[col] = iqr if iqr != 0 else 1.0
+
+
+    def transform(self, df: pl.DataFrame) -> pl.DataFrame:
+
+        '''
+        Apply causal rolling robust scaling: (x - rolling_median) / rolling_IQR.
+
+        For each row the median and IQR are taken from the trailing `window`
+        rows strictly before it (`.shift(1)`), so the transform never reads
+        the current row or any future row. Rows with fewer than `min_samples`
+        trailing observations fall back to the train-fitted median and IQR.
+        The scaled output is clipped to +/- `clip`.
+
+        Args:
+            df (pl.DataFrame): Data to transform
+
+        Returns:
+            pl.DataFrame: Transformed data
+        '''
+
+        q_low, q_high = self.quantile_range
+        exprs = []
+
+        for col in df.columns:
+            if col not in self.medians:
+                continue
+
+            center = (
+                pl.col(col)
+                .rolling_median(window_size=self.window, min_samples=self.min_samples)
+                .shift(1)
+                .fill_null(self.medians[col])
+            )
+            q_hi = pl.col(col).rolling_quantile(
+                q_high, window_size=self.window, min_samples=self.min_samples,
+            ).shift(1)
+            q_lo = pl.col(col).rolling_quantile(
+                q_low, window_size=self.window, min_samples=self.min_samples,
+            ).shift(1)
+
+            scale = (q_hi - q_lo).fill_null(self.iqrs[col])
+            scale = pl.when(scale > 0).then(scale).otherwise(self.iqrs[col])
+
+            exprs.append(
+                ((pl.col(col) - center) / scale).clip(-self.clip, self.clip).alias(col)
+            )
+
+        if not exprs:
+            return df
+
+        return df.with_columns(exprs)

--- a/limen/scalers/causal_rolling_robust_scaler.py
+++ b/limen/scalers/causal_rolling_robust_scaler.py
@@ -39,11 +39,16 @@ class CausalRollingRobustScaler:
             raise ValueError(f"window must be >= 2, got {window}")
         if clip <= 0:
             raise ValueError(f"clip must be > 0, got {clip}")
+        if not (1 <= min_samples <= window):
+            raise ValueError(
+                f"min_samples must satisfy 1 <= min_samples <= window ({window}), "
+                f"got {min_samples}"
+            )
 
         self.window = window
         self.quantile_range = quantile_range
         self.clip = clip
-        self.min_samples = max(1, min(min_samples, window))
+        self.min_samples = min_samples
 
         self.medians: dict[str, float] = {}
         self.iqrs: dict[str, float] = {}

--- a/limen/scalers/registry.py
+++ b/limen/scalers/registry.py
@@ -1,3 +1,4 @@
+from limen.scalers.causal_rolling_robust_scaler import CausalRollingRobustScaler
 from limen.scalers.linear_scaler import LinearScaler
 from limen.scalers.logreg_scaler import LogRegScaler
 from limen.scalers.robust_scaler import RobustScaler
@@ -8,4 +9,5 @@ SCALER_REGISTRY: dict[str, type] = {
     'logreg': LogRegScaler,
     'robust': RobustScaler,
     'rank_gauss': RankGaussScaler,
+    'causal_rolling_robust': CausalRollingRobustScaler,
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaquum_limen"
-version = "3.5.2"
+version = "3.5.3"
 description = "Bitcoin-first research and trading platform."
 readme = "README.md"
 authors = [

--- a/tests/test_scalers.py
+++ b/tests/test_scalers.py
@@ -257,6 +257,17 @@ def test_causal_rolling_robust_scaler_invalid_quantile_range():
         assert 'quantile_range' in str(e)
 
 
+def test_causal_rolling_robust_scaler_invalid_min_samples():
+
+    try:
+        CausalRollingRobustScaler(
+            pl.DataFrame({'a': [1.0, 2.0, 3.0]}), window=10, min_samples=50,
+        )
+        assert False, 'Expected ValueError'
+    except ValueError as e:
+        assert 'min_samples' in str(e)
+
+
 def _make_manifest_with_scaler_from_params() -> MLManifest:
 
     return (MLManifest()

--- a/tests/test_scalers.py
+++ b/tests/test_scalers.py
@@ -2,6 +2,7 @@ import polars as pl
 import numpy as np
 
 from limen.experiment import MLManifest
+from limen.scalers.causal_rolling_robust_scaler import CausalRollingRobustScaler
 from limen.scalers.rank_gauss_scaler import RankGaussScaler
 from limen.scalers.registry import SCALER_REGISTRY
 from limen.scalers.robust_scaler import RobustScaler
@@ -144,6 +145,118 @@ def test_robust_scaler_all_null_column():
     assert 'normal' in scaler.medians
 
 
+def test_causal_rolling_robust_scaler_fit_and_transform():
+
+    train = _make_train_data()
+    scaler = CausalRollingRobustScaler(train, window=20, min_samples=5)
+    transformed = scaler.transform(train)
+
+    assert 'price' in transformed.columns
+    assert 'datetime' in transformed.columns
+    assert transformed.height == train.height
+    assert not transformed['price'].is_nan().any()
+
+
+def test_causal_rolling_robust_scaler_no_lookahead():
+
+    train = _make_train_data()
+    scaler = CausalRollingRobustScaler(train, window=20, min_samples=5)
+    full = scaler.transform(train)
+
+    for t in (10, 40, 80):
+        prefix = scaler.transform(train.head(t + 1))
+        assert abs(full['price'][t] - prefix['price'][t]) < 1e-9
+
+
+def test_causal_rolling_robust_scaler_warmup_uses_fallback():
+
+    train = _make_train_data()
+    scaler = CausalRollingRobustScaler(train, window=20, min_samples=5)
+    transformed = scaler.transform(train)
+
+    raw = (train['price'][0] - scaler.medians['price']) / scaler.iqrs['price']
+    expected = max(-scaler.clip, min(scaler.clip, raw))
+    assert abs(transformed['price'][0] - expected) < 1e-9
+
+
+def test_causal_rolling_robust_scaler_clip_bound():
+
+    train = _make_train_data()
+    scaler = CausalRollingRobustScaler(train, window=20, min_samples=5, clip=3.0)
+    transformed = scaler.transform(train)
+
+    price = transformed['price'].to_numpy()
+    assert price.max() <= 3.0 + 1e-9
+    assert price.min() >= -3.0 - 1e-9
+
+
+def test_causal_rolling_robust_scaler_zero_iqr_guard():
+
+    train = pl.DataFrame({
+        'constant': [5.0] * 80,
+        'normal': np.random.RandomState(42).normal(0, 1, 80),
+    })
+    scaler = CausalRollingRobustScaler(train, window=20, min_samples=5)
+    assert scaler.iqrs['constant'] == 1.0
+
+    transformed = scaler.transform(train)
+    assert not transformed['constant'].is_nan().any()
+    assert not np.any(np.isinf(transformed['constant'].to_numpy()))
+
+
+def test_causal_rolling_robust_scaler_preserves_datetime():
+
+    train = _make_train_data()
+    scaler = CausalRollingRobustScaler(train)
+    assert 'datetime' not in scaler.medians
+
+    transformed = scaler.transform(train)
+    assert transformed['datetime'].equals(train['datetime'])
+
+
+def test_causal_rolling_robust_scaler_all_null_column():
+
+    train = pl.DataFrame({
+        'all_null': pl.Series([None] * 40, dtype=pl.Float64),
+        'normal': np.random.RandomState(42).normal(0, 1, 40),
+    })
+    scaler = CausalRollingRobustScaler(train, window=10, min_samples=3)
+    assert 'all_null' not in scaler.medians
+    assert 'normal' in scaler.medians
+
+    unchanged = scaler.transform(pl.DataFrame({'other': [1.0, 2.0, 3.0]}))
+    assert unchanged['other'].to_list() == [1.0, 2.0, 3.0]
+
+
+def test_causal_rolling_robust_scaler_invalid_window():
+
+    try:
+        CausalRollingRobustScaler(pl.DataFrame({'a': [1.0, 2.0, 3.0]}), window=1)
+        assert False, 'Expected ValueError'
+    except ValueError as e:
+        assert 'window' in str(e)
+
+
+def test_causal_rolling_robust_scaler_invalid_clip():
+
+    try:
+        CausalRollingRobustScaler(pl.DataFrame({'a': [1.0, 2.0, 3.0]}), clip=0.0)
+        assert False, 'Expected ValueError'
+    except ValueError as e:
+        assert 'clip' in str(e)
+
+
+def test_causal_rolling_robust_scaler_invalid_quantile_range():
+
+    try:
+        CausalRollingRobustScaler(
+            pl.DataFrame({'a': [1.0, 2.0, 3.0]}), quantile_range=(0.9, 0.1),
+        )
+        assert False, 'Expected ValueError'
+    except ValueError as e:
+        assert 'quantile_range' in str(e)
+
+
 def _make_manifest_with_scaler_from_params() -> MLManifest:
 
     return (MLManifest()
@@ -210,7 +323,7 @@ def test_scaler_factory_selects_all_types():
 
     manifest = _make_manifest_with_scaler_from_params()
     raw_data = manifest.fetch_test_data()
-    for scaler_type in ('linear', 'logreg', 'robust', 'rank_gauss'):
+    for scaler_type in ('linear', 'logreg', 'robust', 'rank_gauss', 'causal_rolling_robust'):
         data = manifest.prepare_data(raw_data, {'scaler_type': scaler_type})
         assert data['x_train'].height > 0
 
@@ -232,3 +345,4 @@ def test_scaler_factory_registry_has_all():
     assert 'logreg' in SCALER_REGISTRY
     assert 'robust' in SCALER_REGISTRY
     assert 'rank_gauss' in SCALER_REGISTRY
+    assert 'causal_rolling_robust' in SCALER_REGISTRY


### PR DESCRIPTION
## Summary

Adds `CausalRollingRobustScaler` to `limen.scalers` — a robust scaler whose median and IQR for each row are computed from a strictly trailing rolling window (`.shift(1)`), so the transform never reads the current or any future row. This suits non-stationary series whose scale drifts over time, where a static train-fitted scaler would either leak or go stale.

- New `limen/scalers/causal_rolling_robust_scaler.py` — follows the existing scaler shape (`__init__(x_train, ...)` fit + `transform()`), all config defaulted so it is registry-constructible.
- Rows without `min_samples` of trailing history fall back to the median/IQR fitted on `x_train`, degrading gracefully to plain `RobustScaler` during warmup.
- Registered in `SCALER_REGISTRY` as `causal_rolling_robust`; exported from `limen.scalers`.
- No `inverse_transform`: each row's scaling factors are derived from the data itself, so the transform is not row-wise invertible from the fitted scaler alone (documented).
- `CHANGELOG.md` entry + version bump to `3.5.3`; `scalers/README.md` and `docs/Scalers.md` updated.

## Test plan

- 10 new unit tests in `tests/test_scalers.py`, including an explicit no-look-ahead guarantee (`transform(df)[t] == transform(df[:t+1])[t]`), warmup fallback, clipping, zero-IQR guard, datetime/non-numeric skipping, and config validation.
- `test_scaler_factory_*` updated — exercises the new scaler end-to-end through `set_scaler_from_params`.
- `pytest tests/test_scalers.py` — 29 passed. `ruff check` — clean.