### PR TITLE
fix: skip post-processing by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -972,6 +972,6 @@ Note: add all new changelog entries to the bottom of this file.
 - Add `limen init <output.yaml> --template <name>` CLI command — scaffolds a new experiment file from a template
 - Add `limen run --resume <results-dir>` CLI command — resumes an experiment from a checkpoint directory using `yaml_reference` and `target_permutations` from the checkpoint
 
-## v3.10.1 on 22nd of May, 2026
+## v4.0.0 on 22nd of May, 2026
 
-- Make `UniversalExperimentLoop.run()` skip terminal post-processing by default and retain `post_processing=True` as an explicit opt-in.
+- Breaking: make `UniversalExperimentLoop.run()` skip terminal post-processing by default and retain `post_processing=True` as an explicit opt-in.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -971,3 +971,7 @@ Note: add all new changelog entries to the bottom of this file.
 - Add `limen list-templates` CLI command — lists all available YAML experiment templates with descriptions
 - Add `limen init <output.yaml> --template <name>` CLI command — scaffolds a new experiment file from a template
 - Add `limen run --resume <results-dir>` CLI command — resumes an experiment from a checkpoint directory using `yaml_reference` and `target_permutations` from the checkpoint
+
+## v3.10.1 on 22nd of May, 2026
+
+- Make `UniversalExperimentLoop.run()` skip terminal post-processing by default and retain `post_processing=True` as an explicit opt-in.

--- a/limen/cohort/regime_pools.py
+++ b/limen/cohort/regime_pools.py
@@ -205,7 +205,8 @@ class OnlineModelLoader:
                 experiment_name=f"rdop_regime_{regime_id}_model_{model_id}",
                 n_permutations=1,
                 prep_each_round=True,
-                params=lambda: params
+                params=lambda: params,
+                post_processing=True,
             )
         else:
             uel = UniversalExperimentLoop(
@@ -216,7 +217,8 @@ class OnlineModelLoader:
                 prep_each_round=False,
                 params=lambda: params,
                 prep=self.sfd.prep,
-                model=self.sfd.model
+                model=self.sfd.model,
+                post_processing=True,
             )
 
         round_id = 0

--- a/limen/experiment/experiment_core.py
+++ b/limen/experiment/experiment_core.py
@@ -123,6 +123,7 @@ class UniversalExperimentLoop:
         self._experiment_dir = Path(experiment_dir) if experiment_dir else None
         self._intra_callback = intra_callback
         self._yaml_reference = copy.deepcopy(yaml_reference)
+        self._clear_post_processing_outputs()
 
     def run(self,
             experiment_name: str,
@@ -134,7 +135,8 @@ class UniversalExperimentLoop:
             params: Callable | None = None,
             prep: Callable | None = None,
             model: Callable | None = None,
-            resume: bool = False) -> None:
+            resume: bool = False,
+            post_processing: bool = False) -> None:
 
         '''
         Run the experiment `n_permutations` times.
@@ -155,6 +157,7 @@ class UniversalExperimentLoop:
             prep (Callable | None): Callable to prepare the data
             model (Callable | None): Callable to run the model
             resume (bool): Whether to resume from an existing checkpoint
+            post_processing (bool): Whether to compute terminal post-run metrics
 
         '''
 
@@ -163,6 +166,7 @@ class UniversalExperimentLoop:
         self.preds = []
         self.scalers = []
         self._alignment = []
+        self._clear_post_processing_outputs()
 
         if resume and self._search_strategy is None:
             raise ValueError(
@@ -175,6 +179,7 @@ class UniversalExperimentLoop:
                 n_permutations=n_permutations,
                 context_params=context_params,
                 resume=resume,
+                post_processing=post_processing,
             )
             return
 
@@ -280,8 +285,17 @@ class UniversalExperimentLoop:
             if self.experiment_log.n_chunks() > STANDARD_RUN_LOG_RECHUNK_THRESHOLD:
                 self.experiment_log = self.experiment_log.rechunk()
 
-        self._finalize()
+        if post_processing:
+            self._finalize()
 
+    def _clear_post_processing_outputs(self) -> None:
+
+        '''Clear terminal post-processing outputs before a run.'''
+
+        self._log = None
+        self.experiment_confusion_metrics = None
+        self.experiment_backtest_results = None
+        self.experiment_parameter_correlation = None
 
     def _finalize(self) -> None:
 
@@ -339,7 +353,8 @@ class UniversalExperimentLoop:
                       experiment_name: str,
                       n_permutations: int,
                       context_params: dict | None,
-                      resume: bool) -> None:
+                      resume: bool,
+                      post_processing: bool = False) -> None:
 
         '''
         Run the experiment using the Mutable-Search-Queue based execution flow.
@@ -354,6 +369,7 @@ class UniversalExperimentLoop:
             n_permutations (int): Maximum number of combinations to run
             context_params (dict | None): Static parameters merged into each round
             resume (bool): Whether to resume from an existing checkpoint
+            post_processing (bool): Whether to compute terminal post-run metrics
 
         '''
 
@@ -381,6 +397,7 @@ class UniversalExperimentLoop:
         self.scalers = []
         self._alignment = []
         self.experiment_log = None
+        self._clear_post_processing_outputs()
 
         start_round = 0
         if resume and self._experiment_dir.exists():
@@ -548,7 +565,8 @@ class UniversalExperimentLoop:
             )
 
         self._flush_results(results_accumulator)
-        self._finalize()
+        if post_processing:
+            self._finalize()
 
 
     def _validate_msq_preconditions(self,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaquum_limen"
-version = "3.10.1"
+version = "4.0.0"
 description = "Limen unifies parameter search across machine learning and rule-based strategies, with built-in analytics that show not just what works, but why it works."
 readme = "README.md"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaquum_limen"
-version = "3.10.0"
+version = "3.10.1"
 description = "Limen unifies parameter search across machine learning and rule-based strategies, with built-in analytics that show not just what works, but why it works."
 readme = "README.md"
 authors = [

--- a/tests/run.py
+++ b/tests/run.py
@@ -290,6 +290,8 @@ from tests.test_checkpoint_manager import test_uel_shutdown_flag
 from tests.test_checkpoint_manager import test_uel_double_signal_raises
 from tests.test_checkpoint_manager import test_uel_checkpoint_and_resume
 from tests.test_experiment_core_msq import test_run_with_msq_basic_flow
+from tests.test_experiment_core_msq import test_run_with_msq_skips_post_processing_by_default
+from tests.test_experiment_core_msq import test_run_with_msq_post_processing_opt_in_reaches_finalize
 from tests.test_experiment_core_msq import test_run_with_msq_context_params
 from tests.test_experiment_core_msq import test_run_with_msq_feedback_trigger
 from tests.test_experiment_core_msq import test_run_with_msq_checkpoint_trigger
@@ -347,6 +349,7 @@ from tests.test_experiment_core_standard_csv import test_standard_run_csv_round_
 from tests.test_experiment_core_standard_csv import test_standard_run_csv_does_not_append_duplicate_headers_on_rerun
 from tests.test_experiment_core_standard_csv import test_standard_run_csv_uses_experiment_dir
 from tests.test_experiment_core_standard_csv import test_standard_run_rechunks_live_log_without_changing_row_output
+from tests.test_experiment_core_standard_csv import test_standard_run_skips_post_processing_by_default
 from tests.test_runtime_tracking import test_execute_test_suite_writes_profile_and_stops_on_first_failure
 from tests.test_runtime_tracking import test_runtime_gate_writes_summary_and_passes_when_within_budget
 from tests.test_runtime_tracking import test_runtime_gate_fails_when_profile_exceeds_budget
@@ -867,6 +870,8 @@ tests = [
     test_uel_double_signal_raises,
     test_uel_checkpoint_and_resume,
     test_run_with_msq_basic_flow,
+    test_run_with_msq_skips_post_processing_by_default,
+    test_run_with_msq_post_processing_opt_in_reaches_finalize,
     test_run_with_msq_context_params,
     test_run_with_msq_feedback_trigger,
     test_run_with_msq_checkpoint_trigger,
@@ -924,6 +929,7 @@ tests = [
     test_standard_run_csv_does_not_append_duplicate_headers_on_rerun,
     test_standard_run_csv_uses_experiment_dir,
     test_standard_run_rechunks_live_log_without_changing_row_output,
+    test_standard_run_skips_post_processing_by_default,
     test_execute_test_suite_writes_profile_and_stops_on_first_failure,
     test_runtime_gate_writes_summary_and_passes_when_within_budget,
     test_runtime_gate_fails_when_profile_exceeds_budget,

--- a/tests/test_experiment_core_msq.py
+++ b/tests/test_experiment_core_msq.py
@@ -51,6 +51,7 @@ def test_run_with_msq_basic_flow():
 
             context_params=None,
             resume=False,
+            post_processing=True,
         )
 
     assert uel.experiment_log.shape[0] == 6
@@ -86,6 +87,50 @@ def test_run_with_msq_basic_flow():
     assert len(uel.experiment_backtest_results) > 0
     corr = uel.experiment_parameter_correlation('auc', min_n=1)
     assert len(corr) > 0
+
+
+def test_run_with_msq_skips_post_processing_by_default():
+
+    uel, _, _ = _make_uel()
+    finalize_calls = []
+
+    def fake_finalize():
+        finalize_calls.append(True)
+
+    uel._finalize = fake_finalize
+
+    with TemporaryDirectory() as tmpdir:
+        uel.run(
+            experiment_name=str(Path(tmpdir) / 'test'),
+            n_permutations=1,
+        )
+
+    assert finalize_calls == []
+    assert uel.experiment_log.shape[0] == 1
+    assert uel._log is None
+    assert uel.experiment_confusion_metrics is None
+    assert uel.experiment_backtest_results is None
+    assert uel.experiment_parameter_correlation is None
+
+
+def test_run_with_msq_post_processing_opt_in_reaches_finalize():
+
+    uel, _, _ = _make_uel()
+    finalize_calls = []
+
+    def fake_finalize():
+        finalize_calls.append(True)
+
+    uel._finalize = fake_finalize
+
+    with TemporaryDirectory() as tmpdir:
+        uel.run(
+            experiment_name=str(Path(tmpdir) / 'test'),
+            n_permutations=1,
+            post_processing=True,
+        )
+
+    assert finalize_calls == [True]
 
 
 def test_run_with_msq_context_params():
@@ -261,6 +306,7 @@ def _shutdown_resume_full_data(strategy_cls):
             n_permutations=6,
             context_params=None,
             resume=True,
+            post_processing=True,
         )
 
         assert uel2.experiment_log.shape[0] == 6

--- a/tests/test_experiment_core_standard_csv.py
+++ b/tests/test_experiment_core_standard_csv.py
@@ -230,3 +230,38 @@ def test_standard_run_rechunks_live_log_without_changing_row_output() -> None:
         assert [int(row['marker']) for row in rows] == list(range(10))
     finally:
         experiment_core.STANDARD_RUN_LOG_RECHUNK_THRESHOLD = original_threshold
+
+
+def test_standard_run_skips_post_processing_by_default() -> None:
+    sfd = SimpleNamespace(
+        params=lambda: {'marker': [0]},
+        prep=_standard_csv_test_prep,
+        model=_standard_csv_test_model,
+    )
+
+    with TemporaryDirectory() as tmpdir:
+        experiment_name = str(Path(tmpdir) / 'standard_csv')
+
+        uel = UniversalExperimentLoop(
+            data=_make_standard_csv_test_data(),
+            sfd=sfd,
+        )
+        finalize_calls = []
+
+        def fake_finalize():
+            finalize_calls.append(True)
+
+        uel._finalize = fake_finalize
+        uel.run(
+            experiment_name=experiment_name,
+            n_permutations=1,
+            prep_each_round=True,
+            random_search=False,
+        )
+
+    assert finalize_calls == []
+    assert uel.experiment_log.height == 1
+    assert uel._log is None
+    assert uel.experiment_confusion_metrics is None
+    assert uel.experiment_backtest_results is None
+    assert uel.experiment_parameter_correlation is None

--- a/tests/test_inline_metrics.py
+++ b/tests/test_inline_metrics.py
@@ -29,6 +29,7 @@ def _run_uel(sfd_module=random_binary_sfd,
         uel.run(
             experiment_name=str(Path(tmpdir) / 'test'),
             n_permutations=n_permutations,
+            post_processing=True,
         )
 
     return uel

--- a/tests/test_regime_diversified_opinion_pools.py
+++ b/tests/test_regime_diversified_opinion_pools.py
@@ -47,6 +47,7 @@ def test_rdop():
                     uel.run(
                         experiment_name=str(experiment_dir / 'test'),
                         n_permutations=1,
+                        post_processing=True,
                     )
 
                     confusion_df = uel.experiment_confusion_metrics


### PR DESCRIPTION
Closes #542.

## Summary
- Default `UniversalExperimentLoop.run()` and `_run_with_msq()` now skip `_finalize()`.
- Added explicit `post_processing=True` opt-in for callers/tests that require post-run metrics.
- Cleared prior post-processing outputs before runs to avoid stale metrics.
- Bumped version to `4.0.0` and recorded the breaking default change in `CHANGELOG.md`.

## Validation
- `.venv/bin/python -m ruff check limen/experiment/experiment_core.py tests/test_experiment_core_msq.py tests/test_experiment_core_standard_csv.py tests/test_inline_metrics.py tests/test_regime_diversified_opinion_pools.py tests/run.py`
- `.venv/bin/python -m pytest tests/test_experiment_core_msq.py tests/test_experiment_core_standard_csv.py tests/test_inline_metrics.py`
- `.venv/bin/python -m pytest tests/test_regime_diversified_opinion_pools.py`
- `.venv/bin/python tests/run.py` — 763 passed, 0 failed
- `git diff --check`

## CI
- PR checks green on head `2a01d459a1b32974d18463e6a478b1ed733986b9`.