### PR TITLE
feat: add limen profile command, profiler module, and run startup summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -997,5 +997,4 @@ Note: add all new changelog entries to the bottom of this file.
 - Fix: add missing `random_state` param to `xgboost_regressor.yaml` template
 - Add `limen profile` CLI command — profiles a YAML experiment's permutation space (total count, per-parameter cardinalities, complexity rating) and, when `test_data_source` is configured, runs a randomised strength-1 covering array to estimate per-permutation runtime
 - Add `limen/yaml/profiler.py` with `ProfileResult`, `make_covering_array`, and `profile()` — profiler core usable independently of the CLI
-- `limen run` now prints `N of M permutations (strategy)` at startup using human-readable K/M/B/T formatting
-- `limen run` writes `permutation_space` (total and per-parameter cardinalities) into `metadata.json` after each experiment
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -994,6 +994,7 @@ Note: add all new changelog entries to the bottom of this file.
 
 ## v3.12.2 on 24th of May, 2026
 
+- Fix: add missing `random_state` param to `xgboost_regressor.yaml` template
 - Add `limen profile` CLI command — profiles a YAML experiment's permutation space (total count, per-parameter cardinalities, complexity rating) and, when `test_data_source` is configured, runs a randomised strength-1 covering array to estimate per-permutation runtime
 - Add `limen/yaml/profiler.py` with `ProfileResult`, `make_covering_array`, and `profile()` — profiler core usable independently of the CLI
 - `limen run` now prints `N of M permutations (strategy)` at startup using human-readable K/M/B/T formatting

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -991,3 +991,10 @@ Note: add all new changelog entries to the bottom of this file.
 ## v3.12.1 on 24th of May, 2026
 
 - Make `Cohort` resolve YAML CLI artifacts through `metadata.json["yaml_reference"]` before falling back to `sfd_module`, preserving Trainer sensor probability output for manifest-based runs.
+
+## v3.12.2 on 24th of May, 2026
+
+- Add `limen profile` CLI command — profiles a YAML experiment's permutation space (total count, per-parameter cardinalities, complexity rating) and, when `test_data_source` is configured, runs a randomised strength-1 covering array to estimate per-permutation runtime
+- Add `limen/yaml/profiler.py` with `ProfileResult`, `make_covering_array`, and `profile()` — profiler core usable independently of the CLI
+- `limen run` now prints `N of M permutations (strategy)` at startup using human-readable K/M/B/T formatting
+- `limen run` writes `permutation_space` (total and per-parameter cardinalities) into `metadata.json` after each experiment

--- a/limen/cli/commands/_load_yaml.py
+++ b/limen/cli/commands/_load_yaml.py
@@ -1,0 +1,47 @@
+from pathlib import Path
+from typing import Any
+
+import click
+
+from limen.yaml.parser import parse
+from limen.yaml.validator import validate as _validate
+
+
+def load_and_validate(yaml_path: Path) -> tuple[dict[str, Any], bool]:
+
+    '''
+    Parse and validate a YAML experiment file, printing all errors and warnings.
+
+    Args:
+        yaml_path (Path): Path to the YAML experiment file
+
+    Returns:
+        tuple[dict, bool]: (yaml_dict, valid). When valid is False, errors have
+            already been printed and the caller should abort.
+
+    '''
+
+    yaml_dict, parse_errors = parse(yaml_path)
+    if parse_errors:
+        for e in parse_errors:
+            location = f' (line {e.line})' if e.line else ''
+            click.secho(f'  PARSE ERROR{location}: {e.message}', fg='red')
+        return yaml_dict, False
+
+    result = _validate(yaml_dict)
+    for e in result.errors:
+        location = f' (line {e.line})' if e.line else ''
+        path = f'  [{e.path}]' if e.path else ''
+        suggestion = f'\n    → {e.suggestion}' if e.suggestion else ''
+        click.secho(f'  ERROR{path}{location}: {e.message}{suggestion}', fg='red')
+    for w in result.warnings:
+        location = f' (line {w.line})' if w.line else ''
+        path = f'  [{w.path}]' if w.path else ''
+        click.secho(f'  WARN{path}{location}: {w.message}', fg='yellow')
+
+    if not result.valid:
+        click.secho(f'  ✗ {len(result.errors)} error(s) found', fg='red')
+        return yaml_dict, False
+
+    click.secho('  ✓ Valid', fg='green')
+    return yaml_dict, True

--- a/limen/cli/commands/profile.py
+++ b/limen/cli/commands/profile.py
@@ -85,7 +85,7 @@ def _print_runtime_sampling(prof: ProfileResult) -> None:
     if attempted == 0:
         click.echo('  Runtime sampling')
         if prof.errors:
-            click.echo('    Skipped — test data could not be loaded (see errors above)')
+            click.echo('    Skipped — test data could not be loaded (see errors below)')
         else:
             click.echo('    Skipped — no test_data_source configured')
         return

--- a/limen/cli/commands/profile.py
+++ b/limen/cli/commands/profile.py
@@ -1,0 +1,133 @@
+from pathlib import Path
+
+import click
+
+from limen.yaml.compiler import CompiledSFD
+from limen.yaml.parser import parse
+from limen.yaml.profiler import ProfileResult
+from limen.yaml.profiler import profile
+from limen.yaml.validator import validate
+
+
+_COMPLEXITY_COLOURS = {
+    'low': 'green',
+    'medium': 'yellow',
+    'high': 'red',
+    'extreme': 'red',
+}
+
+
+def run_profile(yaml_path: Path) -> bool:
+
+    '''
+    Validate, compile, and profile a YAML experiment file.
+
+    Args:
+        yaml_path (Path): Path to the YAML experiment file
+
+    Returns:
+        bool: True on success, False on validation failure or profile error
+
+    '''
+
+    click.echo(f"Profiling {yaml_path} ...")
+
+    yaml_dict, parse_errors = parse(yaml_path)
+    if parse_errors:
+        for e in parse_errors:
+            location = f' (line {e.line})' if e.line else ''
+            click.secho(f'  PARSE ERROR{location}: {e.message}', fg='red')
+        return False
+
+    result = validate(yaml_dict)
+    for e in result.errors:
+        location = f' (line {e.line})' if e.line else ''
+        path = f'  [{e.path}]' if e.path else ''
+        suggestion = f'\n    → {e.suggestion}' if e.suggestion else ''
+        click.secho(f'  ERROR{path}{location}: {e.message}{suggestion}', fg='red')
+    for w in result.warnings:
+        location = f' (line {w.line})' if w.line else ''
+        path = f'  [{w.path}]' if w.path else ''
+        click.secho(f'  WARN{path}{location}: {w.message}', fg='yellow')
+
+    if not result.valid:
+        click.secho(f'  ✗ {len(result.errors)} validation error(s) — aborting', fg='red')
+        return False
+
+    click.secho('  ✓ Valid', fg='green')
+
+    try:
+        sfd = CompiledSFD(yaml_dict)
+        prof = profile(sfd)
+    except Exception as exc:  # noqa: BLE001
+        click.secho(f'  ✗ Profile failed: {exc}', fg='red')
+        return False
+
+    _print_profile(prof)
+    return True
+
+
+def _print_profile(prof: ProfileResult) -> None:
+
+    click.echo('')
+    _print_permutation_space(prof)
+    _print_runtime_sampling(prof)
+
+    for w in prof.warnings:
+        click.secho(f'  WARN: {w}', fg='yellow')
+    for e in prof.errors:
+        click.secho(f'  ERROR: {e}', fg='red')
+
+
+def _print_permutation_space(prof: ProfileResult) -> None:
+
+    colour = _COMPLEXITY_COLOURS.get(prof.complexity_rating, 'white')
+    rating_label = click.style(f'[{prof.complexity_rating}]', fg=colour)
+    n_params = len(prof.param_cardinalities)
+    click.echo("  Permutation space")
+    click.echo(f"    Total:       {prof.total_permutations:,}  {rating_label}")
+    click.echo(f"    Parameters:  {n_params}")
+
+    sorted_params = sorted(
+        prof.param_cardinalities.items(),
+        key=lambda kv: kv[1],
+        reverse=True,
+    )
+    for name, card in sorted_params:
+        click.echo(f"      {name:<24} {card} value{'s' if card != 1 else ''}")
+
+
+def _print_runtime_sampling(prof: ProfileResult) -> None:
+
+    click.echo('')
+    attempted = prof.sample_permutations_attempted
+    completed = prof.sample_permutations_completed
+
+    if attempted == 0:
+        click.echo('  Runtime sampling')
+        click.echo('    Skipped — no test_data_source configured')
+        return
+
+    click.echo(f"  Runtime sampling  ({completed} of {attempted} completed)")
+
+    if prof.sample_time_seconds_per_permutation is not None:
+        t = prof.sample_time_seconds_per_permutation
+        click.echo(f"    Per permutation: {t:.3f}s")
+        estimated_total = t * prof.total_permutations
+        click.echo(f"    Estimated total: {_format_duration(estimated_total)}  "
+                   f"({prof.total_permutations:,} permutations)")
+    else:
+        click.echo('    Per permutation: —  (no completed runs)')
+
+
+_SECONDS_PER_MINUTE = 60
+_SECONDS_PER_HOUR = 3600
+
+
+def _format_duration(seconds: float) -> str:
+
+    if seconds < _SECONDS_PER_MINUTE:
+        return f"{seconds:.1f}s"
+    if seconds < _SECONDS_PER_HOUR:
+        return f"{seconds / _SECONDS_PER_MINUTE:.1f}m"
+    return f"{seconds / _SECONDS_PER_HOUR:.1f}h"

--- a/limen/cli/commands/profile.py
+++ b/limen/cli/commands/profile.py
@@ -101,6 +101,8 @@ def _print_runtime_sampling(prof: ProfileResult) -> None:
 
 _SECONDS_PER_MINUTE = 60
 _SECONDS_PER_HOUR = 3600
+_SECONDS_PER_DAY = 86400
+_SECONDS_PER_YEAR = 31_536_000
 
 _SPACE_UNITS = [
     (10 ** 12, 'T'),
@@ -126,4 +128,8 @@ def _format_duration(seconds: float) -> str:
         return f"{seconds:.1f}s"
     if seconds < _SECONDS_PER_HOUR:
         return f"{seconds / _SECONDS_PER_MINUTE:.1f}m"
-    return f"{seconds / _SECONDS_PER_HOUR:.1f}h"
+    if seconds < _SECONDS_PER_DAY:
+        return f"{seconds / _SECONDS_PER_HOUR:.1f}h"
+    if seconds < _SECONDS_PER_YEAR:
+        return f"{seconds / _SECONDS_PER_DAY:.1f}d"
+    return f"{seconds / _SECONDS_PER_YEAR:.1f}y"

--- a/limen/cli/commands/profile.py
+++ b/limen/cli/commands/profile.py
@@ -85,7 +85,7 @@ def _print_permutation_space(prof: ProfileResult) -> None:
     rating_label = click.style(f'[{prof.complexity_rating}]', fg=colour)
     n_params = len(prof.param_cardinalities)
     click.echo("  Permutation space")
-    click.echo(f"    Total:       {prof.total_permutations:,}  {rating_label}")
+    click.echo(f"    Total:       {_format_space(prof.total_permutations)}  {rating_label}")
     click.echo(f"    Parameters:  {n_params}")
 
     sorted_params = sorted(
@@ -115,13 +115,30 @@ def _print_runtime_sampling(prof: ProfileResult) -> None:
         click.echo(f"    Per permutation: {t:.3f}s")
         estimated_total = t * prof.total_permutations
         click.echo(f"    Estimated total: {_format_duration(estimated_total)}  "
-                   f"({prof.total_permutations:,} permutations)")
+                   f"({_format_space(prof.total_permutations)} permutations)")
     else:
         click.echo('    Per permutation: —  (no completed runs)')
 
 
 _SECONDS_PER_MINUTE = 60
 _SECONDS_PER_HOUR = 3600
+
+_SPACE_UNITS = [
+    (10 ** 12, 'T'),
+    (10 ** 9, 'B'),
+    (10 ** 6, 'M'),
+    (10 ** 3, 'K'),
+]
+
+
+def _format_space(n: int) -> str:
+
+    if n >= 10 ** 15:
+        return f"{float(n):.2e}"
+    for threshold, suffix in _SPACE_UNITS:
+        if n >= threshold:
+            return f"{n / threshold:.1f}{suffix}"
+    return str(n)
 
 
 def _format_duration(seconds: float) -> str:

--- a/limen/cli/commands/profile.py
+++ b/limen/cli/commands/profile.py
@@ -84,7 +84,10 @@ def _print_runtime_sampling(prof: ProfileResult) -> None:
 
     if attempted == 0:
         click.echo('  Runtime sampling')
-        click.echo('    Skipped — no test_data_source configured')
+        if prof.errors:
+            click.echo('    Skipped — test data could not be loaded (see errors above)')
+        else:
+            click.echo('    Skipped — no test_data_source configured')
         return
 
     click.echo(f"  Runtime sampling  ({completed} of {attempted} completed)")

--- a/limen/cli/commands/profile.py
+++ b/limen/cli/commands/profile.py
@@ -137,7 +137,7 @@ def _format_space(n: int) -> str:
         return f"{float(n):.2e}"
     for threshold, suffix in _SPACE_UNITS:
         if n >= threshold:
-            return f"{n / threshold:.1f}{suffix}"
+            return f"{n / threshold:.2f}{suffix}"
     return str(n)
 
 

--- a/limen/cli/commands/profile.py
+++ b/limen/cli/commands/profile.py
@@ -2,11 +2,10 @@ from pathlib import Path
 
 import click
 
+from limen.cli.commands._load_yaml import load_and_validate
 from limen.yaml.compiler import CompiledSFD
-from limen.yaml.parser import parse
 from limen.yaml.profiler import ProfileResult
 from limen.yaml.profiler import profile
-from limen.yaml.validator import validate
 
 
 _COMPLEXITY_COLOURS = {
@@ -32,29 +31,9 @@ def run_profile(yaml_path: Path) -> bool:
 
     click.echo(f"Profiling {yaml_path} ...")
 
-    yaml_dict, parse_errors = parse(yaml_path)
-    if parse_errors:
-        for e in parse_errors:
-            location = f' (line {e.line})' if e.line else ''
-            click.secho(f'  PARSE ERROR{location}: {e.message}', fg='red')
+    yaml_dict, valid = load_and_validate(yaml_path)
+    if not valid:
         return False
-
-    result = validate(yaml_dict)
-    for e in result.errors:
-        location = f' (line {e.line})' if e.line else ''
-        path = f'  [{e.path}]' if e.path else ''
-        suggestion = f'\n    → {e.suggestion}' if e.suggestion else ''
-        click.secho(f'  ERROR{path}{location}: {e.message}{suggestion}', fg='red')
-    for w in result.warnings:
-        location = f' (line {w.line})' if w.line else ''
-        path = f'  [{w.path}]' if w.path else ''
-        click.secho(f'  WARN{path}{location}: {w.message}', fg='yellow')
-
-    if not result.valid:
-        click.secho(f'  ✗ {len(result.errors)} validation error(s) — aborting', fg='red')
-        return False
-
-    click.secho('  ✓ Valid', fg='green')
 
     try:
         sfd = CompiledSFD(yaml_dict)
@@ -85,7 +64,7 @@ def _print_permutation_space(prof: ProfileResult) -> None:
     rating_label = click.style(f'[{prof.complexity_rating}]', fg=colour)
     n_params = len(prof.param_cardinalities)
     click.echo("  Permutation space")
-    click.echo(f"    Total:       {_format_space(prof.total_permutations)}  {rating_label}")
+    click.echo(f"    Total:       {format_space(prof.total_permutations)}  {rating_label}")
     click.echo(f"    Parameters:  {n_params}")
 
     sorted_params = sorted(
@@ -115,7 +94,7 @@ def _print_runtime_sampling(prof: ProfileResult) -> None:
         click.echo(f"    Per permutation: {t:.3f}s")
         estimated_total = t * prof.total_permutations
         click.echo(f"    Estimated total: {_format_duration(estimated_total)}  "
-                   f"({_format_space(prof.total_permutations)} permutations)")
+                   f"({format_space(prof.total_permutations)} permutations)")
     else:
         click.echo('    Per permutation: —  (no completed runs)')
 
@@ -131,7 +110,7 @@ _SPACE_UNITS = [
 ]
 
 
-def _format_space(n: int) -> str:
+def format_space(n: int) -> str:
 
     if n >= 10 ** 15:
         return f"{float(n):.2e}"

--- a/limen/cli/commands/run.py
+++ b/limen/cli/commands/run.py
@@ -57,7 +57,7 @@ def run_experiment(yaml_path: Path, dry_run: bool = False) -> bool:
     compiled = CompiledSFD(yaml_dict)
 
     _params = compiled.params()
-    total_space = math.prod(len(v) for v in _params.values()) if _params else 0
+    total_space = math.prod(len(v) for v in _params.values())
     strategy_type: str = uel_cfg.get('search_strategy', {}).get('type', 'random')
     click.echo(
         f"Running '{experiment_name}' — "

--- a/limen/cli/commands/run.py
+++ b/limen/cli/commands/run.py
@@ -1,3 +1,4 @@
+import json
 import math
 import shutil
 from datetime import datetime
@@ -108,6 +109,8 @@ def run_experiment(yaml_path: Path, dry_run: bool = False) -> bool:
         click.secho(f'  ✗ Experiment failed: {exc}', fg='red')
         return False
 
+    _patch_metadata(results_dir, total_space, _params)
+
     output_format: str = uel_cfg.get('output_format', 'csv')
     if output_format == 'parquet' and uel.experiment_log is not None:
         parquet_path = results_dir / 'results.parquet'
@@ -117,6 +120,21 @@ def run_experiment(yaml_path: Path, dry_run: bool = False) -> bool:
     click.secho('  ✓ Experiment complete', fg='green')
 
     return True
+
+
+def _patch_metadata(results_dir: Path, total_space: int, params: dict) -> None:
+
+    metadata_path = results_dir / 'metadata.json'
+    if not metadata_path.exists():
+        return
+    with metadata_path.open() as f:
+        meta = json.load(f)
+    meta['permutation_space'] = {
+        'total': total_space,
+        'param_cardinalities': {k: len(v) for k, v in params.items()},
+    }
+    with metadata_path.open('w') as f:
+        json.dump(meta, f, indent=2)
 
 
 def _build_results_dir(uel_cfg: dict[str, Any], experiment_name: str) -> Path:

--- a/limen/cli/commands/run.py
+++ b/limen/cli/commands/run.py
@@ -1,4 +1,3 @@
-import json
 import math
 import shutil
 from datetime import datetime
@@ -58,8 +57,7 @@ def run_experiment(yaml_path: Path, dry_run: bool = False) -> bool:
     compiled = CompiledSFD(yaml_dict)
 
     _params = compiled.params()
-    _cardinalities = {k: len(v) for k, v in _params.items()}
-    total_space = math.prod(_cardinalities.values()) if _cardinalities else 0
+    total_space = math.prod(len(v) for v in _params.values()) if _params else 0
     strategy_type: str = uel_cfg.get('search_strategy', {}).get('type', 'random')
     click.echo(
         f"Running '{experiment_name}' — "
@@ -89,8 +87,6 @@ def run_experiment(yaml_path: Path, dry_run: bool = False) -> bool:
         click.secho(f'  ✗ Experiment failed: {exc}', fg='red')
         return False
 
-    _patch_metadata(results_dir, total_space, _cardinalities)
-
     output_format: str = uel_cfg.get('output_format', 'csv')
     if output_format == 'parquet' and uel.experiment_log is not None:
         parquet_path = results_dir / 'results.parquet'
@@ -100,21 +96,6 @@ def run_experiment(yaml_path: Path, dry_run: bool = False) -> bool:
     click.secho('  ✓ Experiment complete', fg='green')
 
     return True
-
-
-def _patch_metadata(results_dir: Path, total_space: int, cardinalities: dict[str, int]) -> None:
-
-    metadata_path = results_dir / 'metadata.json'
-    if not metadata_path.exists():
-        return
-    with metadata_path.open() as f:
-        meta = json.load(f)
-    meta['permutation_space'] = {
-        'total': total_space,
-        'param_cardinalities': cardinalities,
-    }
-    with metadata_path.open('w') as f:
-        json.dump(meta, f, indent=2)
 
 
 def _build_results_dir(uel_cfg: dict[str, Any], experiment_name: str) -> Path:

--- a/limen/cli/commands/run.py
+++ b/limen/cli/commands/run.py
@@ -1,3 +1,4 @@
+import math
 import shutil
 from datetime import datetime
 from pathlib import Path
@@ -5,6 +6,7 @@ from typing import Any
 
 import click
 
+from limen.cli.commands.profile import _format_space
 from limen.experiment.experiment_core import UniversalExperimentLoop
 from limen.yaml.compiler import CompiledSFD
 from limen.yaml.compiler import build_search_strategy
@@ -75,7 +77,13 @@ def run_experiment(yaml_path: Path, dry_run: bool = False) -> bool:
     search_strategy = build_search_strategy(yaml_dict)
     compiled = CompiledSFD(yaml_dict)
 
-    click.echo(f"Running '{experiment_name}' ({n_permutations} permutations) ...")
+    _params = compiled.params()
+    total_space = math.prod(len(v) for v in _params.values()) if _params else 0
+    strategy_type: str = uel_cfg.get('search_strategy', {}).get('type', 'random')
+    click.echo(
+        f"Running '{experiment_name}' — "
+        f"{n_permutations:,} of {_format_space(total_space)} permutations ({strategy_type})"
+    )
     click.echo(f"  Results → {results_dir}")
 
     feedback_interval: int = int(uel_cfg.get('feedback_interval', 100))

--- a/limen/cli/commands/run.py
+++ b/limen/cli/commands/run.py
@@ -7,12 +7,11 @@ from typing import Any
 
 import click
 
-from limen.cli.commands.profile import _format_space
+from limen.cli.commands._load_yaml import load_and_validate
+from limen.cli.commands.profile import format_space
 from limen.experiment.experiment_core import UniversalExperimentLoop
 from limen.yaml.compiler import CompiledSFD
 from limen.yaml.compiler import build_search_strategy
-from limen.yaml.parser import parse
-from limen.yaml.validator import validate
 
 
 def run_experiment(yaml_path: Path, dry_run: bool = False) -> bool:
@@ -31,29 +30,9 @@ def run_experiment(yaml_path: Path, dry_run: bool = False) -> bool:
 
     click.echo(f"Loading {yaml_path} ...")
 
-    yaml_dict, parse_errors = parse(yaml_path)
-    if parse_errors:
-        for e in parse_errors:
-            location = f' (line {e.line})' if e.line else ''
-            click.secho(f'  PARSE ERROR{location}: {e.message}', fg='red')
+    yaml_dict, valid = load_and_validate(yaml_path)
+    if not valid:
         return False
-
-    result = validate(yaml_dict)
-    for e in result.errors:
-        location = f' (line {e.line})' if e.line else ''
-        path = f'  [{e.path}]' if e.path else ''
-        suggestion = f'\n    → {e.suggestion}' if e.suggestion else ''
-        click.secho(f'  ERROR{path}{location}: {e.message}{suggestion}', fg='red')
-    for w in result.warnings:
-        location = f' (line {w.line})' if w.line else ''
-        path = f'  [{w.path}]' if w.path else ''
-        click.secho(f'  WARN{path}{location}: {w.message}', fg='yellow')
-
-    if not result.valid:
-        click.secho(f'  ✗ {len(result.errors)} validation error(s) — aborting', fg='red')
-        return False
-
-    click.secho('  ✓ Valid', fg='green')
 
     if dry_run:
         try:
@@ -79,11 +58,12 @@ def run_experiment(yaml_path: Path, dry_run: bool = False) -> bool:
     compiled = CompiledSFD(yaml_dict)
 
     _params = compiled.params()
-    total_space = math.prod(len(v) for v in _params.values()) if _params else 0
+    _cardinalities = {k: len(v) for k, v in _params.items()}
+    total_space = math.prod(_cardinalities.values()) if _cardinalities else 0
     strategy_type: str = uel_cfg.get('search_strategy', {}).get('type', 'random')
     click.echo(
         f"Running '{experiment_name}' — "
-        f"{n_permutations:,} of {_format_space(total_space)} permutations ({strategy_type})"
+        f"{n_permutations:,} of {format_space(total_space)} permutations ({strategy_type})"
     )
     click.echo(f"  Results → {results_dir}")
 
@@ -109,7 +89,7 @@ def run_experiment(yaml_path: Path, dry_run: bool = False) -> bool:
         click.secho(f'  ✗ Experiment failed: {exc}', fg='red')
         return False
 
-    _patch_metadata(results_dir, total_space, _params)
+    _patch_metadata(results_dir, total_space, _cardinalities)
 
     output_format: str = uel_cfg.get('output_format', 'csv')
     if output_format == 'parquet' and uel.experiment_log is not None:
@@ -122,7 +102,7 @@ def run_experiment(yaml_path: Path, dry_run: bool = False) -> bool:
     return True
 
 
-def _patch_metadata(results_dir: Path, total_space: int, params: dict) -> None:
+def _patch_metadata(results_dir: Path, total_space: int, cardinalities: dict[str, int]) -> None:
 
     metadata_path = results_dir / 'metadata.json'
     if not metadata_path.exists():
@@ -131,7 +111,7 @@ def _patch_metadata(results_dir: Path, total_space: int, params: dict) -> None:
         meta = json.load(f)
     meta['permutation_space'] = {
         'total': total_space,
-        'param_cardinalities': {k: len(v) for k, v in params.items()},
+        'param_cardinalities': cardinalities,
     }
     with metadata_path.open('w') as f:
         json.dump(meta, f, indent=2)

--- a/limen/cli/commands/validate.py
+++ b/limen/cli/commands/validate.py
@@ -2,8 +2,7 @@ from pathlib import Path
 
 import click
 
-from limen.yaml.parser import parse
-from limen.yaml.validator import validate
+from limen.cli.commands._load_yaml import load_and_validate
 
 
 def run_validate(yaml_path: Path) -> bool:
@@ -20,31 +19,5 @@ def run_validate(yaml_path: Path) -> bool:
     '''
 
     click.echo(f"Validating {yaml_path} ...")
-
-    yaml_dict, parse_errors = parse(yaml_path)
-
-    if parse_errors:
-        for e in parse_errors:
-            location = f' (line {e.line})' if e.line else ''
-            click.secho(f'  PARSE ERROR{location}: {e.message}', fg='red')
-        return False
-
-    result = validate(yaml_dict)
-
-    for e in result.errors:
-        location = f' (line {e.line})' if e.line else ''
-        path = f'  [{e.path}]' if e.path else ''
-        suggestion = f'\n    → {e.suggestion}' if e.suggestion else ''
-        click.secho(f'  ERROR{path}{location}: {e.message}{suggestion}', fg='red')
-
-    for w in result.warnings:
-        location = f' (line {w.line})' if w.line else ''
-        path = f'  [{w.path}]' if w.path else ''
-        click.secho(f'  WARN{path}{location}: {w.message}', fg='yellow')
-
-    if result.valid:
-        click.secho('  ✓ Valid', fg='green')
-    else:
-        click.secho(f'  ✗ {len(result.errors)} error(s) found', fg='red')
-
-    return result.valid
+    _, valid = load_and_validate(yaml_path)
+    return valid

--- a/limen/cli/main.py
+++ b/limen/cli/main.py
@@ -4,6 +4,7 @@ import click
 
 from limen.cli.commands.init import run_init
 from limen.cli.commands.list_templates import run_list_templates
+from limen.cli.commands.profile import run_profile
 from limen.cli.commands.resume import run_resume
 from limen.cli.commands.run import run_experiment
 from limen.cli.commands.validate import run_validate
@@ -22,6 +23,7 @@ def cli() -> None:
     \b
     Quick start:
       limen validate experiment.yaml       Check your YAML for errors
+      limen profile experiment.yaml        Profile permutation space and runtime
       limen run experiment.yaml            Run the experiment
       limen run --dry-run experiment.yaml  Validate + compile only, no execution
 
@@ -77,6 +79,37 @@ def validate(yaml_file: Path) -> None:
     '''
 
     ok = run_validate(yaml_file)
+    raise SystemExit(0 if ok else 1)
+
+
+@cli.command('profile')
+@click.argument('yaml_file', type=click.Path(exists=True, path_type=Path))
+def profile_cmd(yaml_file: Path) -> None:
+
+    '''
+    Profile a YAML experiment — permutation space and runtime estimate.
+
+    \b
+    Always computed:
+      - Total permutations and complexity rating (low / medium / high / extreme)
+      - Per-parameter value counts
+
+    \b
+    Computed when test_data_source is configured:
+      - Average time per permutation (covering array sampling)
+      - Estimated total runtime across the full permutation space
+      - Errors encountered during sampling (small data, NaN, class imbalance)
+
+    \b
+    Exits 0 on success, 1 on validation failure or profile error.
+
+    \b
+    Examples:
+      limen profile experiment.yaml
+      limen profile limen/yaml/templates/logreg_binary.yaml
+    '''
+
+    ok = run_profile(yaml_file)
     raise SystemExit(0 if ok else 1)
 
 

--- a/limen/cli/main.py
+++ b/limen/cli/main.py
@@ -101,7 +101,8 @@ def profile_cmd(yaml_file: Path) -> None:
       - Errors encountered during sampling (small data, NaN, class imbalance)
 
     \b
-    Exits 0 on success, 1 on validation failure or profile error.
+    Exits 0 on success, 1 on validation or compilation failure.
+    Sampling errors are non-fatal and reported in the output.
 
     \b
     Examples:

--- a/limen/yaml/__init__.py
+++ b/limen/yaml/__init__.py
@@ -6,6 +6,9 @@ from limen.yaml.errors import ResolutionError
 from limen.yaml.errors import ValidationError
 from limen.yaml.errors import YAMLError
 from limen.yaml.parser import parse
+from limen.yaml.profiler import ProfileResult
+from limen.yaml.profiler import make_covering_array
+from limen.yaml.profiler import profile
 from limen.yaml.resolver import resolve
 from limen.yaml.schema import VERSION
 from limen.yaml.validator import ValidationResult
@@ -15,13 +18,16 @@ __all__ = [
     'VERSION',
     'CompiledSFD',
     'GitError',
+    'ProfileResult',
     'ResolutionError',
     'ValidationError',
     'ValidationResult',
     'YAMLError',
     'build_manifest',
     'build_search_strategy',
+    'make_covering_array',
     'parse',
+    'profile',
     'resolve',
     'validate',
 ]

--- a/limen/yaml/profiler.py
+++ b/limen/yaml/profiler.py
@@ -1,0 +1,175 @@
+import random
+import time
+import warnings
+from dataclasses import dataclass
+from dataclasses import field
+from typing import TYPE_CHECKING
+from typing import Any
+
+if TYPE_CHECKING:
+    from limen.yaml.compiler import CompiledSFD
+
+
+_COMPLEXITY_THRESHOLDS = [
+    (100, 'low'),
+    (1000, 'medium'),
+    (10000, 'high'),
+]
+
+
+@dataclass
+class ProfileResult:
+
+    '''Summary of a YAML experiment profile run.'''
+
+    total_permutations: int
+    param_cardinalities: dict[str, int]
+    complexity_rating: str
+    sample_permutations_attempted: int = 0
+    sample_permutations_completed: int = 0
+    sample_time_seconds_per_permutation: float | None = None
+    warnings: list[str] = field(default_factory=list)
+    errors: list[str] = field(default_factory=list)
+
+
+def _complexity_rating(total: int) -> str:
+
+    for threshold, label in _COMPLEXITY_THRESHOLDS:
+        if total <= threshold:
+            return label
+    return 'extreme'
+
+
+def _total_permutations(params: dict[str, list[Any]]) -> int:
+
+    result = 1
+    for values in params.values():
+        result *= len(values)
+    return result
+
+
+def make_covering_array(params: dict[str, list[Any]], seed: int = 42) -> list[dict[str, Any]]:
+
+    '''
+    Build a randomised strength-1 covering array for the given parameter space.
+
+    Every value of every parameter appears in at least one permutation.
+    N = max cardinality across all params. Each parameter's column is filled
+    with round-robin values then shuffled independently, removing systematic
+    correlation between parameter assignments.
+
+    Args:
+        params (dict): Parameter name to list of values
+        seed (int): Random seed for reproducibility
+
+    Returns:
+        list[dict]: N permutations, each a dict of param name to sampled value
+
+    '''
+
+    if not params:
+        return []
+
+    n = max(len(v) for v in params.values())
+    rng = random.Random(seed)
+    columns: dict[str, list[Any]] = {}
+
+    for key, values in params.items():
+        column = [values[i % len(values)] for i in range(n)]
+        rng.shuffle(column)
+        columns[key] = column
+
+    return [{key: columns[key][i] for key in params} for i in range(n)]
+
+
+def _classify_error(exc: Exception) -> str:
+
+    msg = str(exc)
+    lower = msg.lower()
+    if 'sample' in lower and ('0 ' in lower or 'empty' in lower):
+        return f'Test data too small — increase n_rows in test_data_source. ({msg})'
+    if 'class' in lower and ('one' in lower or '1' in lower or 'least' in lower):
+        return f'Not enough class diversity in test data — try larger n_rows. ({msg})'
+    if 'nan' in lower or 'inf' in lower:
+        return f'Test data contains NaN or Inf values. ({msg})'
+    return f'{type(exc).__name__}: {msg}'
+
+
+def profile(compiled_sfd: 'CompiledSFD') -> ProfileResult:
+
+    '''
+    Profile a compiled YAML experiment.
+
+    Computes static fields (permutation count, complexity) always. If
+    test_data_source is configured, runs a randomised strength-1 covering
+    array of permutations against test data and records timing.
+
+    Args:
+        compiled_sfd (CompiledSFD): Compiled SFD built from a validated yaml_dict
+
+    Returns:
+        ProfileResult: Static fields always populated; runtime fields populated
+            only when test_data_source is present and at least one permutation
+            completes successfully
+
+    '''
+
+    params: dict[str, list[Any]] = {
+        k: list(v) for k, v in compiled_sfd.params().items()
+    }
+    cardinalities = {k: len(v) for k, v in params.items()}
+    total = _total_permutations(params) if params else 0
+
+    result = ProfileResult(
+        total_permutations=total,
+        param_cardinalities=cardinalities,
+        complexity_rating=_complexity_rating(total),
+    )
+
+    manifest = compiled_sfd.manifest()
+
+    if manifest.test_data_source_config is None:
+        result.warnings.append(
+            'test_data_source not defined — runtime sampling skipped. '
+            'Add test_data_source to the manifest for timing estimates.'
+        )
+        return result
+
+    try:
+        raw_data = manifest.fetch_test_data()
+    except (OSError, ValueError, RuntimeError, ConnectionError) as exc:
+        result.errors.append(f'Failed to load test data: {type(exc).__name__}: {exc}')
+        return result
+
+    permutations = make_covering_array(params)
+    result.sample_permutations_attempted = len(permutations)
+
+    elapsed_times: list[float] = []
+
+    for round_params in permutations:
+        try:
+            with warnings.catch_warnings():
+                warnings.simplefilter('ignore')
+                data_dict = manifest.prepare_data(raw_data, round_params)
+                t0 = time.perf_counter()
+                manifest.run_model(data_dict, round_params)
+                elapsed_times.append(time.perf_counter() - t0)
+        except (ValueError, RuntimeError, MemoryError, TypeError, ArithmeticError) as exc:
+            result.errors.append(_classify_error(exc))
+
+    result.sample_permutations_completed = len(elapsed_times)
+
+    if elapsed_times:
+        result.sample_time_seconds_per_permutation = sum(elapsed_times) / len(elapsed_times)
+    elif not result.errors:
+        result.warnings.append('No permutations completed — timing unavailable.')
+
+    if result.sample_permutations_completed < result.sample_permutations_attempted:
+        failed = result.sample_permutations_attempted - result.sample_permutations_completed
+        result.warnings.append(
+            f'{failed} of {result.sample_permutations_attempted} sample '
+            f'permutation(s) failed — timing estimate based on '
+            f'{result.sample_permutations_completed} completed run(s).'
+        )
+
+    return result

--- a/limen/yaml/profiler.py
+++ b/limen/yaml/profiler.py
@@ -41,10 +41,6 @@ def _complexity_rating(total: int) -> str:
     return 'extreme'
 
 
-def _total_permutations(params: dict[str, list[Any]]) -> int:
-
-    return math.prod(len(v) for v in params.values())
-
 
 def make_covering_array(params: dict[str, list[Any]], seed: int = 42) -> list[dict[str, Any]]:
 
@@ -112,11 +108,13 @@ def profile(compiled_sfd: 'CompiledSFD') -> ProfileResult:
 
     '''
 
-    params: dict[str, list[Any]] = {
-        k: list(v) for k, v in compiled_sfd.params().items()
-    }
-    cardinalities = {k: len(v) for k, v in params.items()}
-    total = _total_permutations(params) if params else 0
+    params: dict[str, list[Any]] = {}
+    cardinalities: dict[str, int] = {}
+    for k, v in compiled_sfd.params().items():
+        lst = list(v)
+        params[k] = lst
+        cardinalities[k] = len(lst)
+    total = math.prod(cardinalities.values()) if cardinalities else 0
 
     result = ProfileResult(
         total_permutations=total,

--- a/limen/yaml/profiler.py
+++ b/limen/yaml/profiler.py
@@ -140,7 +140,7 @@ def profile(compiled_sfd: 'CompiledSFD') -> ProfileResult:
 
     try:
         raw_data = manifest.fetch_test_data()
-    except (OSError, ValueError, RuntimeError, ConnectionError) as exc:
+    except Exception as exc:  # noqa: BLE001
         result.errors.append(f'Failed to load test data: {type(exc).__name__}: {exc}')
         return result
 
@@ -153,8 +153,8 @@ def profile(compiled_sfd: 'CompiledSFD') -> ProfileResult:
         warnings.simplefilter('ignore')
         for round_params in permutations:
             try:
-                data_dict = manifest.prepare_data(raw_data, round_params)
                 t0 = time.perf_counter()
+                data_dict = manifest.prepare_data(raw_data, round_params)
                 manifest.run_model(data_dict, round_params)
                 elapsed_times.append(time.perf_counter() - t0)
             except (ValueError, RuntimeError, MemoryError, TypeError, ArithmeticError) as exc:

--- a/limen/yaml/profiler.py
+++ b/limen/yaml/profiler.py
@@ -1,5 +1,6 @@
 import math
 import random
+import re
 import time
 import warnings
 from dataclasses import dataclass
@@ -82,9 +83,9 @@ def _classify_error(exc: Exception) -> str:
     lower = msg.lower()
     if 'sample' in lower and ('0 ' in lower or 'empty' in lower):
         return f'Test data too small — increase n_rows in test_data_source. ({msg})'
-    if 'class' in lower and ('one' in lower or '1' in lower or 'least' in lower):
+    if 'class' in lower and ('one' in lower or 'least' in lower):
         return f'Not enough class diversity in test data — try larger n_rows. ({msg})'
-    if 'nan' in lower or 'inf' in lower:
+    if 'nan' in lower or re.search(r'\binf\b', lower):
         return f'Test data contains NaN or Inf values. ({msg})'
     return f'{type(exc).__name__}: {msg}'
 

--- a/limen/yaml/profiler.py
+++ b/limen/yaml/profiler.py
@@ -8,14 +8,18 @@ from dataclasses import field
 from typing import TYPE_CHECKING
 from typing import Any
 
+from limen.yaml.schema import COMPLEXITY_HIGH_MAX
+from limen.yaml.schema import COMPLEXITY_LOW_MAX
+from limen.yaml.schema import COMPLEXITY_MEDIUM_MAX
+
 if TYPE_CHECKING:
     from limen.yaml.compiler import CompiledSFD
 
 
 _COMPLEXITY_THRESHOLDS = [
-    (100, 'low'),
-    (1000, 'medium'),
-    (10000, 'high'),
+    (COMPLEXITY_LOW_MAX, 'low'),
+    (COMPLEXITY_MEDIUM_MAX, 'medium'),
+    (COMPLEXITY_HIGH_MAX, 'high'),
 ]
 
 
@@ -115,7 +119,7 @@ def profile(compiled_sfd: 'CompiledSFD') -> ProfileResult:
         lst = list(v)
         params[k] = lst
         cardinalities[k] = len(lst)
-    total = math.prod(cardinalities.values()) if cardinalities else 0
+    total = math.prod(cardinalities.values())
 
     result = ProfileResult(
         total_permutations=total,

--- a/limen/yaml/profiler.py
+++ b/limen/yaml/profiler.py
@@ -74,6 +74,8 @@ def make_covering_array(params: dict[str, list[Any]], seed: int = 42) -> list[di
     columns: dict[str, list[Any]] = {}
 
     for key, values in params.items():
+        if not values:
+            raise ValueError(f"Parameter '{key}' has an empty values list")
         column = [values[i % len(values)] for i in range(n)]
         rng.shuffle(column)
         columns[key] = column

--- a/limen/yaml/profiler.py
+++ b/limen/yaml/profiler.py
@@ -1,3 +1,4 @@
+import math
 import random
 import time
 import warnings
@@ -42,10 +43,7 @@ def _complexity_rating(total: int) -> str:
 
 def _total_permutations(params: dict[str, list[Any]]) -> int:
 
-    result = 1
-    for values in params.values():
-        result *= len(values)
-    return result
+    return math.prod(len(v) for v in params.values())
 
 
 def make_covering_array(params: dict[str, list[Any]], seed: int = 42) -> list[dict[str, Any]]:
@@ -146,16 +144,16 @@ def profile(compiled_sfd: 'CompiledSFD') -> ProfileResult:
 
     elapsed_times: list[float] = []
 
-    for round_params in permutations:
-        try:
-            with warnings.catch_warnings():
-                warnings.simplefilter('ignore')
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore')
+        for round_params in permutations:
+            try:
                 data_dict = manifest.prepare_data(raw_data, round_params)
                 t0 = time.perf_counter()
                 manifest.run_model(data_dict, round_params)
                 elapsed_times.append(time.perf_counter() - t0)
-        except (ValueError, RuntimeError, MemoryError, TypeError, ArithmeticError) as exc:
-            result.errors.append(_classify_error(exc))
+            except (ValueError, RuntimeError, MemoryError, TypeError, ArithmeticError) as exc:
+                result.errors.append(_classify_error(exc))
 
     result.sample_permutations_completed = len(elapsed_times)
 

--- a/limen/yaml/rules.py
+++ b/limen/yaml/rules.py
@@ -685,6 +685,14 @@ class SfdParams:
             ))
             return
 
+        if not params:
+            errors.append(YAMLError(
+                message="'sfd.params' must not be empty",
+                path='sfd.params',
+                suggestion='Add at least one parameter, e.g. lookback: [12, 24, 48]',
+            ))
+            return
+
         for key, values in params.items():
             if not isinstance(key, str):
                 errors.append(YAMLError(

--- a/limen/yaml/templates/xgboost_regressor.yaml
+++ b/limen/yaml/templates/xgboost_regressor.yaml
@@ -105,6 +105,7 @@ sfd:
     objective: ["reg:squarederror"]
     booster: [gbtree]
     early_stopping_rounds: [50]
+    random_state: [42]
 
 uel:
   n_permutations: 50

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaquum_limen"
-version = "3.12.1"
+version = "3.12.2"
 description = "Limen unifies parameter search across machine learning and rule-based strategies, with built-in analytics that show not just what works, but why it works."
 readme = "README.md"
 authors = [

--- a/tests/run.py
+++ b/tests/run.py
@@ -173,6 +173,8 @@ from tests.test_cli import test_cli_profile_shows_timing_when_sampling_completed
 from tests.test_cli import test_cli_profile_shows_errors_from_sampling
 from tests.test_cli import test_cli_profile_parse_error_exits_1
 from tests.test_cli import test_cli_profile_validation_error_exits_1
+from tests.test_cli import test_patch_metadata_adds_permutation_space
+from tests.test_cli import test_patch_metadata_no_op_when_file_absent
 from tests.test_foundational_sfd import test_foundational_sfd
 from tests.test_conserved_flux_renormalization import test_conserved_flux_renormalization
 from tests.test_confidence_filtering_system import test_calibrate_confidence_threshold
@@ -1227,6 +1229,8 @@ tests = [
     test_cli_profile_shows_errors_from_sampling,
     test_cli_profile_parse_error_exits_1,
     test_cli_profile_validation_error_exits_1,
+    test_patch_metadata_adds_permutation_space,
+    test_patch_metadata_no_op_when_file_absent,
     test_foundational_sfd,
     test_conserved_flux_renormalization,
     test_calibrate_confidence_threshold,

--- a/tests/run.py
+++ b/tests/run.py
@@ -106,6 +106,10 @@ from tests.test_yaml import test_compiled_sfd_manifest_is_cached
 from tests.test_yaml import test_compiled_sfd_manifest_is_ml_manifest
 from tests.test_yaml import test_build_search_strategy_raises_for_unknown_type
 from tests.test_yaml import test_build_search_strategy_raises_for_non_mapping_strategy
+from tests.test_yaml import test_all_templates_have_valid_limen_version
+from tests.test_yaml import test_tabpfn_binary_template_is_valid_and_arch_surface_complete
+from tests.test_yaml import test_xgboost_regressor_template_is_valid_and_arch_surface_complete
+from tests.test_yaml import test_rule_based_template_is_valid_and_compiles
 from tests.test_cli import test_cli_run_dry_run_valid_yaml_shows_dry_run_complete
 from tests.test_cli import test_cli_validate_valid_yaml_exits_0
 from tests.test_cli import test_cli_validate_shows_valid_checkmark
@@ -1124,6 +1128,10 @@ tests = [
     test_compiled_sfd_manifest_is_ml_manifest,
     test_build_search_strategy_raises_for_unknown_type,
     test_build_search_strategy_raises_for_non_mapping_strategy,
+    test_all_templates_have_valid_limen_version,
+    test_tabpfn_binary_template_is_valid_and_arch_surface_complete,
+    test_xgboost_regressor_template_is_valid_and_arch_surface_complete,
+    test_rule_based_template_is_valid_and_compiles,
     test_cli_run_dry_run_valid_yaml_shows_dry_run_complete,
     test_cli_validate_valid_yaml_exits_0,
     test_cli_validate_shows_valid_checkmark,

--- a/tests/run.py
+++ b/tests/run.py
@@ -110,6 +110,30 @@ from tests.test_yaml import test_all_templates_have_valid_limen_version
 from tests.test_yaml import test_tabpfn_binary_template_is_valid_and_arch_surface_complete
 from tests.test_yaml import test_xgboost_regressor_template_is_valid_and_arch_surface_complete
 from tests.test_yaml import test_rule_based_template_is_valid_and_compiles
+from tests.test_profiler import test_complexity_rating_low
+from tests.test_profiler import test_complexity_rating_medium
+from tests.test_profiler import test_complexity_rating_high
+from tests.test_profiler import test_complexity_rating_extreme
+from tests.test_profiler import test_covering_array_covers_all_values
+from tests.test_profiler import test_covering_array_length_equals_max_cardinality
+from tests.test_profiler import test_covering_array_empty_params_returns_empty
+from tests.test_profiler import test_covering_array_single_param
+from tests.test_profiler import test_covering_array_is_reproducible_with_same_seed
+from tests.test_profiler import test_covering_array_differs_with_different_seeds
+from tests.test_profiler import test_covering_array_columns_are_independently_shuffled
+from tests.test_profiler import test_covering_array_all_rows_have_all_keys
+from tests.test_profiler import test_covering_array_values_are_from_original_lists
+from tests.test_profiler import test_classify_error_small_dataset
+from tests.test_profiler import test_classify_error_class_diversity
+from tests.test_profiler import test_classify_error_nan
+from tests.test_profiler import test_classify_error_generic
+from tests.test_profiler import test_profile_static_fields_correct_for_logreg_template
+from tests.test_profiler import test_profile_total_permutations_is_product_of_cardinalities
+from tests.test_profiler import test_profile_warns_when_test_data_source_absent
+from tests.test_profiler import test_profile_runtime_records_timing_when_all_permutations_succeed
+from tests.test_profiler import test_profile_runtime_records_errors_when_all_permutations_fail
+from tests.test_profiler import test_profile_runtime_partial_failure_timing_from_completed_only
+from tests.test_profiler import test_profile_runtime_fetch_data_failure_reported_as_error
 from tests.test_cli import test_cli_run_dry_run_valid_yaml_shows_dry_run_complete
 from tests.test_cli import test_cli_validate_valid_yaml_exits_0
 from tests.test_cli import test_cli_validate_shows_valid_checkmark
@@ -1132,6 +1156,30 @@ tests = [
     test_tabpfn_binary_template_is_valid_and_arch_surface_complete,
     test_xgboost_regressor_template_is_valid_and_arch_surface_complete,
     test_rule_based_template_is_valid_and_compiles,
+    test_complexity_rating_low,
+    test_complexity_rating_medium,
+    test_complexity_rating_high,
+    test_complexity_rating_extreme,
+    test_covering_array_covers_all_values,
+    test_covering_array_length_equals_max_cardinality,
+    test_covering_array_empty_params_returns_empty,
+    test_covering_array_single_param,
+    test_covering_array_is_reproducible_with_same_seed,
+    test_covering_array_differs_with_different_seeds,
+    test_covering_array_columns_are_independently_shuffled,
+    test_covering_array_all_rows_have_all_keys,
+    test_covering_array_values_are_from_original_lists,
+    test_classify_error_small_dataset,
+    test_classify_error_class_diversity,
+    test_classify_error_nan,
+    test_classify_error_generic,
+    test_profile_static_fields_correct_for_logreg_template,
+    test_profile_total_permutations_is_product_of_cardinalities,
+    test_profile_warns_when_test_data_source_absent,
+    test_profile_runtime_records_timing_when_all_permutations_succeed,
+    test_profile_runtime_records_errors_when_all_permutations_fail,
+    test_profile_runtime_partial_failure_timing_from_completed_only,
+    test_profile_runtime_fetch_data_failure_reported_as_error,
     test_cli_run_dry_run_valid_yaml_shows_dry_run_complete,
     test_cli_validate_valid_yaml_exits_0,
     test_cli_validate_shows_valid_checkmark,

--- a/tests/run.py
+++ b/tests/run.py
@@ -173,8 +173,6 @@ from tests.test_cli import test_cli_profile_shows_timing_when_sampling_completed
 from tests.test_cli import test_cli_profile_shows_errors_from_sampling
 from tests.test_cli import test_cli_profile_parse_error_exits_1
 from tests.test_cli import test_cli_profile_validation_error_exits_1
-from tests.test_cli import test_patch_metadata_adds_permutation_space
-from tests.test_cli import test_patch_metadata_no_op_when_file_absent
 from tests.test_foundational_sfd import test_foundational_sfd
 from tests.test_conserved_flux_renormalization import test_conserved_flux_renormalization
 from tests.test_confidence_filtering_system import test_calibrate_confidence_threshold
@@ -1229,8 +1227,6 @@ tests = [
     test_cli_profile_shows_errors_from_sampling,
     test_cli_profile_parse_error_exits_1,
     test_cli_profile_validation_error_exits_1,
-    test_patch_metadata_adds_permutation_space,
-    test_patch_metadata_no_op_when_file_absent,
     test_foundational_sfd,
     test_conserved_flux_renormalization,
     test_calibrate_confidence_threshold,

--- a/tests/run.py
+++ b/tests/run.py
@@ -165,6 +165,14 @@ from tests.test_cli import test_cli_run_resume_errors_when_checkpoint_missing_me
 from tests.test_cli import test_cli_run_resume_errors_when_metadata_json_is_invalid_json
 from tests.test_cli import test_cli_run_resume_errors_when_yaml_reference_is_not_a_dict
 from tests.test_cli import test_cli_run_resume_errors_when_yaml_reference_missing_metadata_name
+from tests.test_cli import test_cli_profile_valid_yaml_exits_0
+from tests.test_cli import test_cli_profile_shows_permutation_count_and_rating
+from tests.test_cli import test_cli_profile_shows_all_param_names
+from tests.test_cli import test_cli_profile_shows_runtime_skipped_when_no_sampling
+from tests.test_cli import test_cli_profile_shows_timing_when_sampling_completed
+from tests.test_cli import test_cli_profile_shows_errors_from_sampling
+from tests.test_cli import test_cli_profile_parse_error_exits_1
+from tests.test_cli import test_cli_profile_validation_error_exits_1
 from tests.test_foundational_sfd import test_foundational_sfd
 from tests.test_conserved_flux_renormalization import test_conserved_flux_renormalization
 from tests.test_confidence_filtering_system import test_calibrate_confidence_threshold
@@ -1211,6 +1219,14 @@ tests = [
     test_cli_run_resume_errors_when_metadata_json_is_invalid_json,
     test_cli_run_resume_errors_when_yaml_reference_is_not_a_dict,
     test_cli_run_resume_errors_when_yaml_reference_missing_metadata_name,
+    test_cli_profile_valid_yaml_exits_0,
+    test_cli_profile_shows_permutation_count_and_rating,
+    test_cli_profile_shows_all_param_names,
+    test_cli_profile_shows_runtime_skipped_when_no_sampling,
+    test_cli_profile_shows_timing_when_sampling_completed,
+    test_cli_profile_shows_errors_from_sampling,
+    test_cli_profile_parse_error_exits_1,
+    test_cli_profile_validation_error_exits_1,
     test_foundational_sfd,
     test_conserved_flux_renormalization,
     test_calibrate_confidence_threshold,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -170,7 +170,7 @@ def test_patch_metadata_adds_permutation_space() -> None:
     with tempfile.TemporaryDirectory() as tmpdir:
         p = Path(tmpdir)
         (p / 'metadata.json').write_text(json.dumps({'limen_version': '1.0.0'}))
-        _patch_metadata(p, 1000, {'a': [1, 2], 'b': [3, 4, 5]})
+        _patch_metadata(p, 1000, {'a': 2, 'b': 3})
         meta = json.loads((p / 'metadata.json').read_text())
         assert meta['permutation_space']['total'] == 1000
         assert meta['permutation_space']['param_cardinalities'] == {'a': 2, 'b': 3}
@@ -181,7 +181,7 @@ def test_patch_metadata_no_op_when_file_absent() -> None:
     import tempfile
     from limen.cli.commands.run import _patch_metadata
     with tempfile.TemporaryDirectory() as tmpdir:
-        _patch_metadata(Path(tmpdir), 100, {'x': [1]})  # should not raise
+        _patch_metadata(Path(tmpdir), 100, {'x': 1})  # should not raise
 
 
 def _make_results_dir(yaml_reference: dict | None = None,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -164,25 +164,6 @@ def test_cli_init_metadata_name_not_updated_in_non_metadata_fields() -> None:
         assert 'name: "RSI oversold"' in text or 'name: RSI oversold' in text
 
 
-def test_patch_metadata_adds_permutation_space() -> None:
-    import tempfile
-    from limen.cli.commands.run import _patch_metadata
-    with tempfile.TemporaryDirectory() as tmpdir:
-        p = Path(tmpdir)
-        (p / 'metadata.json').write_text(json.dumps({'limen_version': '1.0.0'}))
-        _patch_metadata(p, 1000, {'a': 2, 'b': 3})
-        meta = json.loads((p / 'metadata.json').read_text())
-        assert meta['permutation_space']['total'] == 1000
-        assert meta['permutation_space']['param_cardinalities'] == {'a': 2, 'b': 3}
-        assert meta['limen_version'] == '1.0.0'
-
-
-def test_patch_metadata_no_op_when_file_absent() -> None:
-    import tempfile
-    from limen.cli.commands.run import _patch_metadata
-    with tempfile.TemporaryDirectory() as tmpdir:
-        _patch_metadata(Path(tmpdir), 100, {'x': 1})  # should not raise
-
 
 def _make_results_dir(yaml_reference: dict | None = None,
                       target_permutations: int = 10) -> tempfile.TemporaryDirectory:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -164,6 +164,26 @@ def test_cli_init_metadata_name_not_updated_in_non_metadata_fields() -> None:
         assert 'name: "RSI oversold"' in text or 'name: RSI oversold' in text
 
 
+def test_patch_metadata_adds_permutation_space() -> None:
+    import tempfile
+    from limen.cli.commands.run import _patch_metadata
+    with tempfile.TemporaryDirectory() as tmpdir:
+        p = Path(tmpdir)
+        (p / 'metadata.json').write_text(json.dumps({'limen_version': '1.0.0'}))
+        _patch_metadata(p, 1000, {'a': [1, 2], 'b': [3, 4, 5]})
+        meta = json.loads((p / 'metadata.json').read_text())
+        assert meta['permutation_space']['total'] == 1000
+        assert meta['permutation_space']['param_cardinalities'] == {'a': 2, 'b': 3}
+        assert meta['limen_version'] == '1.0.0'
+
+
+def test_patch_metadata_no_op_when_file_absent() -> None:
+    import tempfile
+    from limen.cli.commands.run import _patch_metadata
+    with tempfile.TemporaryDirectory() as tmpdir:
+        _patch_metadata(Path(tmpdir), 100, {'x': [1]})  # should not raise
+
+
 def _make_results_dir(yaml_reference: dict | None = None,
                       target_permutations: int = 10) -> tempfile.TemporaryDirectory:
     td = tempfile.TemporaryDirectory()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,6 +7,7 @@ from click.testing import CliRunner
 
 from limen.cli.main import cli
 from limen.yaml.parser import parse
+from limen.yaml.profiler import ProfileResult
 from tests.test_yaml import _MINIMAL_ML_YAML
 
 
@@ -308,6 +309,105 @@ def test_cli_run_resume_errors_when_yaml_reference_is_not_a_dict() -> None:
         result = runner.invoke(cli, ['run', '--resume', str(tmp)])
         assert result.exit_code == 1
         assert 'yaml_reference' in result.output
+
+
+def _make_profile_result(*, attempted: int = 0, completed: int = 0,
+                         time_per: float | None = None,
+                         warnings: list | None = None,
+                         errors: list | None = None) -> ProfileResult:
+    return ProfileResult(
+        total_permutations=120,
+        param_cardinalities={'solver': 3, 'C': 4, 'max_iter': 2, 'tol': 5},
+        complexity_rating='low',
+        sample_permutations_attempted=attempted,
+        sample_permutations_completed=completed,
+        sample_time_seconds_per_permutation=time_per,
+        warnings=warnings or [],
+        errors=errors or [],
+    )
+
+
+def test_cli_profile_valid_yaml_exits_0() -> None:
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        Path('exp.yaml').write_text(_MINIMAL_ML_YAML)
+        with patch('limen.cli.commands.profile.profile', return_value=_make_profile_result()):
+            result = runner.invoke(cli, ['profile', 'exp.yaml'])
+        assert result.exit_code == 0
+
+
+def test_cli_profile_shows_permutation_count_and_rating() -> None:
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        Path('exp.yaml').write_text(_MINIMAL_ML_YAML)
+        with patch('limen.cli.commands.profile.profile', return_value=_make_profile_result()):
+            result = runner.invoke(cli, ['profile', 'exp.yaml'])
+        assert '120' in result.output
+        assert 'low' in result.output
+
+
+def test_cli_profile_shows_all_param_names() -> None:
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        Path('exp.yaml').write_text(_MINIMAL_ML_YAML)
+        with patch('limen.cli.commands.profile.profile', return_value=_make_profile_result()):
+            result = runner.invoke(cli, ['profile', 'exp.yaml'])
+        for name in ('solver', 'C', 'max_iter', 'tol'):
+            assert name in result.output
+
+
+def test_cli_profile_shows_runtime_skipped_when_no_sampling() -> None:
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        Path('exp.yaml').write_text(_MINIMAL_ML_YAML)
+        prof = _make_profile_result(
+            warnings=['test_data_source not defined — runtime sampling skipped.'],
+        )
+        with patch('limen.cli.commands.profile.profile', return_value=prof):
+            result = runner.invoke(cli, ['profile', 'exp.yaml'])
+        assert 'Skipped' in result.output
+
+
+def test_cli_profile_shows_timing_when_sampling_completed() -> None:
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        Path('exp.yaml').write_text(_MINIMAL_ML_YAML)
+        prof = _make_profile_result(attempted=5, completed=5, time_per=0.42)
+        with patch('limen.cli.commands.profile.profile', return_value=prof):
+            result = runner.invoke(cli, ['profile', 'exp.yaml'])
+        assert '0.420s' in result.output
+        assert '5 of 5' in result.output
+
+
+def test_cli_profile_shows_errors_from_sampling() -> None:
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        Path('exp.yaml').write_text(_MINIMAL_ML_YAML)
+        prof = _make_profile_result(
+            attempted=3, completed=1, time_per=0.1,
+            errors=['Test data too small — increase n_rows in test_data_source.'],
+        )
+        with patch('limen.cli.commands.profile.profile', return_value=prof):
+            result = runner.invoke(cli, ['profile', 'exp.yaml'])
+        assert 'ERROR' in result.output
+        assert 'n_rows' in result.output
+
+
+def test_cli_profile_parse_error_exits_1() -> None:
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        Path('exp.yaml').write_text('sfd: [unclosed')
+        result = runner.invoke(cli, ['profile', 'exp.yaml'])
+        assert result.exit_code == 1
+
+
+def test_cli_profile_validation_error_exits_1() -> None:
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        Path('exp.yaml').write_text(_MINIMAL_ML_YAML.replace('name: test_exp\n', ''))
+        result = runner.invoke(cli, ['profile', 'exp.yaml'])
+        assert result.exit_code == 1
+        assert 'ERROR' in result.output
 
 
 def test_cli_run_resume_errors_when_yaml_reference_missing_metadata_name() -> None:

--- a/tests/test_profiler.py
+++ b/tests/test_profiler.py
@@ -119,6 +119,19 @@ def test_classify_error_generic() -> None:
     assert 'unexpected' in msg
 
 
+def test_classify_error_no_false_positive_on_numeric_1_in_message() -> None:
+    # "1" appears in learning_rate value — must not match class-diversity branch
+    msg = _classify_error(ValueError('XGBClassifier: learning_rate must be > 0.1'))
+    assert 'class diversity' not in msg
+
+
+def test_classify_error_no_false_positive_on_information_in_message() -> None:
+    # "inf" appears inside "information" — must not match NaN/Inf branch
+    msg = _classify_error(ValueError('For more information see sklearn docs'))
+    assert 'NaN' not in msg
+    assert 'Inf' not in msg
+
+
 def test_profile_static_fields_correct_for_logreg_template() -> None:
     template = _TEMPLATES_DIR / 'logreg_binary.yaml'
     yaml_dict, _ = parse(template.read_text(encoding='utf-8'))

--- a/tests/test_profiler.py
+++ b/tests/test_profiler.py
@@ -12,8 +12,6 @@ from limen.yaml.profiler import profile
 _TEMPLATES_DIR = Path(__file__).resolve().parents[1] / 'limen' / 'yaml' / 'templates'
 
 
-# --- _complexity_rating ---
-
 def test_complexity_rating_low() -> None:
     assert _complexity_rating(1) == 'low'
     assert _complexity_rating(100) == 'low'
@@ -34,8 +32,6 @@ def test_complexity_rating_extreme() -> None:
     assert _complexity_rating(10 ** 9) == 'extreme'
 
 
-# --- make_covering_array ---
-
 def test_covering_array_covers_all_values() -> None:
     params = {
         'a': [1, 2, 3],
@@ -43,10 +39,10 @@ def test_covering_array_covers_all_values() -> None:
         'c': [True, False, True, False],
     }
     array = make_covering_array(params)
-    assert len(array) == 4  # max cardinality
+    assert len(array) == 4
     for key, values in params.items():
         covered = {row[key] for row in array}
-        assert covered == set(values), f'param {key!r} not fully covered'
+        assert covered == set(values), f"param {key!r} not fully covered"
 
 
 def test_covering_array_length_equals_max_cardinality() -> None:
@@ -76,16 +72,12 @@ def test_covering_array_differs_with_different_seeds() -> None:
 
 
 def test_covering_array_columns_are_independently_shuffled() -> None:
-    # If columns were not independently shuffled (pure round-robin),
-    # the first values of each param would all appear in the same row.
+    # Without independent shuffle, all params would share the same rank order.
     params = {'a': [1, 2, 3, 4, 5], 'b': [10, 20, 30, 40, 50]}
     array = make_covering_array(params, seed=42)
-    # In pure round-robin, row 0 would always be a[0]=1, b[0]=10.
-    # With independent shuffle this should not hold for all seeds.
-    # We verify by checking that not all params follow the same rank order.
     a_order = [row['a'] for row in array]
     b_order = [row['b'] for row in array]
-    # Normalise to rank order — if columns were identical rank order, shuffle was not independent
+    # rank-order comparison: identical rank order ↔ columns shuffled as one
     a_ranks = sorted(range(len(a_order)), key=lambda i: a_order[i])
     b_ranks = sorted(range(len(b_order)), key=lambda i: b_order[i])
     assert a_ranks != b_ranks
@@ -105,8 +97,6 @@ def test_covering_array_values_are_from_original_lists() -> None:
         assert row['p'] in params['p']
         assert row['q'] in params['q']
 
-
-# --- _classify_error ---
 
 def test_classify_error_small_dataset() -> None:
     msg = _classify_error(ValueError('Found array with 0 sample(s)'))
@@ -128,8 +118,6 @@ def test_classify_error_generic() -> None:
     assert 'RuntimeError' in msg
     assert 'unexpected' in msg
 
-
-# --- profile() — static fields ---
 
 def test_profile_static_fields_correct_for_logreg_template() -> None:
     template = _TEMPLATES_DIR / 'logreg_binary.yaml'
@@ -214,8 +202,6 @@ def test_profile_warns_when_test_data_source_absent() -> None:
     assert result.sample_permutations_attempted == 0
     assert result.sample_time_seconds_per_permutation is None
 
-
-# --- profile() — runtime sampling (mocked) ---
 
 def _make_mock_manifest(fail: bool = False) -> MagicMock:
     manifest = MagicMock()

--- a/tests/test_profiler.py
+++ b/tests/test_profiler.py
@@ -1,0 +1,289 @@
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from limen.yaml.compiler import CompiledSFD
+from limen.yaml.parser import parse
+from limen.yaml.profiler import ProfileResult
+from limen.yaml.profiler import _classify_error
+from limen.yaml.profiler import _complexity_rating
+from limen.yaml.profiler import make_covering_array
+from limen.yaml.profiler import profile
+
+_TEMPLATES_DIR = Path(__file__).resolve().parents[1] / 'limen' / 'yaml' / 'templates'
+
+
+# --- _complexity_rating ---
+
+def test_complexity_rating_low() -> None:
+    assert _complexity_rating(1) == 'low'
+    assert _complexity_rating(100) == 'low'
+
+
+def test_complexity_rating_medium() -> None:
+    assert _complexity_rating(101) == 'medium'
+    assert _complexity_rating(1000) == 'medium'
+
+
+def test_complexity_rating_high() -> None:
+    assert _complexity_rating(1001) == 'high'
+    assert _complexity_rating(10000) == 'high'
+
+
+def test_complexity_rating_extreme() -> None:
+    assert _complexity_rating(10001) == 'extreme'
+    assert _complexity_rating(10 ** 9) == 'extreme'
+
+
+# --- make_covering_array ---
+
+def test_covering_array_covers_all_values() -> None:
+    params = {
+        'a': [1, 2, 3],
+        'b': ['x', 'y'],
+        'c': [True, False, True, False],
+    }
+    array = make_covering_array(params)
+    assert len(array) == 4  # max cardinality
+    for key, values in params.items():
+        covered = {row[key] for row in array}
+        assert covered == set(values), f'param {key!r} not fully covered'
+
+
+def test_covering_array_length_equals_max_cardinality() -> None:
+    params = {'x': [1, 2, 3, 4, 5], 'y': [10, 20]}
+    assert len(make_covering_array(params)) == 5
+
+
+def test_covering_array_empty_params_returns_empty() -> None:
+    assert make_covering_array({}) == []
+
+
+def test_covering_array_single_param() -> None:
+    params = {'p': [10, 20, 30]}
+    array = make_covering_array(params)
+    assert len(array) == 3
+    assert {row['p'] for row in array} == {10, 20, 30}
+
+
+def test_covering_array_is_reproducible_with_same_seed() -> None:
+    params = {'a': [1, 2, 3], 'b': ['x', 'y', 'z']}
+    assert make_covering_array(params, seed=7) == make_covering_array(params, seed=7)
+
+
+def test_covering_array_differs_with_different_seeds() -> None:
+    params = {'a': [1, 2, 3, 4, 5], 'b': ['x', 'y', 'z', 'w', 'v']}
+    assert make_covering_array(params, seed=1) != make_covering_array(params, seed=2)
+
+
+def test_covering_array_columns_are_independently_shuffled() -> None:
+    # If columns were not independently shuffled (pure round-robin),
+    # the first values of each param would all appear in the same row.
+    params = {'a': [1, 2, 3, 4, 5], 'b': [10, 20, 30, 40, 50]}
+    array = make_covering_array(params, seed=42)
+    # In pure round-robin, row 0 would always be a[0]=1, b[0]=10.
+    # With independent shuffle this should not hold for all seeds.
+    # We verify by checking that not all params follow the same rank order.
+    a_order = [row['a'] for row in array]
+    b_order = [row['b'] for row in array]
+    # Normalise to rank order — if columns were identical rank order, shuffle was not independent
+    a_ranks = sorted(range(len(a_order)), key=lambda i: a_order[i])
+    b_ranks = sorted(range(len(b_order)), key=lambda i: b_order[i])
+    assert a_ranks != b_ranks
+
+
+def test_covering_array_all_rows_have_all_keys() -> None:
+    params = {'x': [1, 2], 'y': ['a', 'b', 'c'], 'z': [True]}
+    array = make_covering_array(params)
+    for row in array:
+        assert set(row.keys()) == {'x', 'y', 'z'}
+
+
+def test_covering_array_values_are_from_original_lists() -> None:
+    params = {'p': [0.1, 0.5, 1.0], 'q': ['foo', 'bar']}
+    array = make_covering_array(params)
+    for row in array:
+        assert row['p'] in params['p']
+        assert row['q'] in params['q']
+
+
+# --- _classify_error ---
+
+def test_classify_error_small_dataset() -> None:
+    msg = _classify_error(ValueError('Found array with 0 sample(s)'))
+    assert 'n_rows' in msg
+
+
+def test_classify_error_class_diversity() -> None:
+    msg = _classify_error(ValueError('The number of classes has to be at least 2'))
+    assert 'class diversity' in msg
+
+
+def test_classify_error_nan() -> None:
+    msg = _classify_error(ValueError('Input contains NaN'))
+    assert 'NaN' in msg
+
+
+def test_classify_error_generic() -> None:
+    msg = _classify_error(RuntimeError('something unexpected'))
+    assert 'RuntimeError' in msg
+    assert 'unexpected' in msg
+
+
+# --- profile() — static fields ---
+
+def test_profile_static_fields_correct_for_logreg_template() -> None:
+    template = _TEMPLATES_DIR / 'logreg_binary.yaml'
+    yaml_dict, _ = parse(template.read_text(encoding='utf-8'))
+    sfd = CompiledSFD(yaml_dict)
+    result = profile(sfd)
+
+    assert isinstance(result, ProfileResult)
+    assert result.total_permutations > 0
+    assert result.complexity_rating in ('low', 'medium', 'high', 'extreme')
+    assert set(result.param_cardinalities.keys()) == set(yaml_dict['sfd']['params'].keys())
+    for key, values in yaml_dict['sfd']['params'].items():
+        assert result.param_cardinalities[key] == len(list(values))
+
+
+def test_profile_total_permutations_is_product_of_cardinalities() -> None:
+    template = _TEMPLATES_DIR / 'logreg_binary.yaml'
+    yaml_dict, _ = parse(template.read_text(encoding='utf-8'))
+    sfd = CompiledSFD(yaml_dict)
+    result = profile(sfd)
+
+    expected = 1
+    for v in result.param_cardinalities.values():
+        expected *= v
+    assert result.total_permutations == expected
+
+
+def test_profile_warns_when_test_data_source_absent() -> None:
+    from textwrap import dedent
+    yaml_str = dedent('''\
+        schema_version: "1.0"
+        metadata:
+          name: no_test_src
+          mode: development
+        sfd:
+          manifest:
+            type: ml
+            data_source:
+              method: limen.data.HistoricalData.get_spot_klines
+              params:
+                kline_size: 3600
+            split_config:
+              train: 8
+              val: 1
+              test: 2
+            target:
+              name: quantile_flag
+              class: limen.targets.QuantileBinaryTarget
+              fit_params:
+                source_column: close
+                quantile: 0.5
+              transform_params:
+                shift: -1
+            reference_architecture: limen.sfd.reference_architecture.logreg_binary
+          params:
+            max_iter: [100]
+            solver: [lbfgs]
+            penalty: [l2]
+            dual: [false]
+            tol: [0.01]
+            C: [1.0]
+            fit_intercept: [true]
+            intercept_scaling: [1.0]
+            class_weight: [0.5]
+            random_state: [42]
+            multi_class: [deprecated]
+            verbose: [0]
+            warm_start: [false]
+            n_jobs: [-1]
+            l1_ratio: [null]
+        uel:
+          n_permutations: 5
+          search_strategy:
+            type: random
+          output_format: csv
+    ''')
+    yaml_dict, _ = parse(yaml_str)
+    sfd = CompiledSFD(yaml_dict)
+    result = profile(sfd)
+
+    assert any('test_data_source' in w for w in result.warnings)
+    assert result.sample_permutations_attempted == 0
+    assert result.sample_time_seconds_per_permutation is None
+
+
+# --- profile() — runtime sampling (mocked) ---
+
+def _make_mock_manifest(fail: bool = False) -> MagicMock:
+    manifest = MagicMock()
+    manifest.test_data_source_config = MagicMock()
+    manifest.fetch_test_data.return_value = MagicMock()
+    manifest.prepare_data.return_value = {'x_train': [], 'y_train': []}
+    if fail:
+        manifest.run_model.side_effect = ValueError('Found array with 0 sample(s)')
+    else:
+        manifest.run_model.return_value = {'metric': 0.8}
+    return manifest
+
+
+def _make_mock_sfd(params: dict, manifest: MagicMock) -> MagicMock:
+    sfd = MagicMock(spec=CompiledSFD)
+    sfd.params.return_value = params
+    sfd.manifest.return_value = manifest
+    return sfd
+
+
+def test_profile_runtime_records_timing_when_all_permutations_succeed() -> None:
+    params = {'a': [1, 2, 3], 'b': ['x', 'y', 'z']}
+    sfd = _make_mock_sfd(params, _make_mock_manifest())
+    result = profile(sfd)
+
+    assert result.sample_permutations_attempted == 3
+    assert result.sample_permutations_completed == 3
+    assert result.sample_time_seconds_per_permutation is not None
+    assert result.sample_time_seconds_per_permutation >= 0.0
+    assert result.errors == []
+
+
+def test_profile_runtime_records_errors_when_all_permutations_fail() -> None:
+    params = {'a': [1, 2, 3], 'b': ['x', 'y', 'z']}
+    sfd = _make_mock_sfd(params, _make_mock_manifest(fail=True))
+    result = profile(sfd)
+
+    assert result.sample_permutations_completed == 0
+    assert result.sample_time_seconds_per_permutation is None
+    assert len(result.errors) == 3
+    assert all('n_rows' in e for e in result.errors)
+
+
+def test_profile_runtime_partial_failure_timing_from_completed_only() -> None:
+    params = {'a': [1, 2, 3]}
+    manifest = _make_mock_manifest()
+    # Fail on second call only
+    manifest.run_model.side_effect = [
+        {'metric': 0.8},
+        ValueError('Found array with 0 sample(s)'),
+        {'metric': 0.7},
+    ]
+    sfd = _make_mock_sfd(params, manifest)
+    result = profile(sfd)
+
+    assert result.sample_permutations_completed == 2
+    assert result.sample_permutations_attempted == 3
+    assert result.sample_time_seconds_per_permutation is not None
+    assert len(result.errors) == 1
+    assert any('2 of 3' in w or '1 of 3' in w for w in result.warnings)
+
+
+def test_profile_runtime_fetch_data_failure_reported_as_error() -> None:
+    params = {'a': [1, 2]}
+    manifest = _make_mock_manifest()
+    manifest.fetch_test_data.side_effect = ConnectionError('network down')
+    sfd = _make_mock_sfd(params, manifest)
+    result = profile(sfd)
+
+    assert any('Failed to load test data' in e for e in result.errors)
+    assert result.sample_permutations_attempted == 0

--- a/tests/test_yaml.py
+++ b/tests/test_yaml.py
@@ -1038,6 +1038,11 @@ def test_all_templates_have_valid_limen_version() -> None:
 
 
 def test_tabpfn_binary_template_is_valid_and_arch_surface_complete() -> None:
+    try:
+        import tabpfn  # noqa: F401
+    except ImportError:
+        return
+
     template = _TEMPLATES_DIR / 'tabpfn_binary.yaml'
     yaml_dict, errors = parse(template.read_text(encoding='utf-8'))
     assert errors == []

--- a/tests/test_yaml.py
+++ b/tests/test_yaml.py
@@ -1,4 +1,5 @@
 import inspect
+import re
 from datetime import date
 from pathlib import Path
 from textwrap import dedent
@@ -20,6 +21,9 @@ from limen.yaml.parser import parse
 from limen.yaml.resolver import is_resolvable
 from limen.yaml.resolver import resolve
 from limen.yaml.validator import validate
+
+_TEMPLATES_DIR = Path(__file__).resolve().parents[1] / 'limen' / 'yaml' / 'templates'
+_SEMVER_RE = re.compile(r'^\d+\.\d+\.\d+')
 
 _MINIMAL_ML_YAML = dedent('''\
     schema_version: "1.0"
@@ -1019,3 +1023,57 @@ def test_build_search_strategy_raises_for_non_mapping_strategy() -> None:
         assert False, 'expected ValueError'
     except ValueError as exc:
         assert 'mapping' in str(exc)
+
+
+def test_all_templates_have_valid_limen_version() -> None:
+    for path in sorted(_TEMPLATES_DIR.glob('*.yaml')):
+        yaml_dict, errors = parse(path.read_text(encoding='utf-8'))
+        assert errors == [], f'{path.name}: parse errors: {errors}'
+        version = yaml_dict.get('metadata', {}).get('limen_version')
+        assert isinstance(version, str) and _SEMVER_RE.match(version), (
+            f'{path.name}: metadata.limen_version missing or invalid: {version!r}'
+        )
+
+
+def test_tabpfn_binary_template_is_valid_and_arch_surface_complete() -> None:
+    template = _TEMPLATES_DIR / 'tabpfn_binary.yaml'
+    yaml_dict, errors = parse(template.read_text(encoding='utf-8'))
+    assert errors == []
+
+    result = validate(yaml_dict)
+    assert result.valid, [e.message for e in result.errors]
+
+    sfd = CompiledSFD(yaml_dict)
+    assert isinstance(sfd.manifest(), MLManifest)
+
+    arch = resolve(yaml_dict['sfd']['manifest']['reference_architecture'])
+    model_params = set(inspect.signature(arch).parameters) - {'data', 'prediction_calibration_config'}
+    assert model_params <= set(yaml_dict['sfd']['params'])
+
+
+def test_xgboost_regressor_template_is_valid_and_arch_surface_complete() -> None:
+    template = _TEMPLATES_DIR / 'xgboost_regressor.yaml'
+    yaml_dict, errors = parse(template.read_text(encoding='utf-8'))
+    assert errors == []
+
+    result = validate(yaml_dict)
+    assert result.valid, [e.message for e in result.errors]
+
+    sfd = CompiledSFD(yaml_dict)
+    assert isinstance(sfd.manifest(), MLManifest)
+
+    arch = resolve(yaml_dict['sfd']['manifest']['reference_architecture'])
+    model_params = set(inspect.signature(arch).parameters) - {'data', 'prediction_calibration_config'}
+    assert model_params <= set(yaml_dict['sfd']['params'])
+
+
+def test_rule_based_template_is_valid_and_compiles() -> None:
+    template = _TEMPLATES_DIR / 'rule_based.yaml'
+    yaml_dict, errors = parse(template.read_text(encoding='utf-8'))
+    assert errors == []
+
+    result = validate(yaml_dict)
+    assert result.valid, [e.message for e in result.errors]
+
+    sfd = CompiledSFD(yaml_dict)
+    assert isinstance(sfd.manifest(), RuleBasedManifest)

--- a/tests/test_yaml.py
+++ b/tests/test_yaml.py
@@ -266,6 +266,8 @@ def test_logreg_yaml_template_exposes_full_architecture_surface() -> None:
     result = validate(yaml_dict)
     assert result.valid, [e.message for e in result.errors]
 
+    build_search_strategy(yaml_dict)
+
     arch = resolve(yaml_dict['sfd']['manifest']['reference_architecture'])
     model_params = set(inspect.signature(arch).parameters) - {
         'data',
@@ -1043,6 +1045,8 @@ def test_tabpfn_binary_template_is_valid_and_arch_surface_complete() -> None:
     result = validate(yaml_dict)
     assert result.valid, [e.message for e in result.errors]
 
+    build_search_strategy(yaml_dict)
+
     sfd = CompiledSFD(yaml_dict)
     assert isinstance(sfd.manifest(), MLManifest)
 
@@ -1059,6 +1063,8 @@ def test_xgboost_regressor_template_is_valid_and_arch_surface_complete() -> None
     result = validate(yaml_dict)
     assert result.valid, [e.message for e in result.errors]
 
+    build_search_strategy(yaml_dict)
+
     sfd = CompiledSFD(yaml_dict)
     assert isinstance(sfd.manifest(), MLManifest)
 
@@ -1074,6 +1080,8 @@ def test_rule_based_template_is_valid_and_compiles() -> None:
 
     result = validate(yaml_dict)
     assert result.valid, [e.message for e in result.errors]
+
+    build_search_strategy(yaml_dict)
 
     sfd = CompiledSFD(yaml_dict)
     assert isinstance(sfd.manifest(), RuleBasedManifest)


### PR DESCRIPTION
**NOTE:** The author must always **first review the PR themselves**, before requesting review from others, that means carefully having reviewed the full diff in GitHub.

## What does this PR change?

- Add `limen profile` CLI command — profiles a YAML experiment's permutation space (total count, per-parameter cardinalities, complexity rating) and, when `test_data_source` is configured, runs a randomised strength-1 covering array to estimate per-permutation runtime
- Add `limen/yaml/profiler.py` with `ProfileResult`, `make_covering_array`, and `profile()` — profiler core usable independently of the CLI

Implements experiment profiler phase of #506 

## Checklist

- [x] I have reviewed full diff in “Files changed”
- [x] I left no unnecessary files in the changes
- [x] I ran `python tests/run.py` locally without errors (where applicable)
- [ ] I updated `/docs` (if behavior/API/config/user/etc changed)
- [x] I added and/or updated docstrings as per [Writing Docstrings](https://github.com/Vaquum/Limen/blob/main/docs/Developer/Writing-Docstrings.md) (for any changed public functions/classes)
- [x] I updated CHANGELOG.md (unless only docs or other non-code aspect was changed)
- [x] I updated pyproject.toml (unless only docs or other non-code aspect was changed)
- [x] I added and/or updated tests (if behavior changed or new code paths added)
- [x] I validated changes manually
- [x] I validated changes with LLM
- [x] I removed any extraneous examples/comments
- [x] I linked issue to auto-close on merge (e.g., “Fixes #123”) when applicable
