### PR TITLE
fix: wrap yaml trainer resolution errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -960,3 +960,7 @@ Note: add all new changelog entries to the bottom of this file.
 ## v3.9.1 on 21st of May, 2026
 
 - Make `Trainer` reconstruct YAML CLI experiment artifacts directly from `metadata.json["yaml_reference"]`, so `sfd_module: yaml:<name>` metadata no longer blocks promotion.
+
+## v3.9.2 on 21st of May, 2026
+
+- Wrap YAML reference resolution failures in `Trainer` as stable `ValueError` messages that point to `metadata.json["yaml_reference"]`.

--- a/limen/experiment/trainer/trainer.py
+++ b/limen/experiment/trainer/trainer.py
@@ -14,6 +14,7 @@ from limen.experiment.trainer.errors import ReconstructionError
 from limen.experiment.trainer.sensor import Sensor
 from limen.sfd.reference_architecture.base import ReferenceModel
 from limen.yaml.compiler import CompiledSFD
+from limen.yaml.errors import ResolutionError
 
 logger = logging.getLogger(__name__)
 
@@ -45,8 +46,9 @@ class Trainer:
         Create a Trainer from a completed experiment directory.
 
         If metadata.json includes `yaml_reference`, Trainer rebuilds the
-        SFD from that declarative YAML payload and does not import or exec
-        Python for SFD reconstruction. Otherwise, the SFD module named by
+        SFD from that declarative YAML payload without importing or
+        executing an experiment-provided SFD module. Otherwise, the SFD
+        module named by
         `metadata.json["sfd_module"]` is loaded in two stages: first the
         experiment_dir is searched for a file of the same name
         (`<sfd_module>.py`); only when that file is absent is the name
@@ -109,7 +111,7 @@ class Trainer:
         try:
             self._manifest = sfd.manifest()
             params = sfd.params()
-        except (KeyError, TypeError, ValueError) as exc:
+        except (KeyError, ResolutionError, TypeError, ValueError) as exc:
             if yaml_reference is not None:
                 raise ValueError(
                     'metadata.json key \'yaml_reference\' is not a valid '

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaquum_limen"
-version = "3.9.1"
+version = "3.9.2"
 description = "Limen unifies parameter search across machine learning and rule-based strategies, with built-in analytics that show not just what works, but why it works."
 readme = "README.md"
 authors = [

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -640,7 +640,10 @@ def test_trainer_wraps_yaml_resolution_error(monkeypatch) -> None:
             return {'alpha': [1]}
 
         def manifest(self):
-            raise trainer_module.ResolutionError('bad reference')
+            raise trainer_module.ResolutionError(
+                'bad.reference',
+                ['limen'],
+            )
 
     monkeypatch.setattr(trainer_module, 'CompiledSFD', FakeCompiledSFD)
 

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -629,6 +629,41 @@ def test_trainer_rejects_malformed_yaml_reference(yaml_reference) -> None:
             )
 
 
+def test_trainer_wraps_yaml_resolution_error(monkeypatch) -> None:
+
+    class FakeCompiledSFD:
+
+        def __init__(self, _yaml_reference):
+            pass
+
+        def params(self):
+            return {'alpha': [1]}
+
+        def manifest(self):
+            raise trainer_module.ResolutionError('bad reference')
+
+    monkeypatch.setattr(trainer_module, 'CompiledSFD', FakeCompiledSFD)
+
+    with TemporaryDirectory() as tmpdir:
+        experiment_dir = Path(tmpdir)
+        (experiment_dir / 'metadata.json').write_text(
+            json.dumps({
+                'sfd_module': 'yaml:yaml_exp',
+                'yaml_reference': {
+                    'metadata': {'name': 'yaml_exp'},
+                    'sfd': {'params': {'alpha': [1]}},
+                },
+            }),
+        )
+        (experiment_dir / 'round_data.jsonl').write_text('')
+
+        with pytest.raises(ValueError, match='yaml_reference'):
+            Trainer(
+                experiment_dir,
+                data=pl.DataFrame({'x': [1, 2, 3]}),
+            )
+
+
 def test_trainer_loads_sfd_rolls_back_sys_modules_on_exec_failure() -> None:
 
     '''


### PR DESCRIPTION
## Summary
- wraps YAML reference resolution failures in Trainer as stable ValueError messages pointing to metadata.json["yaml_reference"]
- clarifies the YAML reconstruction docstring so it does not claim zero Python imports
- bumps package version to 3.9.2 and adds CHANGELOG entry

## Validation
- .venv/bin/python -m ruff check limen/experiment/trainer/trainer.py tests/test_trainer.py
- .venv/bin/python -m pytest tests/test_trainer.py tests/test_yaml.py -q