### PR TITLE
fix: reconstruct yaml artifacts in trainer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -956,3 +956,7 @@ Note: add all new changelog entries to the bottom of this file.
 - Add `ForwardVolNormalizedReturnTarget` for forward log-return labels normalized by current Parkinson volatility
 - Route new regression coverage into the existing feature-library and target test suites
 - Require code-changing PRs to include both a CHANGELOG entry and package version update
+
+## v3.9.1 on 21st of May, 2026
+
+- Make `Trainer` reconstruct YAML CLI experiment artifacts directly from `metadata.json["yaml_reference"]`, so `sfd_module: yaml:<name>` metadata no longer blocks promotion.

--- a/limen/experiment/trainer/trainer.py
+++ b/limen/experiment/trainer/trainer.py
@@ -13,6 +13,7 @@ import polars as pl
 from limen.experiment.trainer.errors import ReconstructionError
 from limen.experiment.trainer.sensor import Sensor
 from limen.sfd.reference_architecture.base import ReferenceModel
+from limen.yaml.compiler import CompiledSFD
 
 logger = logging.getLogger(__name__)
 
@@ -75,13 +76,22 @@ class Trainer:
                 f"Only experiments created with experiment_dir support training."
             ) from None
 
-        if 'sfd_module' not in self._metadata:
-            raise ValueError(
-                'metadata.json missing required key: sfd_module'
-            )
+        yaml_reference = self._metadata.get('yaml_reference')
+        if yaml_reference is not None:
+            if not isinstance(yaml_reference, dict):
+                raise ValueError(
+                    "metadata.json key 'yaml_reference' must be an object"
+                )
+            sfd_module_name = self._metadata.get('sfd_module', 'yaml_reference')
+            sfd = CompiledSFD(yaml_reference)
+        else:
+            if 'sfd_module' not in self._metadata:
+                raise ValueError(
+                    'metadata.json missing required key: sfd_module'
+                )
 
-        sfd_module_name = self._metadata['sfd_module']
-        sfd = self._load_sfd_module(sfd_module_name)
+            sfd_module_name = self._metadata['sfd_module']
+            sfd = self._load_sfd_module(sfd_module_name)
 
         if not hasattr(sfd, 'manifest') or not hasattr(sfd, 'params'):
             raise ValueError(

--- a/limen/experiment/trainer/trainer.py
+++ b/limen/experiment/trainer/trainer.py
@@ -44,18 +44,19 @@ class Trainer:
         '''
         Create a Trainer from a completed experiment directory.
 
-        The SFD module named by `metadata.json["sfd_module"]` is loaded
-        in two stages: first the experiment_dir is searched for a file
-        of the same name (`<sfd_module>.py`); only when that file is
-        absent is the name resolved via `importlib.import_module` against
-        `sys.path` (the legacy mode for built-in SFDs referenced by a
-        fully-qualified package path). The experiment-local path is the
-        forward-looking contract — `trainer_prep.py`-style flows can
-        ship the SFD inside the experiment_dir and the Trainer becomes
-        self-sufficient with no operator-side `PYTHONPATH` wiring.
+        If metadata.json includes `yaml_reference`, Trainer rebuilds the
+        SFD from that declarative YAML payload and does not import or exec
+        Python for SFD reconstruction. Otherwise, the SFD module named by
+        `metadata.json["sfd_module"]` is loaded in two stages: first the
+        experiment_dir is searched for a file of the same name
+        (`<sfd_module>.py`); only when that file is absent is the name
+        resolved via `importlib.import_module` against `sys.path` (the
+        legacy mode for built-in SFDs referenced by a fully-qualified
+        package path).
 
-        NOTE: experiment_dir must be trusted. The SFD module is imported
-        as Python and executes arbitrary code from that module.
+        NOTE: experiment_dir must be trusted when the Python SFD module
+        path is used. That path imports Python and executes arbitrary code
+        from the module.
 
         Args:
             experiment_dir (str | Path): Path to completed experiment directory
@@ -80,10 +81,16 @@ class Trainer:
         if yaml_reference is not None:
             if not isinstance(yaml_reference, dict):
                 raise ValueError(
-                    "metadata.json key 'yaml_reference' must be an object"
+                    'metadata.json key \'yaml_reference\' must be an object'
                 )
             sfd_module_name = self._metadata.get('sfd_module', 'yaml_reference')
-            sfd = CompiledSFD(yaml_reference)
+            try:
+                sfd = CompiledSFD(yaml_reference)
+            except (KeyError, TypeError, ValueError) as exc:
+                raise ValueError(
+                    'metadata.json key \'yaml_reference\' is not a valid '
+                    'YAML SFD reference'
+                ) from exc
         else:
             if 'sfd_module' not in self._metadata:
                 raise ValueError(
@@ -99,8 +106,16 @@ class Trainer:
                 f"params(). Trainer requires a manifest-based SFD."
             )
 
-        self._manifest = sfd.manifest()
-        params = sfd.params()
+        try:
+            self._manifest = sfd.manifest()
+            params = sfd.params()
+        except (KeyError, TypeError, ValueError) as exc:
+            if yaml_reference is not None:
+                raise ValueError(
+                    'metadata.json key \'yaml_reference\' is not a valid '
+                    'YAML SFD reference'
+                ) from exc
+            raise
         self._param_keys = frozenset(params.keys())
         self._round_data = self._load_round_data()
         self._original_log = self._load_original_log()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "vaquum_limen"
 version = "3.9.1"
-description = "Bitcoin-first research and trading platform."
+description = "Limen unifies parameter search across machine learning and rule-based strategies, with built-in analytics that show not just what works, but why it works."
 readme = "README.md"
 authors = [
   { name = "Mikko Kotila", email = "mailme@mikkokotila.com" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaquum_limen"
-version = "3.9.0"
+version = "3.9.1"
 description = "Bitcoin-first research and trading platform."
 readme = "README.md"
 authors = [

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -603,14 +603,21 @@ def test_trainer_reconstructs_yaml_artifact_from_metadata_reference(monkeypatch)
     assert trainer._param_keys == frozenset({'alpha'})
 
 
-def test_trainer_rejects_malformed_yaml_reference() -> None:
+@pytest.mark.parametrize(
+    'yaml_reference',
+    [
+        [],
+        {'metadata': {'name': 'yaml_exp'}, 'sfd': {}},
+    ],
+)
+def test_trainer_rejects_malformed_yaml_reference(yaml_reference) -> None:
 
     with TemporaryDirectory() as tmpdir:
         experiment_dir = Path(tmpdir)
         (experiment_dir / 'metadata.json').write_text(
             json.dumps({
                 'sfd_module': 'yaml:yaml_exp',
-                'yaml_reference': [],
+                'yaml_reference': yaml_reference,
             }),
         )
         (experiment_dir / 'round_data.jsonl').write_text('')

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -555,6 +555,73 @@ def test_trainer_loads_sfd_from_experiment_dir_without_sys_path_mutation() -> No
     assert sys.path == sys_path_before
 
 
+def test_trainer_reconstructs_yaml_artifact_from_metadata_reference(monkeypatch) -> None:
+
+    '''
+    YAML CLI runs store the declarative SFD under metadata.json["yaml_reference"]
+    while metadata.json["sfd_module"] uses a non-importable yaml:<name> marker.
+    Trainer must use the YAML reference directly instead of treating that marker
+    as a Python module path.
+    '''
+
+    seen = {}
+
+    class FakeCompiledSFD:
+
+        def __init__(self, yaml_reference):
+            seen['yaml_reference'] = yaml_reference
+
+        def params(self):
+            return {'alpha': [1]}
+
+        def manifest(self):
+            return SimpleNamespace(architecture_function=None)
+
+    monkeypatch.setattr(trainer_module, 'CompiledSFD', FakeCompiledSFD)
+
+    yaml_reference = {
+        'metadata': {'name': 'yaml_exp'},
+        'sfd': {'params': {'alpha': [1]}},
+    }
+
+    with TemporaryDirectory() as tmpdir:
+        experiment_dir = Path(tmpdir)
+        (experiment_dir / 'metadata.json').write_text(
+            json.dumps({
+                'sfd_module': 'yaml:yaml_exp',
+                'yaml_reference': yaml_reference,
+            }),
+        )
+        (experiment_dir / 'round_data.jsonl').write_text('')
+
+        trainer = Trainer(
+            experiment_dir,
+            data=pl.DataFrame({'x': [1, 2, 3]}),
+        )
+
+    assert seen['yaml_reference'] == yaml_reference
+    assert trainer._param_keys == frozenset({'alpha'})
+
+
+def test_trainer_rejects_malformed_yaml_reference() -> None:
+
+    with TemporaryDirectory() as tmpdir:
+        experiment_dir = Path(tmpdir)
+        (experiment_dir / 'metadata.json').write_text(
+            json.dumps({
+                'sfd_module': 'yaml:yaml_exp',
+                'yaml_reference': [],
+            }),
+        )
+        (experiment_dir / 'round_data.jsonl').write_text('')
+
+        with pytest.raises(ValueError, match='yaml_reference'):
+            Trainer(
+                experiment_dir,
+                data=pl.DataFrame({'x': [1, 2, 3]}),
+            )
+
+
 def test_trainer_loads_sfd_rolls_back_sys_modules_on_exec_failure() -> None:
 
     '''


### PR DESCRIPTION
## Summary
- Make Trainer reconstruct YAML CLI experiment artifacts directly from `metadata.json["yaml_reference"]`.
- Preserve existing Python SFD module loading for non-YAML artifacts.
- Add regression coverage for `sfd_module: yaml:<name>` metadata and malformed YAML references.
- Bump package version to 3.9.1 and update CHANGELOG.

## Root Cause
YAML CLI runs already persist the parsed experiment under `yaml_reference`, but `Trainer` tries to import `sfd_module` first. For YAML runs that value is `yaml:<name>`, which is provenance metadata, not a Python module path.

## Validation Plan
- Run focused Trainer tests locally after PR creation.
- Run YAML tests locally after PR creation.
- Watch PR checks and review state.
