### PR TITLE
fix: preserve yaml cohort sensor contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -987,3 +987,7 @@ Note: add all new changelog entries to the bottom of this file.
 - Add built-in single-file Cohort selectors under `limen.cohort.sfc`: `all`, `top_n`, `backtest_pareto`, and `diverse_metrics`.
 - Make `all` the default selector, preserving existing Cohort behavior when `permutation_ids` is omitted.
 - Remove `RegimeDiversifiedOpinionPools`; its reusable metric-diversity selection idea now lives in `diverse_metrics`, while replay and per-regime output behavior are no longer part of the public package.
+
+## v5.0.1 on 24th of May, 2026
+
+- Make `Cohort` resolve YAML CLI artifacts through `metadata.json["yaml_reference"]` before falling back to `sfd_module`, preserving Trainer sensor probability output for manifest-based runs.

--- a/docs/Cohort.md
+++ b/docs/Cohort.md
@@ -174,6 +174,9 @@ Members are expected to behave like Sensor/model wrappers with a `predict(data_d
 ## Aggregation Modes
 
 Aggregation mode is selected at construction based on architecture capability hints.
+For YAML CLI runs, Cohort reads `metadata.json["yaml_reference"]` to recover the
+manifest `reference_architecture`; this keeps `sfd_module: yaml:<name>` bundles
+compatible with Trainer-reconstructed sensors.
 
 ### 1) `probability_weighted`
 

--- a/limen/cohort/cohort.py
+++ b/limen/cohort/cohort.py
@@ -604,8 +604,8 @@ class Cohort:
 
         return next(iter(architecture_ids))
 
-    @staticmethod
-    def _extract_architecture_id(round_entry: dict, metadata: dict) -> str:
+    @classmethod
+    def _extract_architecture_id(cls, round_entry: dict, metadata: dict) -> str:
 
         round_params = round_entry.get('round_params', {})
         for key in (
@@ -620,11 +620,36 @@ class Cohort:
             if isinstance(value, str) and value.strip():
                 return value.strip()
 
+        yaml_architecture = cls._extract_yaml_reference_architecture(metadata)
+        if yaml_architecture is not None:
+            return yaml_architecture
+
         sfd_module = metadata.get('sfd_module')
         if isinstance(sfd_module, str) and sfd_module.strip():
             return sfd_module.strip()
 
         return 'unknown_architecture'
+
+    @staticmethod
+    def _extract_yaml_reference_architecture(metadata: dict) -> str | None:
+
+        yaml_reference = metadata.get('yaml_reference')
+        if not isinstance(yaml_reference, dict):
+            return None
+
+        sfd_config = yaml_reference.get('sfd')
+        if not isinstance(sfd_config, dict):
+            return None
+
+        manifest_config = sfd_config.get('manifest')
+        if not isinstance(manifest_config, dict):
+            return None
+
+        reference_architecture = manifest_config.get('reference_architecture')
+        if isinstance(reference_architecture, str) and reference_architecture.strip():
+            return reference_architecture.strip()
+
+        return None
 
     @classmethod
     def _architecture_supports_probabilities(cls, architecture_id: str) -> bool:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaquum_limen"
-version = "5.0.0"
+version = "5.0.1"
 description = "Limen unifies parameter search across machine learning and rule-based strategies, with built-in analytics that show not just what works, but why it works."
 readme = "README.md"
 authors = [

--- a/tests/run.py
+++ b/tests/run.py
@@ -746,6 +746,7 @@ from tests.test_proto_cohort import test_rejects_unresolvable_experiment_id
 from tests.test_proto_cohort import test_rejects_ambiguous_experiment_id_resolution
 from tests.test_proto_cohort import test_rejects_mixed_architecture_selection
 from tests.test_proto_cohort import test_sets_probability_mode_for_probability_capable_architecture
+from tests.test_proto_cohort import test_yaml_cli_artifact_cohort_preserves_trainer_sensor_contract
 from tests.test_proto_cohort import test_sets_fallback_mode_for_non_probability_architecture
 from tests.test_proto_cohort import test_probability_weighted_predict_aggregates_mean_p1
 from tests.test_proto_cohort import test_probability_weighted_predict_single_member_matches_own_thresholded_probs
@@ -1507,6 +1508,7 @@ tests = [
     test_rejects_ambiguous_experiment_id_resolution,
     test_rejects_mixed_architecture_selection,
     test_sets_probability_mode_for_probability_capable_architecture,
+    test_yaml_cli_artifact_cohort_preserves_trainer_sensor_contract,
     test_sets_fallback_mode_for_non_probability_architecture,
     test_probability_weighted_predict_aggregates_mean_p1,
     test_probability_weighted_predict_single_member_matches_own_thresholded_probs,

--- a/tests/test_proto_cohort.py
+++ b/tests/test_proto_cohort.py
@@ -1,17 +1,24 @@
 import json
+import math
+from datetime import datetime
+from datetime import timedelta
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
 import numpy as np
 import pandas as pd
+import polars as pl
 
+from limen.cli.commands.run import run_experiment
 from limen.cohort import Cohort
 from limen.cohort.sfc.top_n import select as select_top_n
+from limen.data import historical_data
 from limen.experiment.experiment_core import UniversalExperimentLoop
 from limen.experiment.param_domain import ParamDomain
 from limen.experiment.param_search import GridStrategy
 from limen.experiment.trainer import Trainer
 from limen.sfd.foundational_sfd import logreg_binary as logreg_sfd
+from tests.test_yaml import _MINIMAL_ML_YAML
 
 
 class _RaisingMember:
@@ -149,6 +156,42 @@ def _train_real_members_and_input(experiment_dir: Path,
     x_test = data_dict['x_test']
 
     return sensors, x_test
+
+
+def _make_yaml_contract_data(kline_size: int = 3600,
+                             n_rows: int | None = None) -> pl.DataFrame:
+
+    _ = kline_size
+    n = int(n_rows or 500)
+    timestamps = [datetime(2025, 1, 1) + timedelta(hours=i) for i in range(n)]
+    close = [100.0 + 0.02 * i + math.sin(i / 7.0) for i in range(n)]
+
+    return pl.DataFrame({
+        'datetime': timestamps,
+        'open': [value - 0.1 for value in close],
+        'high': [value + 0.2 for value in close],
+        'low': [value - 0.2 for value in close],
+        'close': close,
+        'volume': [1000.0 + i for i in range(n)],
+    })
+
+
+def _minimal_yaml_cli_contract_text(output_path: Path) -> str:
+
+    yaml_text = _MINIMAL_ML_YAML.replace('n_permutations: 5', 'n_permutations: 1')
+    yaml_text = yaml_text.replace(
+        'use_calibration: [true, false]',
+        'use_calibration: [false]',
+    )
+    yaml_text = yaml_text.replace(
+        'use_threshold: [true, false]',
+        'use_threshold: [false]',
+    )
+
+    return yaml_text.replace(
+        'output_format: csv',
+        f'output_format: csv\n  output_path: "{output_path}"',
+    )
 
 
 def test_rejects_when_no_source_provided():
@@ -472,6 +515,61 @@ def test_sets_probability_mode_for_probability_capable_architecture():
         assert cohort.architecture_id.endswith('logreg_binary')
         assert cohort.supports_probabilities is True
         assert cohort.aggregation_mode == 'probability_weighted'
+
+
+def test_yaml_cli_artifact_cohort_preserves_trainer_sensor_contract():
+
+    original_get_spot_klines = historical_data.HistoricalData.get_spot_klines
+    historical_data.HistoricalData.get_spot_klines = staticmethod(
+        _make_yaml_contract_data,
+    )
+
+    try:
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            yaml_path = root / 'exp.yaml'
+            exp_dir = root / 'results' / 'test_exp'
+            yaml_path.write_text(
+                _minimal_yaml_cli_contract_text(exp_dir),
+            )
+
+            assert run_experiment(yaml_path) is True
+
+            with (exp_dir / 'metadata.json').open('r') as f:
+                metadata = json.load(f)
+            with (exp_dir / 'round_data.jsonl').open('r') as f:
+                round_entry = json.loads(f.readline())
+
+            assert metadata['sfd_module'] == 'yaml:test_exp'
+            assert isinstance(metadata['yaml_reference'], dict)
+            assert not [
+                key for key in round_entry['round_params']
+                if 'architecture' in key
+            ]
+
+            trainer = Trainer(exp_dir)
+            sensors = trainer.train([0])
+            data_dict = trainer._manifest.prepare_data(
+                trainer._data,
+                sensors[0].round_params,
+            )
+            live_input = {'x_test': data_dict['x_test']}
+
+            sensor_result = sensors[0].predict(live_input)
+            cohort = Cohort(experiment_log_path=str(exp_dir), permutation_ids=[0])
+
+            assert cohort.architecture_id == 'limen.sfd.reference_architecture.logreg_binary'
+            assert cohort.aggregation_mode == 'probability_weighted'
+
+            cohort.set_members(sensors)
+            cohort_result = cohort.predict(live_input)
+
+            assert '_probs' in sensor_result
+            assert '_probs' in cohort_result
+            np.testing.assert_array_equal(cohort_result['_preds'], sensor_result['_preds'])
+            np.testing.assert_allclose(cohort_result['_probs'], sensor_result['_probs'])
+    finally:
+        historical_data.HistoricalData.get_spot_klines = original_get_spot_klines
 
 
 def test_rejects_raw_input_for_sensor_compatible_predict_contract():


### PR DESCRIPTION
## Summary
- Resolve Cohort architecture for YAML CLI artifacts from `metadata.json["yaml_reference"].sfd.manifest.reference_architecture` before falling back to `sfd_module`.
- Preserve Trainer sensor passthrough for YAML manifest runs where `sfd_module` is the non-importable `yaml:<name>` marker.
- Add a YAML CLI artifact regression that runs `limen run`, trains a real Trainer sensor, binds it to Cohort, and verifies `_preds`/`_probs` match.

## Validation
- `.venv/bin/python -m pytest tests/test_proto_cohort.py::test_yaml_cli_artifact_cohort_preserves_trainer_sensor_contract -q`
- `.venv/bin/python -m pytest tests/test_proto_cohort.py -q`
- `.venv/bin/python -m ruff check limen/cohort/cohort.py tests/test_proto_cohort.py tests/run.py`
- `.venv/bin/python tests/run.py` — 760 passed, 0 failed
