### PR TITLE
perf: reduce UEL run memory growth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -975,3 +975,8 @@ Note: add all new changelog entries to the bottom of this file.
 ## v4.0.0 on 22nd of May, 2026
 
 - Breaking: make `UniversalExperimentLoop.run()` skip terminal post-processing by default and retain `post_processing=True` as an explicit opt-in.
+
+## v4.0.1 on 23rd of May, 2026
+
+- Stop retaining post-processing inputs in memory during default `post_processing=False` UEL runs while preserving persisted round data for resume and promotion workflows.
+- Batch standard UEL experiment-log construction to avoid row-count-dependent slowdown from per-round Polars `vstack`.

--- a/limen/experiment/experiment_core.py
+++ b/limen/experiment/experiment_core.py
@@ -27,7 +27,7 @@ from limen.experiment.manifest_core import RuleBasedManifest
 
 logger = logging.getLogger(__name__)
 
-STANDARD_RUN_LOG_RECHUNK_THRESHOLD = 500
+STANDARD_RUN_LOG_BATCH_SIZE = 1000
 
 
 class UniversalExperimentLoop:
@@ -166,6 +166,7 @@ class UniversalExperimentLoop:
         self.preds = []
         self.scalers = []
         self._alignment = []
+        self.experiment_log = None
         self._clear_post_processing_outputs()
 
         if resume and self._search_strategy is None:
@@ -211,6 +212,15 @@ class UniversalExperimentLoop:
         else:
             csv_path = Path(f'{experiment_name}.csv')
 
+        retain_round_artifacts = post_processing
+        results_accumulator: list[dict[str, Any]] = []
+        log_batches: list[pl.DataFrame] = []
+
+        csv_header: list[str] | None = None
+        if csv_path.exists() and csv_path.stat().st_size > 0:
+            with csv_path.open('r', newline='') as f:
+                csv_header = next(csv.reader(f), None)
+
         for i in tqdm(range(n_permutations)):
 
             # Start counting execution_time
@@ -239,51 +249,68 @@ class UniversalExperimentLoop:
             if maintain_details_in_params is True:
                 round_params.pop('_experiment_details')
 
-            # Add alignment details
-            self._alignment.append(data_dict['_alignment'])
+            if retain_round_artifacts:
+                self._alignment.append(data_dict['_alignment'])
 
             # Handle any extra results that are returned from the model
             if 'extras' in round_results:
-                self.extras.append(round_results['extras'])
+                if retain_round_artifacts:
+                    self.extras.append(round_results['extras'])
                 round_results.pop('extras')
 
             # Handle any models that are returned from the model
             if 'models' in round_results:
-                self.models.append(round_results['models'])
+                if retain_round_artifacts:
+                    self.models.append(round_results['models'])
                 round_results.pop('models')
 
             if '_preds' in round_results:
-                self.preds.append(round_results['_preds'])
+                if retain_round_artifacts:
+                    self.preds.append(round_results['_preds'])
                 round_results.pop('_preds')
 
-            if '_scaler' in data_dict:
+            if retain_round_artifacts and '_scaler' in data_dict:
                 self.scalers.append(data_dict['_scaler'])
 
             # Add the round number and execution time to the results
             round_results['id'] = i
             round_results['execution_time'] = round(time.time() - start_time, 2)
 
-            self.round_params.append(round_params)
+            if retain_round_artifacts:
+                self.round_params.append(round_params)
 
             for key in round_params:
                 round_results[key] = round_params[key]
 
-            # Handle writing to the DataFrame
-            if i == 0:
-                self.experiment_log = pl.DataFrame([round_results])
-            else:
-                self.experiment_log = self.experiment_log.vstack(pl.DataFrame([round_results]))
+            results_accumulator.append(dict(round_results))
+            if len(results_accumulator) >= STANDARD_RUN_LOG_BATCH_SIZE:
+                log_batches.append(pl.DataFrame(results_accumulator))
+                results_accumulator = []
 
             # Match the MSQ path: only write a header when the CSV is new or empty.
             write_header = not csv_path.exists() or csv_path.stat().st_size == 0
             with csv_path.open('a', newline='') as f:
                 writer = csv.writer(f)
                 if write_header:
-                    writer.writerow(round_results.keys())
-                writer.writerow(self.experiment_log.row(i))
+                    csv_header = list(round_results.keys())
+                    writer.writerow(csv_header)
+                writer.writerow([
+                    '' if (v := round_results.get(col)) is None else v
+                    for col in csv_header
+                ])
+                extra_keys = set(round_results) - set(csv_header)
+                if extra_keys:
+                    logger.warning(
+                        'Round %d result keys not in CSV header — values dropped: %s',
+                        i, sorted(extra_keys),
+                    )
 
-            if self.experiment_log.n_chunks() > STANDARD_RUN_LOG_RECHUNK_THRESHOLD:
-                self.experiment_log = self.experiment_log.rechunk()
+        if results_accumulator:
+            log_batches.append(pl.DataFrame(results_accumulator))
+        if log_batches:
+            self.experiment_log = pl.concat(
+                log_batches, how='vertical_relaxed',
+            )
 
         if post_processing:
             self._finalize()
@@ -405,6 +432,7 @@ class UniversalExperimentLoop:
                 msq, domain, feedback_controller, checkpoint_manager,
                 content_hash=content_hash, strategy_type=strategy_type,
                 csv_path=csv_path, round_data_path=round_data_path,
+                retain_round_artifacts=post_processing,
             )
         elif self._experiment_dir:
             self._guard_stale_artifacts()
@@ -481,24 +509,31 @@ class UniversalExperimentLoop:
             )
 
             if 'extras' in round_results:
-                self.extras.append(round_results.pop('extras'))
+                extras = round_results.pop('extras')
+                if post_processing:
+                    self.extras.append(extras)
             if 'models' in round_results:
-                self.models.append(round_results.pop('models'))
+                models = round_results.pop('models')
+                if post_processing:
+                    self.models.append(models)
             current_preds = round_results.pop('_preds', None)
             if current_preds is None:
                 current_preds = []
-            self.preds.append(current_preds)
-            if '_scaler' in data_dict:
+            if post_processing:
+                self.preds.append(current_preds)
+            if post_processing and '_scaler' in data_dict:
                 self.scalers.append(data_dict['_scaler'])
 
-            self._alignment.append(data_dict['_alignment'])
+            if post_processing:
+                self._alignment.append(data_dict['_alignment'])
 
             round_results['id'] = current_round
             round_results['execution_time'] = round(
                 time.time() - start_time, 2,
             )
 
-            self.round_params.append(sfd_params)
+            if post_processing:
+                self.round_params.append(sfd_params)
             for key, value in round_params.items():
                 round_results[key] = value
             if context_params is not None:
@@ -649,7 +684,8 @@ class UniversalExperimentLoop:
                                    content_hash: str,
                                    strategy_type: str,
                                    csv_path: Path,
-                                   round_data_path: Path | None) -> int:
+                                   round_data_path: Path | None,
+                                   retain_round_artifacts: bool) -> int:
 
         '''
         Restore experiment state from checkpoint and data files.
@@ -706,11 +742,15 @@ class UniversalExperimentLoop:
                 f"{start_round} rounds completed but no round "
                 f"data exists."
             )
-        self._load_round_data(round_data_path, up_to_round=start_round)
-        if len(self.round_params) < start_round:
+        loaded_rounds = self._load_round_data(
+            round_data_path,
+            up_to_round=start_round,
+            retain_round_artifacts=retain_round_artifacts,
+        )
+        if loaded_rounds < start_round:
             raise ValueError(
                 f"Cannot resume: round_data.jsonl has "
-                f"{len(self.round_params)} entries but checkpoint "
+                f"{loaded_rounds} entries but checkpoint "
                 f"indicates {start_round} rounds completed."
             )
 
@@ -932,7 +972,9 @@ class UniversalExperimentLoop:
 
     def _load_round_data(self,
                          round_data_path: Path,
-                         up_to_round: int | None = None) -> None:
+                         up_to_round: int | None = None,
+                         *,
+                         retain_round_artifacts: bool = True) -> int:
 
         '''
         Load accumulated round data from JSONL into instance lists.
@@ -945,8 +987,9 @@ class UniversalExperimentLoop:
         '''
 
         if not round_data_path.exists():
-            return
+            return 0
 
+        loaded_rounds = 0
         with round_data_path.open('r') as f:
             for raw_line in f:
                 stripped = raw_line.strip()
@@ -963,20 +1006,24 @@ class UniversalExperimentLoop:
                 ):
                     break
 
-                self.round_params.append(entry['round_params'])
-                self.preds.append(entry['preds'])
-                self._alignment.append({
-                    'missing_datetimes': [
-                        datetime.fromisoformat(dt)
-                        for dt in entry['alignment']['missing_datetimes']
-                    ],
-                    'first_test_datetime': datetime.fromisoformat(
-                        entry['alignment']['first_test_datetime'],
-                    ),
-                    'last_test_datetime': datetime.fromisoformat(
-                        entry['alignment']['last_test_datetime'],
-                    ),
-                })
+                loaded_rounds += 1
+                if retain_round_artifacts:
+                    self.round_params.append(entry['round_params'])
+                    self.preds.append(entry['preds'])
+                    self._alignment.append({
+                        'missing_datetimes': [
+                            datetime.fromisoformat(dt)
+                            for dt in entry['alignment']['missing_datetimes']
+                        ],
+                        'first_test_datetime': datetime.fromisoformat(
+                            entry['alignment']['first_test_datetime'],
+                        ),
+                        'last_test_datetime': datetime.fromisoformat(
+                            entry['alignment']['last_test_datetime'],
+                        ),
+                    })
+
+        return loaded_rounds
 
 
     def _resume_from_checkpoint(self,

--- a/limen/experiment/experiment_core.py
+++ b/limen/experiment/experiment_core.py
@@ -221,6 +221,10 @@ class UniversalExperimentLoop:
         if csv_path.exists() and csv_path.stat().st_size > 0:
             with csv_path.open('r', newline='') as f:
                 csv_header = next(csv.reader(f), None)
+            if not csv_header or not any(col.strip() for col in csv_header):
+                raise ValueError(
+                    f'Existing results CSV has no header: {csv_path}'
+                )
 
         for i in tqdm(range(n_permutations)):
 

--- a/limen/experiment/experiment_core.py
+++ b/limen/experiment/experiment_core.py
@@ -163,6 +163,7 @@ class UniversalExperimentLoop:
 
         self.round_params = []
         self.models = []
+        self.extras = []
         self.preds = []
         self.scalers = []
         self._alignment = []
@@ -699,6 +700,8 @@ class UniversalExperimentLoop:
             strategy_type (str): Expected strategy type for validation
             csv_path (Path): Path to results CSV
             round_data_path (Path | None): Path to round_data.jsonl
+            retain_round_artifacts (bool): Whether to hydrate round data
+                into instance artifact lists, or only count entries
 
         Returns:
             int: The round number to resume from
@@ -983,6 +986,11 @@ class UniversalExperimentLoop:
             round_data_path (Path): Path to the round_data.jsonl file
             up_to_round (int | None): If set, only load entries with
                 round_id < up_to_round (for crash recovery consistency)
+            retain_round_artifacts (bool): Whether to hydrate entries into
+                instance artifact lists, or only validate/count them
+
+        Returns:
+            int: The number of round data entries loaded or counted
 
         '''
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaquum_limen"
-version = "4.0.0"
+version = "4.0.1"
 description = "Limen unifies parameter search across machine learning and rule-based strategies, with built-in analytics that show not just what works, but why it works."
 readme = "README.md"
 authors = [

--- a/tests/run.py
+++ b/tests/run.py
@@ -291,6 +291,7 @@ from tests.test_checkpoint_manager import test_uel_double_signal_raises
 from tests.test_checkpoint_manager import test_uel_checkpoint_and_resume
 from tests.test_experiment_core_msq import test_run_with_msq_basic_flow
 from tests.test_experiment_core_msq import test_run_with_msq_skips_post_processing_by_default
+from tests.test_experiment_core_msq import test_run_with_msq_default_persists_round_data_without_memory_retention
 from tests.test_experiment_core_msq import test_run_with_msq_post_processing_opt_in_reaches_finalize
 from tests.test_experiment_core_msq import test_run_with_msq_context_params
 from tests.test_experiment_core_msq import test_run_with_msq_feedback_trigger
@@ -348,7 +349,7 @@ from tests.test_predicates import test_rule_based_config_operand_elements_must_b
 from tests.test_experiment_core_standard_csv import test_standard_run_csv_round_trips_special_string_fields
 from tests.test_experiment_core_standard_csv import test_standard_run_csv_does_not_append_duplicate_headers_on_rerun
 from tests.test_experiment_core_standard_csv import test_standard_run_csv_uses_experiment_dir
-from tests.test_experiment_core_standard_csv import test_standard_run_rechunks_live_log_without_changing_row_output
+from tests.test_experiment_core_standard_csv import test_standard_run_batches_live_log_without_changing_row_output
 from tests.test_experiment_core_standard_csv import test_standard_run_skips_post_processing_by_default
 from tests.test_runtime_tracking import test_execute_test_suite_writes_profile_and_stops_on_first_failure
 from tests.test_runtime_tracking import test_runtime_gate_writes_summary_and_passes_when_within_budget
@@ -871,6 +872,7 @@ tests = [
     test_uel_checkpoint_and_resume,
     test_run_with_msq_basic_flow,
     test_run_with_msq_skips_post_processing_by_default,
+    test_run_with_msq_default_persists_round_data_without_memory_retention,
     test_run_with_msq_post_processing_opt_in_reaches_finalize,
     test_run_with_msq_context_params,
     test_run_with_msq_feedback_trigger,
@@ -928,7 +930,7 @@ tests = [
     test_standard_run_csv_round_trips_special_string_fields,
     test_standard_run_csv_does_not_append_duplicate_headers_on_rerun,
     test_standard_run_csv_uses_experiment_dir,
-    test_standard_run_rechunks_live_log_without_changing_row_output,
+    test_standard_run_batches_live_log_without_changing_row_output,
     test_standard_run_skips_post_processing_by_default,
     test_execute_test_suite_writes_profile_and_stops_on_first_failure,
     test_runtime_gate_writes_summary_and_passes_when_within_budget,

--- a/tests/test_experiment_core_msq.py
+++ b/tests/test_experiment_core_msq.py
@@ -107,10 +107,37 @@ def test_run_with_msq_skips_post_processing_by_default():
 
     assert finalize_calls == []
     assert uel.experiment_log.shape[0] == 1
+    assert uel.round_params == []
+    assert uel.preds == []
+    assert uel.scalers == []
+    assert uel._alignment == []
     assert uel._log is None
     assert uel.experiment_confusion_metrics is None
     assert uel.experiment_backtest_results is None
     assert uel.experiment_parameter_correlation is None
+
+
+def test_run_with_msq_default_persists_round_data_without_memory_retention():
+
+    with TemporaryDirectory() as tmpdir:
+        exp_dir = Path(tmpdir) / 'exp'
+        uel, _, _ = _make_uel(experiment_dir=exp_dir)
+
+        uel.run(
+            experiment_name='test',
+            n_permutations=2,
+        )
+
+        round_data_path = exp_dir / 'round_data.jsonl'
+        assert round_data_path.exists()
+        with round_data_path.open('r') as f:
+            lines = [line for line in f if line.strip()]
+
+    assert len(lines) == 2
+    assert uel.round_params == []
+    assert uel.preds == []
+    assert uel.scalers == []
+    assert uel._alignment == []
 
 
 def test_run_with_msq_post_processing_opt_in_reaches_finalize():

--- a/tests/test_experiment_core_standard_csv.py
+++ b/tests/test_experiment_core_standard_csv.py
@@ -5,6 +5,7 @@ from tempfile import TemporaryDirectory
 from types import SimpleNamespace
 
 import polars as pl
+import pytest
 
 from limen.experiment import experiment_core
 from limen.experiment.experiment_core import UniversalExperimentLoop
@@ -190,6 +191,31 @@ def test_standard_run_csv_uses_experiment_dir() -> None:
     assert rows[0]['note'] == first_note
     assert rows[1]['note'] == second_note
     assert rows[1]['id'] != 'id'
+
+
+def test_standard_run_rejects_existing_csv_without_header() -> None:
+    sfd = SimpleNamespace(
+        params=lambda: {'marker': [0]},
+        prep=_standard_csv_test_prep,
+        model=_standard_csv_test_model,
+    )
+
+    with TemporaryDirectory() as tmpdir:
+        experiment_name = str(Path(tmpdir) / 'standard_csv')
+        Path(f'{experiment_name}.csv').write_text('\n')
+
+        uel = UniversalExperimentLoop(
+            data=_make_standard_csv_test_data(),
+            sfd=sfd,
+        )
+
+        with pytest.raises(ValueError, match='Existing results CSV has no header'):
+            uel.run(
+                experiment_name=experiment_name,
+                n_permutations=1,
+                prep_each_round=True,
+                random_search=False,
+            )
 
 
 def test_standard_run_batches_live_log_without_changing_row_output() -> None:

--- a/tests/test_experiment_core_standard_csv.py
+++ b/tests/test_experiment_core_standard_csv.py
@@ -192,9 +192,9 @@ def test_standard_run_csv_uses_experiment_dir() -> None:
     assert rows[1]['id'] != 'id'
 
 
-def test_standard_run_rechunks_live_log_without_changing_row_output() -> None:
-    original_threshold = experiment_core.STANDARD_RUN_LOG_RECHUNK_THRESHOLD
-    experiment_core.STANDARD_RUN_LOG_RECHUNK_THRESHOLD = 4
+def test_standard_run_batches_live_log_without_changing_row_output() -> None:
+    original_batch_size = experiment_core.STANDARD_RUN_LOG_BATCH_SIZE
+    experiment_core.STANDARD_RUN_LOG_BATCH_SIZE = 4
 
     try:
         sfd = SimpleNamespace(
@@ -229,7 +229,7 @@ def test_standard_run_rechunks_live_log_without_changing_row_output() -> None:
         assert [int(row['id']) for row in rows] == list(range(10))
         assert [int(row['marker']) for row in rows] == list(range(10))
     finally:
-        experiment_core.STANDARD_RUN_LOG_RECHUNK_THRESHOLD = original_threshold
+        experiment_core.STANDARD_RUN_LOG_BATCH_SIZE = original_batch_size
 
 
 def test_standard_run_skips_post_processing_by_default() -> None:
@@ -261,6 +261,10 @@ def test_standard_run_skips_post_processing_by_default() -> None:
 
     assert finalize_calls == []
     assert uel.experiment_log.height == 1
+    assert uel.round_params == []
+    assert uel.preds == []
+    assert uel.scalers == []
+    assert uel._alignment == []
     assert uel._log is None
     assert uel.experiment_confusion_metrics is None
     assert uel.experiment_backtest_results is None

--- a/tests/test_experiment_core_standard_csv.py
+++ b/tests/test_experiment_core_standard_csv.py
@@ -247,6 +247,7 @@ def test_standard_run_skips_post_processing_by_default() -> None:
             sfd=sfd,
         )
         finalize_calls = []
+        uel.extras = [{'stale': True}]
 
         def fake_finalize():
             finalize_calls.append(True)
@@ -265,6 +266,7 @@ def test_standard_run_skips_post_processing_by_default() -> None:
     assert uel.preds == []
     assert uel.scalers == []
     assert uel._alignment == []
+    assert uel.extras == []
     assert uel._log is None
     assert uel.experiment_confusion_metrics is None
     assert uel.experiment_backtest_results is None


### PR DESCRIPTION
## Summary
- Stop retaining post-processing artifacts in memory for default `post_processing=False` runs.
- Preserve persisted `round_data.jsonl` for resume and promotion workflows.
- Batch standard UEL experiment-log construction instead of row-wise Polars `vstack`.
- Clear standard-run `extras` on reused UEL instances to avoid stale retained artifacts.
- Bump package version to `4.0.1` and update `CHANGELOG.md`.

## Performance Evidence
- Standard wide-row synthetic benchmark, 50k rounds: `38.767s` before, `10.971s` after (**3.5x faster**).
- Standard wide-row synthetic benchmark, 20k rounds: `15.332s` before, `4.202s` after (**3.6x faster**).
- Default large-prediction synthetic trace, 5k rounds: retained in-memory preds/params now `0`; `tracemalloc` peak `3.7MB` default vs `197.5MB` with `post_processing=True` opt-in retention.

## Algebraic Equivalence Proof
Compared `origin/main` `f9a4abe154aecd60a3ca91dd61ab6020c2fc6ff1` against PR head `a3689afa079780933de162c618c759136b161a7e`. Excluded only `execution_time` as non-deterministic runtime telemetry.

- CLI ML manifest grid run: 4 rows, max numeric delta `0`, identical SHA-256.
- CLI rule-based manifest grid run: 3 rows, max numeric delta `0`, identical SHA-256.
- Direct MSQ grid default run: 6 rows, max numeric delta `0`, identical CSV and experiment-log SHA-256; `round_data.jsonl` lines `6 == 6`.
- Direct MSQ shutdown/resume default run: 6 rows, max numeric delta `0`, identical CSV and experiment-log SHA-256; `round_data.jsonl` lines `6 == 6`.
- Direct legacy non-MSQ standard default run: 1205 rows, max numeric delta `0`, identical CSV and experiment-log SHA-256.
- Direct legacy non-MSQ `post_processing=True` run: 8 rows, max numeric delta `0`, identical CSV and experiment-log SHA-256.

Expected non-algebraic retained-object counts changed only for default runs: main retained artifacts in memory, PR retained `0`; persisted outputs remained identical.

## Validation
- `.venv/bin/python -m ruff check limen/experiment/experiment_core.py tests/test_experiment_core_standard_csv.py` — passed
- `.venv/bin/python -m ruff check limen/experiment/experiment_core.py tests/test_experiment_core_msq.py tests/test_experiment_core_standard_csv.py tests/run.py` — passed
- `.venv/bin/python -m pytest tests/test_experiment_core_standard_csv.py` — 5 passed
- `.venv/bin/python -m pytest tests/test_experiment_core_msq.py tests/test_experiment_core_standard_csv.py` — 25 passed
- `.venv/bin/python -m pytest tests/test_inline_metrics.py tests/test_regime_diversified_opinion_pools.py tests/test_trainer.py tests/test_proto_cohort.py` — 81 passed
- `git diff --check` — passed
- `.venv/bin/python tests/run.py` — 764 passed, 0 failed on pushed head `a3689afa079780933de162c618c759136b161a7e`
- PR CI on head `a3689afa079780933de162c618c759136b161a7e` — Ruff, Tests, Runtime, Coverage, CodeQL, Workers all passed

## Review
- Copilot review threads addressed and resolved.
