### PR TITLE
chore: keep release versions in 3 series

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -972,22 +972,22 @@ Note: add all new changelog entries to the bottom of this file.
 - Add `limen init <output.yaml> --template <name>` CLI command — scaffolds a new experiment file from a template
 - Add `limen run --resume <results-dir>` CLI command — resumes an experiment from a checkpoint directory using `yaml_reference` and `target_permutations` from the checkpoint
 
-## v4.0.0 on 22nd of May, 2026
+## v3.11.0 on 22nd of May, 2026
 
-- Breaking: make `UniversalExperimentLoop.run()` skip terminal post-processing by default and retain `post_processing=True` as an explicit opt-in.
+- Change `UniversalExperimentLoop.run()` to skip terminal post-processing by default and retain `post_processing=True` as an explicit opt-in.
 
-## v4.0.1 on 23rd of May, 2026
+## v3.11.1 on 23rd of May, 2026
 
 - Stop retaining post-processing inputs in memory during default `post_processing=False` UEL runs while preserving persisted round data for resume and promotion workflows.
 - Batch standard UEL experiment-log construction to avoid row-count-dependent slowdown from per-round Polars `vstack`.
 
-## v5.0.0 on 23rd of May, 2026
+## v3.12.0 on 23rd of May, 2026
 
 - Add Cohort selector support with the `select(context, **params) -> list[int | str]` contract.
 - Add built-in single-file Cohort selectors under `limen.cohort.sfc`: `all`, `top_n`, `backtest_pareto`, and `diverse_metrics`.
 - Make `all` the default selector, preserving existing Cohort behavior when `permutation_ids` is omitted.
 - Remove `RegimeDiversifiedOpinionPools`; its reusable metric-diversity selection idea now lives in `diverse_metrics`, while replay and per-regime output behavior are no longer part of the public package.
 
-## v5.0.1 on 24th of May, 2026
+## v3.12.1 on 24th of May, 2026
 
 - Make `Cohort` resolve YAML CLI artifacts through `metadata.json["yaml_reference"]` before falling back to `sfd_module`, preserving Trainer sensor probability output for manifest-based runs.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaquum_limen"
-version = "5.0.1"
+version = "3.12.1"
 description = "Limen unifies parameter search across machine learning and rule-based strategies, with built-in analytics that show not just what works, but why it works."
 readme = "README.md"
 authors = [


### PR DESCRIPTION
## Intent

This PR keeps Limen on the `3.x` release line. The recent jump from `3.x` to `4.x` and then `5.x` overstated the release scope for this package.

The intent is explicit: even where strict SemVer could justify a major bump, these changes should be represented as minor/patch movement inside the current `3.x` series. Removing dead code, including RDOP removal, should not reset the public package line to a new major version.

## Changes

- Set package version from `5.0.1` to `3.12.1`.
- Remap changelog headings:
  - `v4.0.0` -> `v3.11.0`
  - `v4.0.1` -> `v3.11.1`
  - `v5.0.0` -> `v3.12.0`
  - `v5.0.1` -> `v3.12.1`
- Reword the `v3.11.0` changelog line away from major-version framing.

## Runtime Impact

None. This is release metadata only: `pyproject.toml` and `CHANGELOG.md`.

## Validation

- `.venv/bin/python - <<'PY' ...` verified `pyproject.toml` reports `3.12.1`, no `v4.0.*` / `v5.0.*` changelog headings remain, and the expected `v3.11.*` / `v3.12.*` headings exist.
- `.venv/bin/python tests/run.py` completed locally on pushed commit `de53e4b0d7f21b7f47d76381ebd34ecbaa75a394`: 760 passed, 0 failed.
