### PR TITLE
Wp limen 0013 yaml pr6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -998,3 +998,13 @@ Note: add all new changelog entries to the bottom of this file.
 - Add `limen profile` CLI command — profiles a YAML experiment's permutation space (total count, per-parameter cardinalities, complexity rating) and, when `test_data_source` is configured, runs a randomised strength-1 covering array to estimate per-permutation runtime
 - Add `limen/yaml/profiler.py` with `ProfileResult`, `make_covering_array`, and `profile()` — profiler core usable independently of the CLI
 
+## v3.13.0 on 27th of May, 2026
+
+- Add `limen new <project-name>` CLI command — scaffolds a new Limen project by cloning the official project template and optionally setting a backup remote
+- Add `limen commit <yaml>` CLI command — content-addresses a YAML manifest into `manifests/committed/`, injects a `lineage` block, updates `index.json`, and git-commits the store; gates on `metadata.mode: production`
+- Add `limen ls` CLI command — lists all committed manifests with copy-pasteable `manifest://sha256:<short>` URIs
+- Add `manifest://sha256:<hex>` URI support to `limen run` — resolves a committed manifest by full or unambiguous short hash, verifies `lineage.id` integrity, and routes results to `results/<short_id>/<timestamp>/`
+- Route development-mode results to `results/dev/` (gitignored in project template) and production-mode results to `results/`
+- Add `limen/yaml/config.py` with `find_project_root()`, `read_limen_toml()`, and `get_store_path()`
+- Add `limen/cli/git_utils.py` with `git_executable()` and `git_add_and_commit()`
+

--- a/limen/cli/commands/commit.py
+++ b/limen/cli/commands/commit.py
@@ -5,6 +5,7 @@ import click
 from limen.cli.commands._load_yaml import load_and_validate
 from limen.cli.git_utils import git_add_and_commit
 from limen.yaml.config import find_project_root
+from limen.yaml.store import _SHA256_PREFIX
 from limen.yaml.store import commit_manifest
 
 
@@ -44,8 +45,8 @@ def run_commit(yaml_path: Path, parent_id: str | None, message: str | None) -> b
         return True
 
     name = str(yaml_dict.get('metadata', {}).get('name', yaml_path.stem))
-    short_id = manifest_id[7:15]
-    commit_msg = message or f'commit: {name} (sha256:{short_id})'
+    short_id = manifest_id[len(_SHA256_PREFIX):len(_SHA256_PREFIX) + 8]
+    commit_msg = message or f'commit: {name} ({_SHA256_PREFIX}{short_id})'
     git_add_and_commit(project_root, Path('manifests') / 'committed', commit_msg)
 
     click.secho(f"\n  ✓ Committed {manifest_id}", fg='green')

--- a/limen/cli/commands/commit.py
+++ b/limen/cli/commands/commit.py
@@ -56,7 +56,14 @@ def run_commit(yaml_path: Path, parent_id: str | None, message: str | None) -> b
     name = str(yaml_dict.get('metadata', {}).get('name', yaml_path.stem))
     short_id = manifest_id[len(_SHA256_PREFIX):len(_SHA256_PREFIX) + 8]
     commit_msg = message or f'commit: {name} ({_SHA256_PREFIX}{short_id})'
-    git_add_and_commit(project_root, Path('manifests') / 'committed', commit_msg)
+    git_ok = git_add_and_commit(project_root, Path('manifests') / 'committed', commit_msg)
 
-    click.secho(f"\n  ✓ Committed {manifest_id}", fg='green')
+    if not git_ok:
+        click.secho(
+            f"\n  ✓ Stored {manifest_id}\n"
+            '  ⚠ Git commit failed — manifest is stored but not version-controlled.',
+            fg='yellow',
+        )
+    else:
+        click.secho(f"\n  ✓ Committed {manifest_id}", fg='green')
     return True

--- a/limen/cli/commands/commit.py
+++ b/limen/cli/commands/commit.py
@@ -63,7 +63,12 @@ def run_commit(yaml_path: Path, parent_id: str | None, message: str | None) -> b
     manifest_id, already_existed = commit_manifest(yaml_path, project_root, parent_id)
 
     if already_existed:
-        click.secho(f"\n  Already committed: {manifest_id}", fg='yellow')
+        short_id = manifest_id[len(_SHA256_PREFIX):len(_SHA256_PREFIX) + 8]
+        repair_msg = f'repair: restore index for {_SHA256_PREFIX}{short_id}'
+        if git_add_and_commit(project_root, Path('manifests') / 'committed', repair_msg):
+            click.secho(f"\n  ✓ Repaired and committed {manifest_id}", fg='green')
+        else:
+            click.secho(f"\n  Already committed: {manifest_id}", fg='yellow')
         return True
 
     name = str(yaml_dict.get('metadata', {}).get('name', yaml_path.stem))

--- a/limen/cli/commands/commit.py
+++ b/limen/cli/commands/commit.py
@@ -38,6 +38,15 @@ def run_commit(yaml_path: Path, parent_id: str | None, message: str | None) -> b
     if not valid:
         return False
 
+    mode = yaml_dict.get('metadata', {}).get('mode', 'development')
+    if mode != 'production':
+        click.secho(
+            '  ✗ Cannot commit a development-mode manifest.\n'
+            '    Set metadata.mode: production before committing.',
+            fg='red',
+        )
+        return False
+
     manifest_id, already_existed = commit_manifest(yaml_path, project_root, parent_id)
 
     if already_existed:

--- a/limen/cli/commands/commit.py
+++ b/limen/cli/commands/commit.py
@@ -5,6 +5,7 @@ import click
 from limen.cli.commands._load_yaml import load_and_validate
 from limen.cli.git_utils import git_add_and_commit
 from limen.yaml.config import find_project_root
+from limen.yaml.store import _SHA256_HEX_LENGTH
 from limen.yaml.store import _SHA256_PREFIX
 from limen.yaml.store import commit_manifest
 
@@ -23,6 +24,16 @@ def run_commit(yaml_path: Path, parent_id: str | None, message: str | None) -> b
         bool: True on success, False on failure
 
     '''
+
+    if parent_id is not None:
+        hex_part = parent_id[len(_SHA256_PREFIX):]
+        if not parent_id.startswith(_SHA256_PREFIX) or len(hex_part) != _SHA256_HEX_LENGTH:
+            click.secho(
+                f"  ✗ Invalid parent ID: '{parent_id}'\n"
+                '    Expected sha256:<64-hex-chars>.',
+                fg='red',
+            )
+            return False
 
     project_root = find_project_root(yaml_path.parent)
     if project_root is None:

--- a/limen/cli/commands/commit.py
+++ b/limen/cli/commands/commit.py
@@ -27,7 +27,9 @@ def run_commit(yaml_path: Path, parent_id: str | None, message: str | None) -> b
 
     if parent_id is not None:
         hex_part = parent_id[len(_SHA256_PREFIX):]
-        if not parent_id.startswith(_SHA256_PREFIX) or len(hex_part) != _SHA256_HEX_LENGTH:
+        if (not parent_id.startswith(_SHA256_PREFIX)
+                or len(hex_part) != _SHA256_HEX_LENGTH
+                or not all(c in '0123456789abcdef' for c in hex_part)):
             click.secho(
                 f"  ✗ Invalid parent ID: '{parent_id}'\n"
                 '    Expected sha256:<64-hex-chars>.',

--- a/limen/cli/commands/commit.py
+++ b/limen/cli/commands/commit.py
@@ -68,7 +68,7 @@ def run_commit(yaml_path: Path, parent_id: str | None, message: str | None) -> b
         if git_add_and_commit(project_root, Path('manifests') / 'committed', repair_msg):
             click.secho(f"\n  ✓ Repaired and committed {manifest_id}", fg='green')
         else:
-            click.secho(f"\n  Already committed: {manifest_id}", fg='yellow')
+            click.secho(f"\n  Already in store: {manifest_id}", fg='yellow')
         return True
 
     name = str(yaml_dict.get('metadata', {}).get('name', yaml_path.stem))

--- a/limen/cli/commands/commit.py
+++ b/limen/cli/commands/commit.py
@@ -1,0 +1,52 @@
+from pathlib import Path
+
+import click
+
+from limen.cli.commands._load_yaml import load_and_validate
+from limen.cli.git_utils import git_add_and_commit
+from limen.yaml.config import find_project_root
+from limen.yaml.store import commit_manifest
+
+
+def run_commit(yaml_path: Path, parent_id: str | None, message: str | None) -> bool:
+
+    '''
+    Validate, store, and git-commit a YAML manifest.
+
+    Args:
+        yaml_path (Path): Path to the source YAML file
+        parent_id (str | None): Parent manifest ID for lineage tracking
+        message (str | None): Custom git commit message; auto-generated if None
+
+    Returns:
+        bool: True on success, False on failure
+
+    '''
+
+    project_root = find_project_root(yaml_path.parent)
+    if project_root is None:
+        click.secho(
+            '  ✗ No limen project found. '
+            'The YAML file must be inside a Limen project directory (containing limen.toml).',
+            fg='red',
+        )
+        return False
+
+    click.echo(f"Validating {yaml_path.name} ...")
+    yaml_dict, valid = load_and_validate(yaml_path)
+    if not valid:
+        return False
+
+    manifest_id, already_existed = commit_manifest(yaml_path, project_root, parent_id)
+
+    if already_existed:
+        click.secho(f"\n  Already committed: {manifest_id}", fg='yellow')
+        return True
+
+    name = str(yaml_dict.get('metadata', {}).get('name', yaml_path.stem))
+    short_id = manifest_id[7:15]
+    commit_msg = message or f'commit: {name} (sha256:{short_id})'
+    git_add_and_commit(project_root, Path('manifests') / 'committed', commit_msg)
+
+    click.secho(f"\n  ✓ Committed {manifest_id}", fg='green')
+    return True

--- a/limen/cli/commands/ls.py
+++ b/limen/cli/commands/ls.py
@@ -32,7 +32,11 @@ def run_ls(start: Path) -> bool:
         click.echo('  No committed manifests yet. Use limen commit to add one.')
         return True
 
-    index = json.loads(index_path.read_text(encoding='utf-8'))
+    try:
+        index = json.loads(index_path.read_text(encoding='utf-8'))
+    except json.JSONDecodeError:
+        click.secho('  ⚠ index.json is corrupted — run limen commit to repair it.', fg='yellow')
+        return True
     manifests = index.get('manifests', [])
 
     if not manifests:

--- a/limen/cli/commands/ls.py
+++ b/limen/cli/commands/ls.py
@@ -5,6 +5,7 @@ import click
 
 from limen.yaml.config import find_project_root
 from limen.yaml.config import _STORE_RELATIVE
+from limen.yaml.store import _MANIFEST_URI_SCHEME
 from limen.yaml.store import _SHA256_PREFIX
 
 
@@ -42,7 +43,8 @@ def run_ls(start: Path) -> bool:
     p = len(_SHA256_PREFIX)
     for entry in manifests:
         short_id = entry['id'][p:p + 8]
+        uri = f'{_MANIFEST_URI_SCHEME}{_SHA256_PREFIX}{short_id}'
         parent = f"  parent: {entry['parent_id'][p:p + 8]}" if entry.get('parent_id') else ''
-        click.echo(f"  {_SHA256_PREFIX}{short_id}  {entry['name']:<30}  {entry['committed_at']}{parent}")
+        click.echo(f"  {uri}  {entry['name']:<30}  {entry['committed_at']}{parent}")
 
     return True

--- a/limen/cli/commands/ls.py
+++ b/limen/cli/commands/ls.py
@@ -37,15 +37,24 @@ def run_ls(start: Path) -> bool:
     except json.JSONDecodeError:
         click.secho('  ⚠ index.json is corrupted — run limen commit to repair it.', fg='yellow')
         return True
-    manifests = index.get('manifests', [])
+
+    if not isinstance(index, dict) or not isinstance(index.get('manifests'), list):
+        click.secho('  ⚠ index.json has invalid structure — run limen commit to repair it.', fg='yellow')
+        return True
+
+    manifests = index['manifests']
 
     if not manifests:
         click.echo('  No committed manifests yet. Use limen commit to add one.')
         return True
 
+    _REQUIRED = {'id', 'name', 'committed_at'}
     click.echo(f"Committed manifests ({len(manifests)}):\n")
     p = len(_SHA256_PREFIX)
     for entry in manifests:
+        if not isinstance(entry, dict) or not _REQUIRED.issubset(entry):
+            click.secho('  ⚠ Skipping malformed entry in index.json.', fg='yellow')
+            continue
         short_id = entry['id'][p:p + 8]
         uri = f'{_MANIFEST_URI_SCHEME}{_SHA256_PREFIX}{short_id}'
         parent = f"  parent: {entry['parent_id'][p:p + 8]}" if entry.get('parent_id') else ''

--- a/limen/cli/commands/ls.py
+++ b/limen/cli/commands/ls.py
@@ -6,6 +6,7 @@ import click
 from limen.yaml.config import find_project_root
 from limen.yaml.config import _STORE_RELATIVE
 from limen.yaml.store import _MANIFEST_URI_SCHEME
+from limen.yaml.store import _SHA256_HEX_LENGTH
 from limen.yaml.store import _SHA256_PREFIX
 
 
@@ -49,23 +50,31 @@ def run_ls(start: Path) -> bool:
         return True
 
     _REQUIRED = {'id', 'name', 'committed_at'}
+    _HEX = frozenset('0123456789abcdef')
     click.echo(f"Committed manifests ({len(manifests)}):\n")
     p = len(_SHA256_PREFIX)
     for entry in manifests:
         entry_id = entry.get('id') if isinstance(entry, dict) else None
+        hex_part = entry_id[p:] if isinstance(entry_id, str) else ''
         if (not isinstance(entry, dict)
                 or not _REQUIRED.issubset(entry)
                 or not isinstance(entry_id, str)
                 or not entry_id.startswith(_SHA256_PREFIX)
+                or len(hex_part) != _SHA256_HEX_LENGTH
+                or not _HEX.issuperset(hex_part)
                 or not isinstance(entry.get('name'), str)
                 or not isinstance(entry.get('committed_at'), str)):
             click.secho('  ⚠ Skipping malformed entry in index.json.', fg='yellow')
             continue
-        short_id = entry_id[p:p + 8]
+        short_id = hex_part[:8]
         uri = f'{_MANIFEST_URI_SCHEME}{_SHA256_PREFIX}{short_id}'
         parent_id_val = entry.get('parent_id')
-        parent = (f"  parent: {parent_id_val[p:p + 8]}"
-                  if isinstance(parent_id_val, str) and parent_id_val.startswith(_SHA256_PREFIX)
+        parent_hex = parent_id_val[p:] if isinstance(parent_id_val, str) else ''
+        parent = (f"  parent: {parent_hex[:8]}"
+                  if (isinstance(parent_id_val, str)
+                      and parent_id_val.startswith(_SHA256_PREFIX)
+                      and len(parent_hex) == _SHA256_HEX_LENGTH
+                      and _HEX.issuperset(parent_hex))
                   else '')
         click.echo(f"  {uri}  {entry['name']:<30}  {entry['committed_at']}{parent}")
 

--- a/limen/cli/commands/ls.py
+++ b/limen/cli/commands/ls.py
@@ -1,0 +1,48 @@
+import json
+from pathlib import Path
+
+import click
+
+from limen.yaml.config import find_project_root
+from limen.yaml.config import _STORE_RELATIVE
+from limen.yaml.store import _SHA256_PREFIX
+
+
+def run_ls(start: Path) -> bool:
+
+    '''
+    List all committed manifests in the project store.
+
+    Args:
+        start (Path): Directory to start searching for the project root
+
+    Returns:
+        bool: True on success, False if no project found
+
+    '''
+
+    project_root = find_project_root(start)
+    if project_root is None:
+        click.secho('  ✗ No limen project found. Run this command from inside a Limen project.', fg='red')
+        return False
+
+    index_path = project_root / _STORE_RELATIVE / 'index.json'
+    if not index_path.exists():
+        click.echo('  No committed manifests yet. Use limen commit to add one.')
+        return True
+
+    index = json.loads(index_path.read_text(encoding='utf-8'))
+    manifests = index.get('manifests', [])
+
+    if not manifests:
+        click.echo('  No committed manifests yet. Use limen commit to add one.')
+        return True
+
+    click.echo(f"Committed manifests ({len(manifests)}):\n")
+    p = len(_SHA256_PREFIX)
+    for entry in manifests:
+        short_id = entry['id'][p:p + 8]
+        parent = f"  parent: {entry['parent_id'][p:p + 8]}" if entry.get('parent_id') else ''
+        click.echo(f"  {_SHA256_PREFIX}{short_id}  {entry['name']:<30}  {entry['committed_at']}{parent}")
+
+    return True

--- a/limen/cli/commands/ls.py
+++ b/limen/cli/commands/ls.py
@@ -56,7 +56,9 @@ def run_ls(start: Path) -> bool:
         if (not isinstance(entry, dict)
                 or not _REQUIRED.issubset(entry)
                 or not isinstance(entry_id, str)
-                or not entry_id.startswith(_SHA256_PREFIX)):
+                or not entry_id.startswith(_SHA256_PREFIX)
+                or not isinstance(entry.get('name'), str)
+                or not isinstance(entry.get('committed_at'), str)):
             click.secho('  ⚠ Skipping malformed entry in index.json.', fg='yellow')
             continue
         short_id = entry_id[p:p + 8]

--- a/limen/cli/commands/ls.py
+++ b/limen/cli/commands/ls.py
@@ -52,12 +52,19 @@ def run_ls(start: Path) -> bool:
     click.echo(f"Committed manifests ({len(manifests)}):\n")
     p = len(_SHA256_PREFIX)
     for entry in manifests:
-        if not isinstance(entry, dict) or not _REQUIRED.issubset(entry):
+        entry_id = entry.get('id') if isinstance(entry, dict) else None
+        if (not isinstance(entry, dict)
+                or not _REQUIRED.issubset(entry)
+                or not isinstance(entry_id, str)
+                or not entry_id.startswith(_SHA256_PREFIX)):
             click.secho('  ⚠ Skipping malformed entry in index.json.', fg='yellow')
             continue
-        short_id = entry['id'][p:p + 8]
+        short_id = entry_id[p:p + 8]
         uri = f'{_MANIFEST_URI_SCHEME}{_SHA256_PREFIX}{short_id}'
-        parent = f"  parent: {entry['parent_id'][p:p + 8]}" if entry.get('parent_id') else ''
+        parent_id_val = entry.get('parent_id')
+        parent = (f"  parent: {parent_id_val[p:p + 8]}"
+                  if isinstance(parent_id_val, str) and parent_id_val.startswith(_SHA256_PREFIX)
+                  else '')
         click.echo(f"  {uri}  {entry['name']:<30}  {entry['committed_at']}{parent}")
 
     return True

--- a/limen/cli/commands/new.py
+++ b/limen/cli/commands/new.py
@@ -4,16 +4,10 @@ from pathlib import Path
 
 import click
 
+from limen.cli.git_utils import git_executable
+
 
 _TEMPLATE_REPO = 'https://github.com/Vaquum/limen-project-template.git'
-
-
-def _git_executable() -> str:
-
-    git = shutil.which('git')
-    if git is None:
-        raise FileNotFoundError('git not found on PATH')
-    return git
 
 
 def run_new(project_name: str, backup_remote: str | None) -> bool:
@@ -60,7 +54,7 @@ def run_new(project_name: str, backup_remote: str | None) -> bool:
 
 def _clone_template(project_path: Path) -> bool:
 
-    git = _git_executable()
+    git = git_executable()
     click.echo('  Cloning template ...')
     result = subprocess.run(
         [git, 'clone', '--depth=1', _TEMPLATE_REPO, str(project_path)],
@@ -77,9 +71,7 @@ def _clone_template(project_path: Path) -> bool:
     subprocess.run([git, 'add', '.'], cwd=project_path, capture_output=True, check=False)
     subprocess.run(
         [git, 'commit', '-m', 'feat: initial project from limen-project-template'],
-        cwd=project_path,
-        capture_output=True,
-        check=False,
+        cwd=project_path, capture_output=True, check=False,
     )
     return True
 

--- a/limen/cli/commands/new.py
+++ b/limen/cli/commands/new.py
@@ -67,12 +67,12 @@ def _clone_template(project_path: Path) -> bool:
         return False
 
     shutil.rmtree(project_path / '.git')
-    init = subprocess.run([git, 'init'], cwd=project_path, capture_output=True, check=False)
+    init = subprocess.run([git, 'init'], cwd=project_path, capture_output=True, text=True, check=False)
     if init.returncode != 0:
         shutil.rmtree(project_path)
         click.secho(f"  ✗ git init failed: {init.stderr.strip()}", fg='red')
         return False
-    add = subprocess.run([git, 'add', '.'], cwd=project_path, capture_output=True, check=False)
+    add = subprocess.run([git, 'add', '.'], cwd=project_path, capture_output=True, text=True, check=False)
     if add.returncode != 0:
         shutil.rmtree(project_path)
         click.secho(f"  ✗ git add failed: {add.stderr.strip()}", fg='red')

--- a/limen/cli/commands/new.py
+++ b/limen/cli/commands/new.py
@@ -67,8 +67,16 @@ def _clone_template(project_path: Path) -> bool:
         return False
 
     shutil.rmtree(project_path / '.git')
-    subprocess.run([git, 'init'], cwd=project_path, capture_output=True, check=False)
-    subprocess.run([git, 'add', '.'], cwd=project_path, capture_output=True, check=False)
+    init = subprocess.run([git, 'init'], cwd=project_path, capture_output=True, check=False)
+    if init.returncode != 0:
+        shutil.rmtree(project_path)
+        click.secho(f"  ✗ git init failed: {init.stderr.strip()}", fg='red')
+        return False
+    add = subprocess.run([git, 'add', '.'], cwd=project_path, capture_output=True, check=False)
+    if add.returncode != 0:
+        shutil.rmtree(project_path)
+        click.secho(f"  ✗ git add failed: {add.stderr.strip()}", fg='red')
+        return False
     commit = subprocess.run(
         [git, 'commit', '-m', 'feat: initial project from limen-project-template'],
         cwd=project_path, capture_output=True, check=False,
@@ -85,6 +93,9 @@ def _write_backup_remote(project_path: Path, remote_url: str) -> None:
 
     toml_path = project_path / 'limen.toml'
     text = toml_path.read_text(encoding='utf-8')
-    text = text.replace('backup_remote = ""', f'backup_remote = "{remote_url}"')
-    toml_path.write_text(text, encoding='utf-8')
+    updated = text.replace('backup_remote = ""', f'backup_remote = "{remote_url}"')
+    if updated == text:
+        click.secho('  ⚠ Could not set backup remote — limen.toml format unexpected.', fg='yellow')
+        return
+    toml_path.write_text(updated, encoding='utf-8')
     click.echo(f"  Backup remote set to: {remote_url}")

--- a/limen/cli/commands/new.py
+++ b/limen/cli/commands/new.py
@@ -54,7 +54,11 @@ def run_new(project_name: str, backup_remote: str | None) -> bool:
 
 def _clone_template(project_path: Path) -> bool:
 
-    git = git_executable()
+    try:
+        git = git_executable()
+    except FileNotFoundError:
+        click.secho('  ✗ git not found on PATH — install git and try again.', fg='red')
+        return False
     click.echo('  Cloning template ...')
     result = subprocess.run(
         [git, 'clone', '--depth=1', _TEMPLATE_REPO, str(project_path)],
@@ -91,6 +95,9 @@ def _clone_template(project_path: Path) -> bool:
 
 def _write_backup_remote(project_path: Path, remote_url: str) -> None:
 
+    if '"' in remote_url or '\n' in remote_url:
+        click.secho('  ⚠ Backup remote URL contains invalid characters — skipping.', fg='yellow')
+        return
     toml_path = project_path / 'limen.toml'
     text = toml_path.read_text(encoding='utf-8')
     updated = text.replace('backup_remote = ""', f'backup_remote = "{remote_url}"')

--- a/limen/cli/commands/new.py
+++ b/limen/cli/commands/new.py
@@ -1,0 +1,154 @@
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import click
+
+
+_TEMPLATE_REPO = 'https://github.com/Vaquum/limen-project-template.git'
+_MIN_PYTHON = (3, 10)
+
+
+def _git_executable() -> str:
+
+    git = shutil.which('git')
+    if git is None:
+        raise FileNotFoundError('git not found on PATH')
+    return git
+
+
+def run_new(project_name: str, backup_remote: str | None) -> bool:
+
+    '''
+    Create a new Limen project from the official project template.
+
+    Args:
+        project_name (str): Name of the new project directory to create
+        backup_remote (str | None): Git remote URL for manifest store backup
+
+    Returns:
+        bool: True on success, False on failure
+
+    '''
+
+    if not _check_python_version():
+        return False
+
+    project_path = Path(project_name)
+
+    if project_path.exists():
+        click.secho(f"  ✗ '{project_name}' already exists.", fg='red')
+        return False
+
+    click.echo(f"Creating project '{project_name}' ...")
+
+    if not _clone_template(project_path):
+        return False
+
+    if not _create_venv(project_path):
+        return False
+
+    if not _install_limen(project_path):
+        return False
+
+    if backup_remote is None:
+        backup_remote = click.prompt(
+            '  Backup remote URL (leave blank to skip)',
+            default='',
+            show_default=False,
+        ).strip()
+
+    if backup_remote:
+        _write_backup_remote(project_path, backup_remote)
+
+    click.secho(f"\n  ✓ Project '{project_name}' created.", fg='green')
+    click.echo("\n  Next steps:")
+    click.echo(f"    cd {project_name}")
+    click.echo("    source venv/bin/activate")
+    return True
+
+
+def _check_python_version() -> bool:
+
+    major, minor = sys.version_info[:2]
+    min_major, min_minor = _MIN_PYTHON
+
+    if (major, minor) < (min_major, min_minor):
+        click.secho(
+            f"  ✗ Python {min_major}.{min_minor}+ required. Found {major}.{minor}.",
+            fg='red',
+        )
+        click.echo(
+            f"  Install via pyenv: pyenv install {min_major}.{min_minor} "
+            f"&& pyenv global {min_major}.{min_minor}"
+        )
+        return False
+    return True
+
+
+def _clone_template(project_path: Path) -> bool:
+
+    git = _git_executable()
+    click.echo('  Cloning template ...')
+    result = subprocess.run(
+        [git, 'clone', '--depth=1', _TEMPLATE_REPO, str(project_path)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        click.secho(f"  ✗ Clone failed: {result.stderr.strip()}", fg='red')
+        return False
+
+    shutil.rmtree(project_path / '.git')
+    subprocess.run([git, 'init'], cwd=project_path, capture_output=True, check=False)
+    subprocess.run([git, 'add', '.'], cwd=project_path, capture_output=True, check=False)
+    subprocess.run(
+        [git, 'commit', '-m', 'feat: initial project from limen-project-template'],
+        cwd=project_path,
+        capture_output=True,
+        check=False,
+    )
+    return True
+
+
+def _create_venv(project_path: Path) -> bool:
+
+    click.echo('  Creating virtual environment ...')
+    result = subprocess.run(
+        [sys.executable, '-m', 'venv', 'venv'],
+        cwd=project_path,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        click.secho(f"  ✗ Failed to create venv: {result.stderr.strip()}", fg='red')
+        return False
+    return True
+
+
+def _install_limen(project_path: Path) -> bool:
+
+    click.echo('  Installing limen ...')
+    venv_pip = project_path / 'venv' / 'bin' / 'pip'
+    result = subprocess.run(
+        [str(venv_pip), 'install', 'vaquum-limen', '--quiet'],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        click.secho(f"  ✗ Failed to install limen: {result.stderr.strip()}", fg='red')
+        return False
+    return True
+
+
+def _write_backup_remote(project_path: Path, remote_url: str) -> None:
+
+    toml_path = project_path / 'limen.toml'
+    text = toml_path.read_text(encoding='utf-8')
+    text = text.replace('backup_remote = ""', f'backup_remote = "{remote_url}"')
+    toml_path.write_text(text, encoding='utf-8')
+    click.echo(f"  Backup remote set to: {remote_url}")

--- a/limen/cli/commands/new.py
+++ b/limen/cli/commands/new.py
@@ -1,13 +1,11 @@
 import shutil
 import subprocess
-import sys
 from pathlib import Path
 
 import click
 
 
 _TEMPLATE_REPO = 'https://github.com/Vaquum/limen-project-template.git'
-_MIN_PYTHON = (3, 10)
 
 
 def _git_executable() -> str:
@@ -32,9 +30,6 @@ def run_new(project_name: str, backup_remote: str | None) -> bool:
 
     '''
 
-    if not _check_python_version():
-        return False
-
     project_path = Path(project_name)
 
     if project_path.exists():
@@ -44,12 +39,6 @@ def run_new(project_name: str, backup_remote: str | None) -> bool:
     click.echo(f"Creating project '{project_name}' ...")
 
     if not _clone_template(project_path):
-        return False
-
-    if not _create_venv(project_path):
-        return False
-
-    if not _install_limen(project_path):
         return False
 
     if backup_remote is None:
@@ -65,25 +54,7 @@ def run_new(project_name: str, backup_remote: str | None) -> bool:
     click.secho(f"\n  ✓ Project '{project_name}' created.", fg='green')
     click.echo("\n  Next steps:")
     click.echo(f"    cd {project_name}")
-    click.echo("    source venv/bin/activate")
-    return True
-
-
-def _check_python_version() -> bool:
-
-    major, minor = sys.version_info[:2]
-    min_major, min_minor = _MIN_PYTHON
-
-    if (major, minor) < (min_major, min_minor):
-        click.secho(
-            f"  ✗ Python {min_major}.{min_minor}+ required. Found {major}.{minor}.",
-            fg='red',
-        )
-        click.echo(
-            f"  Install via pyenv: pyenv install {min_major}.{min_minor} "
-            f"&& pyenv global {min_major}.{min_minor}"
-        )
-        return False
+    click.echo("    limen validate manifests/examples/logreg_binary.yaml")
     return True
 
 
@@ -110,38 +81,6 @@ def _clone_template(project_path: Path) -> bool:
         capture_output=True,
         check=False,
     )
-    return True
-
-
-def _create_venv(project_path: Path) -> bool:
-
-    click.echo('  Creating virtual environment ...')
-    result = subprocess.run(
-        [sys.executable, '-m', 'venv', 'venv'],
-        cwd=project_path,
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-    if result.returncode != 0:
-        click.secho(f"  ✗ Failed to create venv: {result.stderr.strip()}", fg='red')
-        return False
-    return True
-
-
-def _install_limen(project_path: Path) -> bool:
-
-    click.echo('  Installing limen ...')
-    venv_pip = project_path / 'venv' / 'bin' / 'pip'
-    result = subprocess.run(
-        [str(venv_pip), 'install', 'vaquum-limen', '--quiet'],
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-    if result.returncode != 0:
-        click.secho(f"  ✗ Failed to install limen: {result.stderr.strip()}", fg='red')
-        return False
     return True
 
 

--- a/limen/cli/commands/new.py
+++ b/limen/cli/commands/new.py
@@ -69,10 +69,15 @@ def _clone_template(project_path: Path) -> bool:
     shutil.rmtree(project_path / '.git')
     subprocess.run([git, 'init'], cwd=project_path, capture_output=True, check=False)
     subprocess.run([git, 'add', '.'], cwd=project_path, capture_output=True, check=False)
-    subprocess.run(
+    commit = subprocess.run(
         [git, 'commit', '-m', 'feat: initial project from limen-project-template'],
         cwd=project_path, capture_output=True, check=False,
     )
+    if commit.returncode != 0:
+        click.secho(
+            '  ⚠ Initial git commit failed — project created but not version-controlled.',
+            fg='yellow',
+        )
     return True
 
 

--- a/limen/cli/commands/run.py
+++ b/limen/cli/commands/run.py
@@ -11,9 +11,12 @@ from limen.cli.commands.profile import format_space
 from limen.experiment.experiment_core import UniversalExperimentLoop
 from limen.yaml.compiler import CompiledSFD
 from limen.yaml.compiler import build_search_strategy
+from limen.yaml.config import _STORE_RELATIVE
 
 
-def run_experiment(yaml_path: Path, dry_run: bool = False) -> bool:
+def run_experiment(yaml_path: Path,
+                   dry_run: bool = False,
+                   manifest_id: str | None = None) -> bool:
 
     '''
     Validate, compile, and execute a YAML experiment file.
@@ -21,6 +24,8 @@ def run_experiment(yaml_path: Path, dry_run: bool = False) -> bool:
     Args:
         yaml_path (Path): Path to the YAML experiment file
         dry_run (bool): When True, validate only — do not execute
+        manifest_id (str | None): Full hex hash when running from a committed manifest URI.
+            Changes results directory layout and YAML copy filename
 
     Returns:
         bool: True on success, False on validation failure
@@ -49,9 +54,11 @@ def run_experiment(yaml_path: Path, dry_run: bool = False) -> bool:
     prep_each_round: bool = bool(uel_cfg.get('prep_each_round', True))
     test_mode: bool = yaml_dict['metadata'].get('mode', 'development') == 'development'
 
-    results_dir = _build_results_dir(uel_cfg, experiment_name)
+    results_base = yaml_path.parents[len(_STORE_RELATIVE.parts)] if manifest_id is not None else Path('.')
+    results_dir = _build_results_dir(uel_cfg, experiment_name, test_mode, manifest_id, results_base)
     results_dir.mkdir(parents=True, exist_ok=True)
-    shutil.copy2(yaml_path, results_dir / yaml_path.name)
+    yaml_dest_name = 'manifest.yaml' if manifest_id is not None else yaml_path.name
+    shutil.copy2(yaml_path, results_dir / yaml_dest_name)
 
     search_strategy = build_search_strategy(yaml_dict)
     compiled = CompiledSFD(yaml_dict)
@@ -98,14 +105,20 @@ def run_experiment(yaml_path: Path, dry_run: bool = False) -> bool:
     return True
 
 
-def _build_results_dir(uel_cfg: dict[str, Any], experiment_name: str) -> Path:
+def _build_results_dir(uel_cfg: dict[str, Any],
+                       experiment_name: str,
+                       test_mode: bool,
+                       manifest_id: str | None = None,
+                       results_base: Path = Path('.')) -> Path:
 
-    output_path_template: str = uel_cfg.get('output_path', './results/{name}_{datetime}')
     timestamp = datetime.now().strftime('%Y%m%d_%H%M%S')
-    return Path(
-        output_path_template
-        .replace('{name}', experiment_name)
-        .replace('{datetime}', timestamp)
-    )
+    results_root = results_base / 'results'
+    prefix = results_root / 'dev' if test_mode else results_root
+
+    if manifest_id is not None:
+        return prefix / manifest_id[:8] / timestamp
+
+    template: str = uel_cfg.get('output_path', '{name}_{datetime}')
+    return prefix / template.replace('{name}', experiment_name).replace('{datetime}', timestamp)
 
 

--- a/limen/cli/commands/run.py
+++ b/limen/cli/commands/run.py
@@ -11,12 +11,12 @@ from limen.cli.commands.profile import format_space
 from limen.experiment.experiment_core import UniversalExperimentLoop
 from limen.yaml.compiler import CompiledSFD
 from limen.yaml.compiler import build_search_strategy
-from limen.yaml.config import _STORE_RELATIVE
 
 
 def run_experiment(yaml_path: Path,
                    dry_run: bool = False,
-                   manifest_id: str | None = None) -> bool:
+                   manifest_id: str | None = None,
+                   results_base: Path = Path('.')) -> bool:
 
     '''
     Validate, compile, and execute a YAML experiment file.
@@ -26,6 +26,8 @@ def run_experiment(yaml_path: Path,
         dry_run (bool): When True, validate only — do not execute
         manifest_id (str | None): Full hex hash when running from a committed manifest URI.
             Changes results directory layout and YAML copy filename
+        results_base (Path): Base directory for results output. Defaults to cwd.
+            Pass the project root when running a committed manifest URI.
 
     Returns:
         bool: True on success, False on validation failure
@@ -54,7 +56,6 @@ def run_experiment(yaml_path: Path,
     prep_each_round: bool = bool(uel_cfg.get('prep_each_round', True))
     test_mode: bool = yaml_dict['metadata'].get('mode', 'development') == 'development'
 
-    results_base = yaml_path.parents[len(_STORE_RELATIVE.parts)] if manifest_id is not None else Path('.')
     results_dir = _build_results_dir(uel_cfg, experiment_name, test_mode, manifest_id, results_base)
     results_dir.mkdir(parents=True, exist_ok=True)
     yaml_dest_name = 'manifest.yaml' if manifest_id is not None else yaml_path.name

--- a/limen/cli/git_utils.py
+++ b/limen/cli/git_utils.py
@@ -22,7 +22,7 @@ def git_executable() -> str:
     return git
 
 
-def git_add_and_commit(repo_root: Path, path: Path, message: str) -> None:
+def git_add_and_commit(repo_root: Path, path: Path, message: str) -> bool:
 
     '''
     Stage a path and create a git commit inside a repository.
@@ -32,8 +32,14 @@ def git_add_and_commit(repo_root: Path, path: Path, message: str) -> None:
         path (Path): Path to stage (relative to repo_root)
         message (str): Commit message
 
+    Returns:
+        bool: True if both git add and git commit succeeded
+
     '''
 
     git = git_executable()
-    subprocess.run([git, 'add', str(path)], cwd=repo_root, capture_output=True, check=False)
-    subprocess.run([git, 'commit', '-m', message], cwd=repo_root, capture_output=True, check=False)
+    add = subprocess.run([git, 'add', str(path)], cwd=repo_root, capture_output=True, check=False)
+    if add.returncode != 0:
+        return False
+    commit = subprocess.run([git, 'commit', '-m', message], cwd=repo_root, capture_output=True, check=False)
+    return commit.returncode == 0

--- a/limen/cli/git_utils.py
+++ b/limen/cli/git_utils.py
@@ -37,7 +37,10 @@ def git_add_and_commit(repo_root: Path, path: Path, message: str) -> bool:
 
     '''
 
-    git = git_executable()
+    try:
+        git = git_executable()
+    except FileNotFoundError:
+        return False
     add = subprocess.run([git, 'add', str(path)], cwd=repo_root, capture_output=True, check=False)
     if add.returncode != 0:
         return False

--- a/limen/cli/git_utils.py
+++ b/limen/cli/git_utils.py
@@ -1,0 +1,39 @@
+import shutil
+import subprocess
+from pathlib import Path
+
+
+def git_executable() -> str:
+
+    '''
+    Locate the git binary on PATH.
+
+    Returns:
+        str: Absolute path to the git executable
+
+    Raises:
+        FileNotFoundError: If git is not found on PATH
+
+    '''
+
+    git = shutil.which('git')
+    if git is None:
+        raise FileNotFoundError('git not found on PATH')
+    return git
+
+
+def git_add_and_commit(repo_root: Path, path: Path, message: str) -> None:
+
+    '''
+    Stage a path and create a git commit inside a repository.
+
+    Args:
+        repo_root (Path): Root directory of the git repository
+        path (Path): Path to stage (relative to repo_root)
+        message (str): Commit message
+
+    '''
+
+    git = git_executable()
+    subprocess.run([git, 'add', str(path)], cwd=repo_root, capture_output=True, check=False)
+    subprocess.run([git, 'commit', '-m', message], cwd=repo_root, capture_output=True, check=False)

--- a/limen/cli/main.py
+++ b/limen/cli/main.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 import click
 
+from limen.cli.commands.commit import run_commit
 from limen.cli.commands.init import run_init
 from limen.cli.commands.list_templates import run_list_templates
 from limen.cli.commands.new import run_new
@@ -51,6 +52,40 @@ def cli() -> None:
     Templates are in limen/yaml/templates/:
       logreg_binary.yaml           Logistic regression binary classifier
     '''
+
+
+@cli.command()
+@click.argument('yaml_file', type=click.Path(exists=True, path_type=Path))
+@click.option('--parent', default=None, metavar='MANIFEST_ID',
+              help='Parent manifest ID for lineage tracking (e.g. sha256:abc123...).')
+@click.option('--message', '-m', default=None,
+              help='Git commit message. Auto-generated if omitted.')
+def commit(yaml_file: Path, parent: str | None, message: str | None) -> None:
+
+    '''
+    Validate and commit a YAML experiment file to the manifest store.
+
+    \b
+    Steps:
+      1. Find the limen project root (walks up from the YAML file location)
+      2. Validate the YAML file
+      3. Content-address and store in manifests/committed/
+      4. Update manifests/committed/index.json
+      5. Git add + commit inside the project
+
+    \b
+    The committed file has a lineage block injected with its ID and timestamp.
+    Committing the same file twice is a no-op (idempotent).
+
+    \b
+    Examples:
+      limen commit manifests/examples/logreg_binary.yaml
+      limen commit manifests/examples/logreg_binary.yaml --message "tuned lookback"
+      limen commit manifests/examples/logreg_binary.yaml --parent sha256:abc123...
+    '''
+
+    ok = run_commit(yaml_file, parent, message)
+    raise SystemExit(0 if ok else 1)
 
 
 @cli.command()

--- a/limen/cli/main.py
+++ b/limen/cli/main.py
@@ -5,6 +5,7 @@ import click
 from limen.cli.commands.commit import run_commit
 from limen.cli.commands.init import run_init
 from limen.cli.commands.list_templates import run_list_templates
+from limen.cli.commands.ls import run_ls
 from limen.cli.commands.new import run_new
 from limen.cli.commands.profile import run_profile
 from limen.cli.commands.resume import run_resume
@@ -85,6 +86,28 @@ def commit(yaml_file: Path, parent: str | None, message: str | None) -> None:
     '''
 
     ok = run_commit(yaml_file, parent, message)
+    raise SystemExit(0 if ok else 1)
+
+
+@cli.command('ls')
+def ls() -> None:
+
+    '''
+    List all committed manifests in the current project.
+
+    \b
+    Reads manifests/committed/index.json and displays each manifest
+    with its short ID, name, and commit timestamp.
+
+    \b
+    Run from anywhere inside a Limen project directory.
+
+    \b
+    Examples:
+      limen ls
+    '''
+
+    ok = run_ls(Path.cwd())
     raise SystemExit(0 if ok else 1)
 
 

--- a/limen/cli/main.py
+++ b/limen/cli/main.py
@@ -227,10 +227,10 @@ def run(target: str | None, dry_run: bool, resume: Path | None) -> None:
             raise SystemExit(1)
         ok = run_resume(resume)
     elif target is not None:
-        yaml_path, manifest_id = _resolve_target(target)
+        yaml_path, manifest_id, results_base = _resolve_target(target)
         if yaml_path is None:
             raise SystemExit(1)
-        ok = run_experiment(yaml_path, dry_run=dry_run, manifest_id=manifest_id)
+        ok = run_experiment(yaml_path, dry_run=dry_run, manifest_id=manifest_id, results_base=results_base)
     else:
         click.secho('Provide a YAML file or --resume <results-dir>.', fg='red')
         raise SystemExit(1)
@@ -238,22 +238,22 @@ def run(target: str | None, dry_run: bool, resume: Path | None) -> None:
     raise SystemExit(0 if ok else 1)
 
 
-def _resolve_target(target: str) -> tuple[Path | None, str | None]:
+def _resolve_target(target: str) -> tuple[Path | None, str | None, Path]:
 
     if target.startswith(_MANIFEST_URI_SCHEME):
         try:
-            path = resolve_manifest_uri(target, Path.cwd())
+            path, project_root = resolve_manifest_uri(target, Path.cwd())
         except ValueError as exc:
             click.secho(f'  ✗ {exc}', fg='red')
-            return None, None
+            return None, None, Path('.')
         click.echo(f"  Resolved {target}")
-        return path, path.stem
+        return path, path.stem, project_root
 
     p = Path(target)
     if not p.exists():
         click.secho(f"  ✗ File not found: {target}", fg='red')
-        return None, None
-    return p, None
+        return None, None, Path('.')
+    return p, None, Path('.')
 
 
 @cli.command('list-templates')

--- a/limen/cli/main.py
+++ b/limen/cli/main.py
@@ -203,7 +203,10 @@ def run(target: str | None, dry_run: bool, resume: Path | None) -> None:
 
     \b
     Output:
-      Results are written to ./results/{name}_{datetime}/results.csv by default.
+      Development mode:  ./results/dev/{name}_{datetime}/results.csv
+      Production mode:   ./results/{name}_{datetime}/results.csv
+      Committed manifest (manifest://):
+                         ./results/[dev/]<short-hash>/<timestamp>/results.csv
       Set uel.output_format: parquet to also write results.parquet.
       Override the output path with uel.output_path in the YAML.
 

--- a/limen/cli/main.py
+++ b/limen/cli/main.py
@@ -4,6 +4,7 @@ import click
 
 from limen.cli.commands.init import run_init
 from limen.cli.commands.list_templates import run_list_templates
+from limen.cli.commands.new import run_new
 from limen.cli.commands.profile import run_profile
 from limen.cli.commands.resume import run_resume
 from limen.cli.commands.run import run_experiment
@@ -207,4 +208,27 @@ def init(output: Path, template: str | None) -> None:
     '''
 
     ok = run_init(output, template)
+    raise SystemExit(0 if ok else 1)
+
+
+@cli.command()
+@click.argument('project_name')
+@click.option('--backup-remote', default=None,
+              help='Git remote URL for manifest store backup (can also be set interactively).')
+def new(project_name: str, backup_remote: str | None) -> None:
+
+    '''
+    Create a new Limen project from the official project template.
+
+    \b
+    Clones Vaquum/limen-project-template, creates a virtual environment,
+    installs limen, and optionally sets up a backup remote.
+
+    \b
+    Examples:
+      limen new my-project
+      limen new my-project --backup-remote git@github.com:user/my-project.git
+    '''
+
+    ok = run_new(project_name, backup_remote)
     raise SystemExit(0 if ok else 1)

--- a/limen/cli/main.py
+++ b/limen/cli/main.py
@@ -221,8 +221,7 @@ def new(project_name: str, backup_remote: str | None) -> None:
     Create a new Limen project from the official project template.
 
     \b
-    Clones Vaquum/limen-project-template, creates a virtual environment,
-    installs limen, and optionally sets up a backup remote.
+    Clones Vaquum/limen-project-template and optionally sets up a backup remote.
 
     \b
     Examples:

--- a/limen/cli/main.py
+++ b/limen/cli/main.py
@@ -11,6 +11,8 @@ from limen.cli.commands.profile import run_profile
 from limen.cli.commands.resume import run_resume
 from limen.cli.commands.run import run_experiment
 from limen.cli.commands.validate import run_validate
+from limen.yaml.store import _MANIFEST_URI_SCHEME
+from limen.yaml.store import resolve_manifest_uri
 
 
 @click.group()
@@ -174,13 +176,13 @@ def profile_cmd(yaml_file: Path) -> None:
 
 
 @cli.command()
-@click.argument('yaml_file', type=click.Path(exists=True, path_type=Path), required=False, default=None)
+@click.argument('target', required=False, default=None, metavar='[YAML_FILE | MANIFEST_URI]')
 @click.option('--dry-run', is_flag=True, default=False,
               help='Validate and compile only — do not execute the experiment.')
 @click.option('--resume', type=click.Path(exists=True, file_okay=False, path_type=Path),
               default=None, metavar='RESULTS_DIR',
               help='Resume from a checkpoint directory instead of starting fresh.')
-def run(yaml_file: Path | None, dry_run: bool, resume: Path | None) -> None:
+def run(target: str | None, dry_run: bool, resume: Path | None) -> None:
 
     '''
     Validate, compile, and run a YAML experiment file.
@@ -212,24 +214,46 @@ def run(yaml_file: Path | None, dry_run: bool, resume: Path | None) -> None:
     Examples:
       limen run experiment.yaml
       limen run --dry-run experiment.yaml
+      limen run manifest://sha256:abc123ef...
       limen run --resume ./results/my_experiment_20260521_120000
     '''
 
     if resume is not None:
-        if yaml_file is not None:
+        if target is not None:
             click.secho('Cannot specify both a YAML file and --resume.', fg='red')
             raise SystemExit(1)
         if dry_run:
             click.secho('--dry-run has no effect with --resume.', fg='red')
             raise SystemExit(1)
         ok = run_resume(resume)
-    elif yaml_file is not None:
-        ok = run_experiment(yaml_file, dry_run=dry_run)
+    elif target is not None:
+        yaml_path, manifest_id = _resolve_target(target)
+        if yaml_path is None:
+            raise SystemExit(1)
+        ok = run_experiment(yaml_path, dry_run=dry_run, manifest_id=manifest_id)
     else:
         click.secho('Provide a YAML file or --resume <results-dir>.', fg='red')
         raise SystemExit(1)
 
     raise SystemExit(0 if ok else 1)
+
+
+def _resolve_target(target: str) -> tuple[Path | None, str | None]:
+
+    if target.startswith(_MANIFEST_URI_SCHEME):
+        try:
+            path = resolve_manifest_uri(target, Path.cwd())
+        except ValueError as exc:
+            click.secho(f'  ✗ {exc}', fg='red')
+            return None, None
+        click.echo(f"  Resolved {target}")
+        return path, path.stem
+
+    p = Path(target)
+    if not p.exists():
+        click.secho(f"  ✗ File not found: {target}", fg='red')
+        return None, None
+    return p, None
 
 
 @cli.command('list-templates')

--- a/limen/yaml/__init__.py
+++ b/limen/yaml/__init__.py
@@ -1,6 +1,7 @@
 from limen.yaml.config import find_project_root
 from limen.yaml.config import get_store_path
 from limen.yaml.config import read_limen_toml
+from limen.yaml.store import resolve_manifest_uri
 from limen.yaml.compiler import CompiledSFD
 from limen.yaml.compiler import build_manifest
 from limen.yaml.compiler import build_search_strategy
@@ -35,5 +36,6 @@ __all__ = [
     'profile',
     'read_limen_toml',
     'resolve',
+    'resolve_manifest_uri',
     'validate',
 ]

--- a/limen/yaml/__init__.py
+++ b/limen/yaml/__init__.py
@@ -1,3 +1,6 @@
+from limen.yaml.config import find_project_root
+from limen.yaml.config import get_store_path
+from limen.yaml.config import read_limen_toml
 from limen.yaml.compiler import CompiledSFD
 from limen.yaml.compiler import build_manifest
 from limen.yaml.compiler import build_search_strategy
@@ -25,9 +28,12 @@ __all__ = [
     'YAMLError',
     'build_manifest',
     'build_search_strategy',
+    'find_project_root',
+    'get_store_path',
     'make_covering_array',
     'parse',
     'profile',
+    'read_limen_toml',
     'resolve',
     'validate',
 ]

--- a/limen/yaml/config.py
+++ b/limen/yaml/config.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib  # type: ignore[no-redef]
+
+
+_LIMEN_TOML_NAME = 'limen.toml'
+_STORE_RELATIVE = Path('manifests') / 'committed'
+
+
+def find_project_root(start: Path) -> Path | None:
+
+    '''
+    Walk up the directory tree looking for limen.toml.
+
+    Args:
+        start (Path): Directory to start searching from
+
+    Returns:
+        Path | None: The directory containing limen.toml, or None if not found
+
+    '''
+
+    current = start.resolve()
+    while True:
+        if (current / _LIMEN_TOML_NAME).exists():
+            return current
+        parent = current.parent
+        if parent == current:
+            return None
+        current = parent
+
+
+def read_limen_toml(project_root: Path) -> dict[str, Any]:
+
+    '''
+    Read limen.toml from the project root.
+
+    Args:
+        project_root (Path): Directory containing limen.toml
+
+    Returns:
+        dict: Parsed contents of limen.toml
+
+    '''
+
+    toml_path = project_root / _LIMEN_TOML_NAME
+    if not toml_path.exists():
+        raise FileNotFoundError(f"limen.toml not found at '{toml_path}'")
+
+    return tomllib.loads(toml_path.read_text(encoding='utf-8'))
+
+
+def get_store_path(start: Path) -> Path:
+
+    '''
+    Locate the manifest store by finding the project root.
+
+    Args:
+        start (Path): Directory to start searching from
+
+    Returns:
+        Path: Path to manifests/committed/
+
+    Raises:
+        FileNotFoundError: If no limen.toml is found in the directory tree
+
+    '''
+
+    root = find_project_root(start)
+    if root is None:
+        raise FileNotFoundError(
+            'No limen.toml found. Run limen new <project-name> to create a project.'
+        )
+    return root / _STORE_RELATIVE

--- a/limen/yaml/schema.py
+++ b/limen/yaml/schema.py
@@ -62,7 +62,6 @@ UEL_OPTIONAL = {
     'pruning_strategies',
     'feedback_interval',
     'checkpoint_interval',
-    'experiment_dir',
     'intra_callback',
     'prep_each_round',
     'output_format',

--- a/limen/yaml/store.py
+++ b/limen/yaml/store.py
@@ -55,7 +55,12 @@ def commit_manifest(yaml_path: Path,
     yaml.preserve_quotes = True
 
     if not already_existed:
-        data = yaml.load(content)
+        try:
+            data = yaml.load(content)
+        except YAMLError as exc:
+            raise ValueError(f"Cannot parse YAML '{yaml_path.name}': {exc}") from exc
+        if not isinstance(data, dict):
+            raise ValueError(f"Invalid YAML format in '{yaml_path.name}': expected a mapping")
         name = str(data.get('metadata', {}).get('name', yaml_path.stem))
         committed_at = datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ')
         lineage: dict = {'id': manifest_id, 'committed_at': committed_at}

--- a/limen/yaml/store.py
+++ b/limen/yaml/store.py
@@ -78,7 +78,7 @@ def commit_manifest(yaml_path: Path,
     return manifest_id, False
 
 
-def resolve_manifest_uri(uri: str, start: Path) -> Path:
+def resolve_manifest_uri(uri: str, start: Path) -> tuple[Path, Path]:
 
     '''
     Resolve a manifest:// URI to a filesystem path.
@@ -91,7 +91,8 @@ def resolve_manifest_uri(uri: str, start: Path) -> Path:
         start (Path): Directory to start searching for the project root
 
     Returns:
-        Path: Resolved path to the committed manifest file
+        tuple[Path, Path]: (manifest_path, project_root) — resolved path to the
+            committed manifest file and the limen project root
 
     Raises:
         ValueError: If the URI is malformed, the project root is not found,
@@ -141,7 +142,7 @@ def resolve_manifest_uri(uri: str, start: Path) -> Path:
             f"does not match expected '{expected_id}'"
         )
 
-    return candidate
+    return candidate, project_root
 
 
 def _update_index(store_path: Path, entry: dict[str, Any]) -> None:

--- a/limen/yaml/store.py
+++ b/limen/yaml/store.py
@@ -9,9 +9,12 @@ from typing import Any
 from ruamel.yaml import YAML
 
 from limen.yaml.config import _STORE_RELATIVE
+from limen.yaml.config import find_project_root
 
 
 _SHA256_PREFIX = 'sha256:'
+_MANIFEST_URI_SCHEME = 'manifest://'
+_SHA256_HEX_LENGTH = 64
 
 
 def commit_manifest(yaml_path: Path,
@@ -73,6 +76,72 @@ def commit_manifest(yaml_path: Path,
     _update_index(store_path, entry)
 
     return manifest_id, False
+
+
+def resolve_manifest_uri(uri: str, start: Path) -> Path:
+
+    '''
+    Resolve a manifest:// URI to a filesystem path.
+
+    Verifies that lineage.id in the committed file matches the URI hash,
+    catching cases where the wrong file is at the expected path.
+
+    Args:
+        uri (str): URI of the form manifest://sha256:<hex>
+        start (Path): Directory to start searching for the project root
+
+    Returns:
+        Path: Resolved path to the committed manifest file
+
+    Raises:
+        ValueError: If the URI is malformed, the project root is not found,
+            the manifest is not in the store, or lineage.id does not match
+
+    '''
+
+    if not uri.startswith(_MANIFEST_URI_SCHEME):
+        raise ValueError(f"Not a manifest URI: '{uri}'")
+
+    ref = uri[len(_MANIFEST_URI_SCHEME):]
+    if not ref.startswith(_SHA256_PREFIX):
+        raise ValueError(f"Manifest URI must use sha256 scheme: '{uri}'")
+
+    hex_hash = ref[len(_SHA256_PREFIX):]
+
+    project_root = find_project_root(start)
+    if project_root is None:
+        raise ValueError('No limen project found. Run from inside a project directory.')
+
+    store_path = project_root / _STORE_RELATIVE
+
+    if len(hex_hash) == _SHA256_HEX_LENGTH:
+        candidate = store_path / f'{hex_hash}.yaml'
+        if not candidate.exists():
+            raise ValueError(f"Manifest not found in store: '{uri}'")
+    else:
+        matches = [p for p in store_path.glob('*.yaml') if p.stem.startswith(hex_hash)]
+        if not matches:
+            raise ValueError(f"Manifest not found in store: '{uri}'")
+        if len(matches) > 1:
+            shorts = ', '.join(p.stem[:12] for p in matches)
+            raise ValueError(f"Ambiguous short hash '{hex_hash}' matches multiple manifests: {shorts}")
+        candidate = matches[0]
+
+    full_hex = candidate.stem
+
+    yaml_obj = YAML()
+    data = yaml_obj.load(candidate.read_text(encoding='utf-8'))
+    if not isinstance(data, dict):
+        raise ValueError(f"Invalid manifest format in '{candidate.name}'")
+    expected_id = f'{_SHA256_PREFIX}{full_hex}'
+    actual_id = data.get('lineage', {}).get('id')
+    if actual_id != expected_id:
+        raise ValueError(
+            f"Integrity check failed: '{candidate.name}' lineage.id "
+            f"does not match expected '{expected_id}'"
+        )
+
+    return candidate
 
 
 def _update_index(store_path: Path, entry: dict[str, Any]) -> None:

--- a/limen/yaml/store.py
+++ b/limen/yaml/store.py
@@ -1,10 +1,17 @@
 import hashlib
 import json
 from datetime import datetime
+from datetime import timezone
 from io import StringIO
 from pathlib import Path
+from typing import Any
 
 from ruamel.yaml import YAML
+
+from limen.yaml.config import _STORE_RELATIVE
+
+
+_SHA256_PREFIX = 'sha256:'
 
 
 def commit_manifest(yaml_path: Path,
@@ -31,9 +38,9 @@ def commit_manifest(yaml_path: Path,
 
     content = yaml_path.read_text(encoding='utf-8')
     hex_hash = hashlib.sha256(content.encode()).hexdigest()
-    manifest_id = f'sha256:{hex_hash}'
+    manifest_id = f'{_SHA256_PREFIX}{hex_hash}'
 
-    store_path = project_root / 'manifests' / 'committed'
+    store_path = project_root / _STORE_RELATIVE
     dest = store_path / f'{hex_hash}.yaml'
 
     if dest.exists():
@@ -43,7 +50,7 @@ def commit_manifest(yaml_path: Path,
     yaml.preserve_quotes = True
     data = yaml.load(content)
     name = str(data.get('metadata', {}).get('name', yaml_path.stem))
-    committed_at = datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%S')
+    committed_at = datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%S')
 
     lineage: dict = {'id': manifest_id, 'committed_at': committed_at}
     if parent_id is not None:
@@ -55,17 +62,20 @@ def commit_manifest(yaml_path: Path,
 
     store_path.mkdir(parents=True, exist_ok=True)
     dest.write_text(stream.getvalue(), encoding='utf-8')
-    _update_index(store_path, manifest_id, name, hex_hash, committed_at, parent_id)
+
+    entry: dict[str, Any] = {
+        'id': manifest_id,
+        'name': name,
+        'committed_at': committed_at,
+        'parent_id': parent_id,
+        'file': f'{hex_hash}.yaml',
+    }
+    _update_index(store_path, entry)
 
     return manifest_id, False
 
 
-def _update_index(store_path: Path,
-                  manifest_id: str,
-                  name: str,
-                  hex_hash: str,
-                  committed_at: str,
-                  parent_id: str | None) -> None:
+def _update_index(store_path: Path, entry: dict[str, Any]) -> None:
 
     index_path = store_path / 'index.json'
     if index_path.exists():
@@ -73,11 +83,5 @@ def _update_index(store_path: Path,
     else:
         index = {'version': 1, 'manifests': []}
 
-    index['manifests'].append({
-        'id': manifest_id,
-        'name': name,
-        'committed_at': committed_at,
-        'parent_id': parent_id,
-        'file': f'{hex_hash}.yaml',
-    })
+    index['manifests'].append(entry)
     index_path.write_text(json.dumps(index, indent=2), encoding='utf-8')

--- a/limen/yaml/store.py
+++ b/limen/yaml/store.py
@@ -1,5 +1,7 @@
 import hashlib
 import json
+import re
+import warnings
 from datetime import datetime
 from datetime import timezone
 from io import StringIO
@@ -113,6 +115,9 @@ def resolve_manifest_uri(uri: str, start: Path) -> tuple[Path, Path]:
 
     hex_hash = ref[len(_SHA256_PREFIX):]
 
+    if not re.fullmatch(r'[0-9a-f]{1,64}', hex_hash):
+        raise ValueError(f"Malformed hash in manifest URI: '{uri}'")
+
     project_root = find_project_root(start)
     if project_root is None:
         raise ValueError('No limen project found. Run from inside a project directory.')
@@ -153,7 +158,11 @@ def _update_index(store_path: Path, entry: dict[str, Any]) -> None:
 
     index_path = store_path / 'index.json'
     if index_path.exists():
-        index = json.loads(index_path.read_text(encoding='utf-8'))
+        try:
+            index = json.loads(index_path.read_text(encoding='utf-8'))
+        except json.JSONDecodeError:
+            warnings.warn(f"index.json is corrupted — reinitializing: {index_path}", stacklevel=2)
+            index = {'version': 1, 'manifests': []}
     else:
         index = {'version': 1, 'manifests': []}
 

--- a/limen/yaml/store.py
+++ b/limen/yaml/store.py
@@ -46,36 +46,40 @@ def commit_manifest(yaml_path: Path,
     store_path = project_root / _STORE_RELATIVE
     dest = store_path / f'{hex_hash}.yaml'
 
-    if dest.exists():
-        return manifest_id, True
+    already_existed = dest.exists()
 
     yaml = YAML()
     yaml.preserve_quotes = True
-    data = yaml.load(content)
-    name = str(data.get('metadata', {}).get('name', yaml_path.stem))
-    committed_at = datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%S')
 
-    lineage: dict = {'id': manifest_id, 'committed_at': committed_at}
-    if parent_id is not None:
-        lineage['parent_id'] = parent_id
-    data['lineage'] = lineage
-
-    stream = StringIO()
-    yaml.dump(data, stream)
-
-    store_path.mkdir(parents=True, exist_ok=True)
-    dest.write_text(stream.getvalue(), encoding='utf-8')
+    if not already_existed:
+        data = yaml.load(content)
+        name = str(data.get('metadata', {}).get('name', yaml_path.stem))
+        committed_at = datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ')
+        lineage: dict = {'id': manifest_id, 'committed_at': committed_at}
+        if parent_id is not None:
+            lineage['parent_id'] = parent_id
+        data['lineage'] = lineage
+        stream = StringIO()
+        yaml.dump(data, stream)
+        store_path.mkdir(parents=True, exist_ok=True)
+        dest.write_text(stream.getvalue(), encoding='utf-8')
+        stored_parent_id = parent_id
+    else:
+        existing = yaml.load(dest.read_text(encoding='utf-8'))
+        name = str(existing.get('metadata', {}).get('name', dest.stem))
+        committed_at = existing.get('lineage', {}).get('committed_at', '')
+        stored_parent_id = existing.get('lineage', {}).get('parent_id')
 
     entry: dict[str, Any] = {
         'id': manifest_id,
         'name': name,
         'committed_at': committed_at,
-        'parent_id': parent_id,
+        'parent_id': stored_parent_id,
         'file': f'{hex_hash}.yaml',
     }
     _update_index(store_path, entry)
 
-    return manifest_id, False
+    return manifest_id, already_existed
 
 
 def resolve_manifest_uri(uri: str, start: Path) -> tuple[Path, Path]:
@@ -120,7 +124,7 @@ def resolve_manifest_uri(uri: str, start: Path) -> tuple[Path, Path]:
         if not candidate.exists():
             raise ValueError(f"Manifest not found in store: '{uri}'")
     else:
-        matches = [p for p in store_path.glob('*.yaml') if p.stem.startswith(hex_hash)]
+        matches = list(store_path.glob(f'{hex_hash}*.yaml'))
         if not matches:
             raise ValueError(f"Manifest not found in store: '{uri}'")
         if len(matches) > 1:
@@ -153,5 +157,6 @@ def _update_index(store_path: Path, entry: dict[str, Any]) -> None:
     else:
         index = {'version': 1, 'manifests': []}
 
-    index['manifests'].append(entry)
+    if not any(m['id'] == entry['id'] for m in index['manifests']):
+        index['manifests'].append(entry)
     index_path.write_text(json.dumps(index, indent=2), encoding='utf-8')

--- a/limen/yaml/store.py
+++ b/limen/yaml/store.py
@@ -77,6 +77,8 @@ def commit_manifest(yaml_path: Path,
             existing = yaml.load(dest.read_text(encoding='utf-8'))
         except (OSError, YAMLError) as exc:
             raise ValueError(f"Cannot read committed manifest '{dest.name}': {exc}") from exc
+        if not isinstance(existing, dict):
+            raise ValueError(f"Invalid committed manifest format in '{dest.name}': expected a mapping")
         name = str(existing.get('metadata', {}).get('name', dest.stem))
         committed_at = existing.get('lineage', {}).get('committed_at', '')
         stored_parent_id = existing.get('lineage', {}).get('parent_id')

--- a/limen/yaml/store.py
+++ b/limen/yaml/store.py
@@ -177,6 +177,6 @@ def _update_index(store_path: Path, entry: dict[str, Any]) -> None:
         warnings.warn(f"index.json has invalid structure — reinitializing: {index_path}", stacklevel=2)
         index = {'version': 1, 'manifests': []}
 
-    if not any(isinstance(m, dict) and m.get('id') == entry['id'] for m in index['manifests']):
-        index['manifests'].append(entry)
+    index['manifests'] = [m for m in index['manifests'] if not (isinstance(m, dict) and m.get('id') == entry['id'])]
+    index['manifests'].append(entry)
     index_path.write_text(json.dumps(index, indent=2), encoding='utf-8')

--- a/limen/yaml/store.py
+++ b/limen/yaml/store.py
@@ -1,0 +1,83 @@
+import hashlib
+import json
+from datetime import datetime
+from io import StringIO
+from pathlib import Path
+
+from ruamel.yaml import YAML
+
+
+def commit_manifest(yaml_path: Path,
+                    project_root: Path,
+                    parent_id: str | None = None) -> tuple[str, bool]:
+
+    '''
+    Content-address and store a YAML manifest in the committed store.
+
+    Reads the source YAML, computes its SHA256, injects a lineage block,
+    writes to manifests/committed/<hex>.yaml, and updates index.json.
+
+    Args:
+        yaml_path (Path): Path to the source YAML file
+        project_root (Path): Root directory of the limen project
+        parent_id (str | None): Parent manifest ID for lineage tracking
+
+    Returns:
+        tuple[str, bool]: (manifest_id, already_existed). manifest_id is
+            "sha256:<hex>". already_existed is True if the manifest was
+            already in the store (idempotent).
+
+    '''
+
+    content = yaml_path.read_text(encoding='utf-8')
+    hex_hash = hashlib.sha256(content.encode()).hexdigest()
+    manifest_id = f'sha256:{hex_hash}'
+
+    store_path = project_root / 'manifests' / 'committed'
+    dest = store_path / f'{hex_hash}.yaml'
+
+    if dest.exists():
+        return manifest_id, True
+
+    yaml = YAML()
+    yaml.preserve_quotes = True
+    data = yaml.load(content)
+    name = str(data.get('metadata', {}).get('name', yaml_path.stem))
+    committed_at = datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%S')
+
+    lineage: dict = {'id': manifest_id, 'committed_at': committed_at}
+    if parent_id is not None:
+        lineage['parent_id'] = parent_id
+    data['lineage'] = lineage
+
+    stream = StringIO()
+    yaml.dump(data, stream)
+
+    store_path.mkdir(parents=True, exist_ok=True)
+    dest.write_text(stream.getvalue(), encoding='utf-8')
+    _update_index(store_path, manifest_id, name, hex_hash, committed_at, parent_id)
+
+    return manifest_id, False
+
+
+def _update_index(store_path: Path,
+                  manifest_id: str,
+                  name: str,
+                  hex_hash: str,
+                  committed_at: str,
+                  parent_id: str | None) -> None:
+
+    index_path = store_path / 'index.json'
+    if index_path.exists():
+        index = json.loads(index_path.read_text(encoding='utf-8'))
+    else:
+        index = {'version': 1, 'manifests': []}
+
+    index['manifests'].append({
+        'id': manifest_id,
+        'name': name,
+        'committed_at': committed_at,
+        'parent_id': parent_id,
+        'file': f'{hex_hash}.yaml',
+    })
+    index_path.write_text(json.dumps(index, indent=2), encoding='utf-8')

--- a/limen/yaml/store.py
+++ b/limen/yaml/store.py
@@ -177,6 +177,6 @@ def _update_index(store_path: Path, entry: dict[str, Any]) -> None:
         warnings.warn(f"index.json has invalid structure — reinitializing: {index_path}", stacklevel=2)
         index = {'version': 1, 'manifests': []}
 
-    if not any(m['id'] == entry['id'] for m in index['manifests']):
+    if not any(isinstance(m, dict) and m.get('id') == entry['id'] for m in index['manifests']):
         index['manifests'].append(entry)
     index_path.write_text(json.dumps(index, indent=2), encoding='utf-8')

--- a/limen/yaml/store.py
+++ b/limen/yaml/store.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Any
 
 from ruamel.yaml import YAML
+from ruamel.yaml.error import YAMLError
 
 from limen.yaml.config import _STORE_RELATIVE
 from limen.yaml.config import find_project_root
@@ -67,7 +68,10 @@ def commit_manifest(yaml_path: Path,
         dest.write_text(stream.getvalue(), encoding='utf-8')
         stored_parent_id = parent_id
     else:
-        existing = yaml.load(dest.read_text(encoding='utf-8'))
+        try:
+            existing = yaml.load(dest.read_text(encoding='utf-8'))
+        except (OSError, YAMLError) as exc:
+            raise ValueError(f"Cannot read committed manifest '{dest.name}': {exc}") from exc
         name = str(existing.get('metadata', {}).get('name', dest.stem))
         committed_at = existing.get('lineage', {}).get('committed_at', '')
         stored_parent_id = existing.get('lineage', {}).get('parent_id')
@@ -140,7 +144,10 @@ def resolve_manifest_uri(uri: str, start: Path) -> tuple[Path, Path]:
     full_hex = candidate.stem
 
     yaml_obj = YAML()
-    data = yaml_obj.load(candidate.read_text(encoding='utf-8'))
+    try:
+        data = yaml_obj.load(candidate.read_text(encoding='utf-8'))
+    except (OSError, YAMLError) as exc:
+        raise ValueError(f"Cannot read manifest '{candidate.name}': {exc}") from exc
     if not isinstance(data, dict):
         raise ValueError(f"Invalid manifest format in '{candidate.name}'")
     expected_id = f'{_SHA256_PREFIX}{full_hex}'
@@ -164,6 +171,10 @@ def _update_index(store_path: Path, entry: dict[str, Any]) -> None:
             warnings.warn(f"index.json is corrupted — reinitializing: {index_path}", stacklevel=2)
             index = {'version': 1, 'manifests': []}
     else:
+        index = {'version': 1, 'manifests': []}
+
+    if not isinstance(index, dict) or not isinstance(index.get('manifests'), list):
+        warnings.warn(f"index.json has invalid structure — reinitializing: {index_path}", stacklevel=2)
         index = {'version': 1, 'manifests': []}
 
     if not any(m['id'] == entry['id'] for m in index['manifests']):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaquum_limen"
-version = "3.12.2"
+version = "3.13.0"
 description = "Limen unifies parameter search across machine learning and rule-based strategies, with built-in analytics that show not just what works, but why it works."
 readme = "README.md"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,7 +126,7 @@ ignore = [
 dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 
 [tool.ruff.lint.per-file-ignores]
-"tests/**/*.py" = ["S101", "BLE001", "PLR2004", "B011", "ANN", "ARG"]
+"tests/**/*.py" = ["S101", "BLE001", "PLR2004", "B011", "ANN", "ARG", "S603", "S607"]
 "limen/targets/*.py" = ["ARG002"]
 "limen/cli/**/*.py" = ["S603"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
   "requests",
   "ruamel.yaml>=0.18",
   "click>=8.0",
+  "tomli>=2.0; python_version < '3.11'",
 ]
 
 [project.scripts]
@@ -127,6 +128,7 @@ dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 [tool.ruff.lint.per-file-ignores]
 "tests/**/*.py" = ["S101", "BLE001", "PLR2004", "B011", "ANN", "ARG"]
 "limen/targets/*.py" = ["ARG002"]
+"limen/cli/**/*.py" = ["S603"]
 
 [tool.ruff.lint.pylint]
 max-statements = 50

--- a/tests/run.py
+++ b/tests/run.py
@@ -808,6 +808,10 @@ from tests.test_proto_cohort import test_single_member_fallback_predict_returns_
 from tests.test_yaml_config import test_find_project_root_walks_up_from_subdirectory
 from tests.test_yaml_config import test_find_project_root_returns_none_when_not_found
 from tests.test_yaml_config import test_get_store_path_raises_when_no_project_root
+from tests.test_yaml_store import test_commit_stores_file_in_committed_dir
+from tests.test_yaml_store import test_commit_is_idempotent
+from tests.test_yaml_store import test_commit_injects_lineage_section
+from tests.test_yaml_store import test_commit_updates_index_json
 
 tests = [
     test_param_domain_init,
@@ -1609,6 +1613,10 @@ tests = [
     test_find_project_root_walks_up_from_subdirectory,
     test_find_project_root_returns_none_when_not_found,
     test_get_store_path_raises_when_no_project_root,
+    test_commit_stores_file_in_committed_dir,
+    test_commit_is_idempotent,
+    test_commit_injects_lineage_section,
+    test_commit_updates_index_json,
 ]
 
 # Configure logging

--- a/tests/run.py
+++ b/tests/run.py
@@ -815,6 +815,8 @@ from tests.test_yaml_store import test_commit_stores_file_in_committed_dir
 from tests.test_yaml_store import test_commit_is_idempotent
 from tests.test_yaml_store import test_commit_injects_lineage_section
 from tests.test_yaml_store import test_commit_updates_index_json
+from tests.test_yaml_store import test_commit_repairs_index_when_missing
+from tests.test_yaml_store import test_commit_timestamps_are_utc
 from tests.test_yaml_store import test_resolve_manifest_uri_returns_path_and_project_root
 from tests.test_yaml_store import test_resolve_manifest_uri_rejects_missing_manifest
 from tests.test_yaml_store import test_resolve_manifest_uri_rejects_tampered_lineage
@@ -825,6 +827,7 @@ from tests.test_cli_commit import test_run_commit_fails_on_invalid_yaml
 from tests.test_cli_commit import test_run_commit_rejects_development_mode
 from tests.test_cli_commit import test_run_commit_succeeds_for_production_yaml
 from tests.test_cli_commit import test_run_commit_is_idempotent
+from tests.test_cli_commit import test_run_commit_rejects_invalid_parent_id
 from tests.test_cli_commit import test_run_commit_uses_custom_message
 from tests.test_cli_ls import test_run_ls_fails_when_no_project_root
 from tests.test_cli_ls import test_run_ls_returns_true_when_no_index
@@ -1645,6 +1648,8 @@ tests = [
     test_commit_is_idempotent,
     test_commit_injects_lineage_section,
     test_commit_updates_index_json,
+    test_commit_repairs_index_when_missing,
+    test_commit_timestamps_are_utc,
     test_resolve_manifest_uri_returns_path_and_project_root,
     test_resolve_manifest_uri_rejects_missing_manifest,
     test_resolve_manifest_uri_rejects_tampered_lineage,
@@ -1655,6 +1660,7 @@ tests = [
     test_run_commit_rejects_development_mode,
     test_run_commit_succeeds_for_production_yaml,
     test_run_commit_is_idempotent,
+    test_run_commit_rejects_invalid_parent_id,
     test_run_commit_uses_custom_message,
     test_run_ls_fails_when_no_project_root,
     test_run_ls_returns_true_when_no_index,

--- a/tests/run.py
+++ b/tests/run.py
@@ -827,6 +827,7 @@ from tests.test_yaml_store import test_resolve_manifest_uri_rejects_missing_mani
 from tests.test_yaml_store import test_resolve_manifest_uri_rejects_tampered_lineage
 from tests.test_yaml_store import test_resolve_manifest_uri_accepts_short_hash
 from tests.test_yaml_store import test_resolve_manifest_uri_rejects_ambiguous_short_hash
+from tests.test_yaml_store import test_update_index_deduplicates_pre_existing_entries
 from tests.test_cli_commit import test_run_commit_fails_when_no_project_root
 from tests.test_cli_commit import test_run_commit_fails_on_invalid_yaml
 from tests.test_cli_commit import test_run_commit_rejects_development_mode
@@ -850,6 +851,8 @@ from tests.test_cli_new import test_run_new_fails_when_directory_exists
 from tests.test_cli_new import test_run_new_succeeds_with_mocked_clone
 from tests.test_cli_new import test_run_new_sets_backup_remote
 from tests.test_cli_new import test_run_new_clone_failure_returns_false
+from tests.test_cli_new import test_run_new_warns_when_backup_remote_placeholder_missing
+from tests.test_cli_new import test_clone_template_fails_fast_on_git_init_failure
 
 tests = [
     test_param_domain_init,
@@ -1670,6 +1673,7 @@ tests = [
     test_resolve_manifest_uri_rejects_tampered_lineage,
     test_resolve_manifest_uri_accepts_short_hash,
     test_resolve_manifest_uri_rejects_ambiguous_short_hash,
+    test_update_index_deduplicates_pre_existing_entries,
     test_run_commit_fails_when_no_project_root,
     test_run_commit_fails_on_invalid_yaml,
     test_run_commit_rejects_development_mode,
@@ -1693,6 +1697,8 @@ tests = [
     test_run_new_succeeds_with_mocked_clone,
     test_run_new_sets_backup_remote,
     test_run_new_clone_failure_returns_false,
+    test_run_new_warns_when_backup_remote_placeholder_missing,
+    test_clone_template_fails_fast_on_git_init_failure,
 ]
 
 # Configure logging

--- a/tests/run.py
+++ b/tests/run.py
@@ -812,6 +812,11 @@ from tests.test_yaml_store import test_commit_stores_file_in_committed_dir
 from tests.test_yaml_store import test_commit_is_idempotent
 from tests.test_yaml_store import test_commit_injects_lineage_section
 from tests.test_yaml_store import test_commit_updates_index_json
+from tests.test_yaml_store import test_resolve_manifest_uri_returns_path
+from tests.test_yaml_store import test_resolve_manifest_uri_rejects_missing_manifest
+from tests.test_yaml_store import test_resolve_manifest_uri_rejects_tampered_lineage
+from tests.test_yaml_store import test_resolve_manifest_uri_accepts_short_hash
+from tests.test_yaml_store import test_resolve_manifest_uri_rejects_ambiguous_short_hash
 
 tests = [
     test_param_domain_init,
@@ -1617,6 +1622,11 @@ tests = [
     test_commit_is_idempotent,
     test_commit_injects_lineage_section,
     test_commit_updates_index_json,
+    test_resolve_manifest_uri_returns_path,
+    test_resolve_manifest_uri_rejects_missing_manifest,
+    test_resolve_manifest_uri_rejects_tampered_lineage,
+    test_resolve_manifest_uri_accepts_short_hash,
+    test_resolve_manifest_uri_rejects_ambiguous_short_hash,
 ]
 
 # Configure logging

--- a/tests/run.py
+++ b/tests/run.py
@@ -815,7 +815,7 @@ from tests.test_yaml_store import test_commit_stores_file_in_committed_dir
 from tests.test_yaml_store import test_commit_is_idempotent
 from tests.test_yaml_store import test_commit_injects_lineage_section
 from tests.test_yaml_store import test_commit_updates_index_json
-from tests.test_yaml_store import test_resolve_manifest_uri_returns_path
+from tests.test_yaml_store import test_resolve_manifest_uri_returns_path_and_project_root
 from tests.test_yaml_store import test_resolve_manifest_uri_rejects_missing_manifest
 from tests.test_yaml_store import test_resolve_manifest_uri_rejects_tampered_lineage
 from tests.test_yaml_store import test_resolve_manifest_uri_accepts_short_hash
@@ -1645,7 +1645,7 @@ tests = [
     test_commit_is_idempotent,
     test_commit_injects_lineage_section,
     test_commit_updates_index_json,
-    test_resolve_manifest_uri_returns_path,
+    test_resolve_manifest_uri_returns_path_and_project_root,
     test_resolve_manifest_uri_rejects_missing_manifest,
     test_resolve_manifest_uri_rejects_tampered_lineage,
     test_resolve_manifest_uri_accepts_short_hash,

--- a/tests/run.py
+++ b/tests/run.py
@@ -830,6 +830,7 @@ from tests.test_yaml_store import test_resolve_manifest_uri_rejects_ambiguous_sh
 from tests.test_yaml_store import test_update_index_deduplicates_pre_existing_entries
 from tests.test_yaml_store import test_commit_manifest_raises_on_invalid_yaml_content
 from tests.test_yaml_store import test_commit_manifest_raises_when_yaml_is_not_a_dict
+from tests.test_yaml_store import test_commit_manifest_raises_when_existing_committed_file_is_not_a_dict
 from tests.test_cli_commit import test_run_commit_fails_when_no_project_root
 from tests.test_cli_commit import test_run_commit_fails_on_invalid_yaml
 from tests.test_cli_commit import test_run_commit_rejects_development_mode
@@ -1680,6 +1681,7 @@ tests = [
     test_update_index_deduplicates_pre_existing_entries,
     test_commit_manifest_raises_on_invalid_yaml_content,
     test_commit_manifest_raises_when_yaml_is_not_a_dict,
+    test_commit_manifest_raises_when_existing_committed_file_is_not_a_dict,
     test_run_commit_fails_when_no_project_root,
     test_run_commit_fails_on_invalid_yaml,
     test_run_commit_rejects_development_mode,

--- a/tests/run.py
+++ b/tests/run.py
@@ -816,8 +816,10 @@ from tests.test_yaml_store import test_commit_is_idempotent
 from tests.test_yaml_store import test_commit_injects_lineage_section
 from tests.test_yaml_store import test_commit_updates_index_json
 from tests.test_yaml_store import test_commit_repairs_index_when_missing
+from tests.test_yaml_store import test_commit_recovers_from_corrupt_index
 from tests.test_yaml_store import test_commit_timestamps_are_utc
 from tests.test_yaml_store import test_resolve_manifest_uri_returns_path_and_project_root
+from tests.test_yaml_store import test_resolve_manifest_uri_rejects_malformed_hash
 from tests.test_yaml_store import test_resolve_manifest_uri_rejects_missing_manifest
 from tests.test_yaml_store import test_resolve_manifest_uri_rejects_tampered_lineage
 from tests.test_yaml_store import test_resolve_manifest_uri_accepts_short_hash
@@ -833,6 +835,7 @@ from tests.test_cli_ls import test_run_ls_fails_when_no_project_root
 from tests.test_cli_ls import test_run_ls_returns_true_when_no_index
 from tests.test_cli_ls import test_run_ls_returns_true_when_empty_manifests
 from tests.test_cli_ls import test_run_ls_lists_committed_manifests
+from tests.test_cli_ls import test_run_ls_returns_true_when_index_is_corrupt
 from tests.test_cli_ls import test_run_ls_shows_parent_id_when_present
 from tests.test_cli_git_utils import test_git_executable_returns_path
 from tests.test_cli_git_utils import test_git_add_and_commit_creates_commit
@@ -1649,8 +1652,10 @@ tests = [
     test_commit_injects_lineage_section,
     test_commit_updates_index_json,
     test_commit_repairs_index_when_missing,
+    test_commit_recovers_from_corrupt_index,
     test_commit_timestamps_are_utc,
     test_resolve_manifest_uri_returns_path_and_project_root,
+    test_resolve_manifest_uri_rejects_malformed_hash,
     test_resolve_manifest_uri_rejects_missing_manifest,
     test_resolve_manifest_uri_rejects_tampered_lineage,
     test_resolve_manifest_uri_accepts_short_hash,
@@ -1666,6 +1671,7 @@ tests = [
     test_run_ls_returns_true_when_no_index,
     test_run_ls_returns_true_when_empty_manifests,
     test_run_ls_lists_committed_manifests,
+    test_run_ls_returns_true_when_index_is_corrupt,
     test_run_ls_shows_parent_id_when_present,
     test_git_executable_returns_path,
     test_git_add_and_commit_creates_commit,

--- a/tests/run.py
+++ b/tests/run.py
@@ -75,6 +75,7 @@ from tests.test_yaml import test_validate_error_for_data_dict_extension_unknown_
 from tests.test_yaml import test_validate_error_for_uel_search_strategy_wrong_type
 from tests.test_yaml import test_validate_error_for_uel_output_path_wrong_type
 from tests.test_yaml import test_validate_error_for_uel_prep_each_round_wrong_type
+from tests.test_yaml import test_validate_warns_for_uel_experiment_dir
 from tests.test_yaml import test_validate_error_for_uel_feedback_interval_wrong_type
 from tests.test_yaml import test_validate_error_for_uel_checkpoint_interval_wrong_type
 from tests.test_yaml import test_validate_error_for_manifest_ref_not_in_sfd_params
@@ -840,6 +841,8 @@ from tests.test_cli_ls import test_run_ls_lists_committed_manifests
 from tests.test_cli_ls import test_run_ls_returns_true_when_index_is_corrupt
 from tests.test_cli_ls import test_run_ls_returns_true_when_index_has_invalid_structure
 from tests.test_cli_ls import test_run_ls_skips_malformed_entries
+from tests.test_cli_ls import test_run_ls_skips_entry_with_non_string_id
+from tests.test_cli_ls import test_run_ls_skips_entry_with_non_string_parent_id
 from tests.test_cli_ls import test_run_ls_shows_parent_id_when_present
 from tests.test_cli_git_utils import test_git_executable_returns_path
 from tests.test_cli_git_utils import test_git_add_and_commit_creates_commit
@@ -1166,6 +1169,7 @@ tests = [
     test_validate_error_for_uel_search_strategy_wrong_type,
     test_validate_error_for_uel_output_path_wrong_type,
     test_validate_error_for_uel_prep_each_round_wrong_type,
+    test_validate_warns_for_uel_experiment_dir,
     test_validate_error_for_uel_feedback_interval_wrong_type,
     test_validate_error_for_uel_checkpoint_interval_wrong_type,
     test_validate_error_for_manifest_ref_not_in_sfd_params,
@@ -1680,6 +1684,8 @@ tests = [
     test_run_ls_returns_true_when_index_is_corrupt,
     test_run_ls_returns_true_when_index_has_invalid_structure,
     test_run_ls_skips_malformed_entries,
+    test_run_ls_skips_entry_with_non_string_id,
+    test_run_ls_skips_entry_with_non_string_parent_id,
     test_run_ls_shows_parent_id_when_present,
     test_git_executable_returns_path,
     test_git_add_and_commit_creates_commit,

--- a/tests/run.py
+++ b/tests/run.py
@@ -805,6 +805,9 @@ from tests.test_proto_cohort import test_predict_return_probs_probability_mode_r
 from tests.test_proto_cohort import test_predict_return_probs_single_member_returns_sample_major_column
 from tests.test_proto_cohort import test_majority_vote_uses_binary_votes_for_continuous_fallback_members
 from tests.test_proto_cohort import test_single_member_fallback_predict_returns_binary_votes
+from tests.test_yaml_config import test_find_project_root_walks_up_from_subdirectory
+from tests.test_yaml_config import test_find_project_root_returns_none_when_not_found
+from tests.test_yaml_config import test_get_store_path_raises_when_no_project_root
 
 tests = [
     test_param_domain_init,
@@ -1603,6 +1606,9 @@ tests = [
     test_validate_probability_range_rejects_non_finite_values,
     test_cohort_is_drop_in_decoder_replacement_for_dict_input,
     test_member_failure_propagates_and_fails_whole_call,
+    test_find_project_root_walks_up_from_subdirectory,
+    test_find_project_root_returns_none_when_not_found,
+    test_get_store_path_raises_when_no_project_root,
 ]
 
 # Configure logging

--- a/tests/run.py
+++ b/tests/run.py
@@ -851,10 +851,13 @@ from tests.test_cli_ls import test_run_ls_skips_entry_with_non_string_name
 from tests.test_cli_ls import test_run_ls_skips_entry_with_non_string_committed_at
 from tests.test_cli_ls import test_run_ls_shows_parent_id_when_present
 from tests.test_cli_git_utils import test_git_executable_returns_path
+from tests.test_cli_git_utils import test_git_add_and_commit_returns_false_when_git_not_found
 from tests.test_cli_git_utils import test_git_add_and_commit_creates_commit
 from tests.test_cli_new import test_run_new_fails_when_directory_exists
 from tests.test_cli_new import test_run_new_succeeds_with_mocked_clone
 from tests.test_cli_new import test_run_new_sets_backup_remote
+from tests.test_cli_new import test_run_new_fails_when_git_not_found
+from tests.test_cli_new import test_run_new_skips_backup_remote_with_invalid_chars
 from tests.test_cli_new import test_run_new_clone_failure_returns_false
 from tests.test_cli_new import test_run_new_warns_when_backup_remote_placeholder_missing
 from tests.test_cli_new import test_clone_template_fails_fast_on_git_init_failure
@@ -1702,10 +1705,13 @@ tests = [
     test_run_ls_skips_entry_with_non_string_committed_at,
     test_run_ls_shows_parent_id_when_present,
     test_git_executable_returns_path,
+    test_git_add_and_commit_returns_false_when_git_not_found,
     test_git_add_and_commit_creates_commit,
     test_run_new_fails_when_directory_exists,
     test_run_new_succeeds_with_mocked_clone,
     test_run_new_sets_backup_remote,
+    test_run_new_fails_when_git_not_found,
+    test_run_new_skips_backup_remote_with_invalid_chars,
     test_run_new_clone_failure_returns_false,
     test_run_new_warns_when_backup_remote_placeholder_missing,
     test_clone_template_fails_fast_on_git_init_failure,

--- a/tests/run.py
+++ b/tests/run.py
@@ -808,6 +808,9 @@ from tests.test_proto_cohort import test_single_member_fallback_predict_returns_
 from tests.test_yaml_config import test_find_project_root_walks_up_from_subdirectory
 from tests.test_yaml_config import test_find_project_root_returns_none_when_not_found
 from tests.test_yaml_config import test_get_store_path_raises_when_no_project_root
+from tests.test_yaml_config import test_get_store_path_returns_committed_dir
+from tests.test_yaml_config import test_read_limen_toml_returns_parsed_contents
+from tests.test_yaml_config import test_read_limen_toml_raises_when_file_missing
 from tests.test_yaml_store import test_commit_stores_file_in_committed_dir
 from tests.test_yaml_store import test_commit_is_idempotent
 from tests.test_yaml_store import test_commit_injects_lineage_section
@@ -817,6 +820,23 @@ from tests.test_yaml_store import test_resolve_manifest_uri_rejects_missing_mani
 from tests.test_yaml_store import test_resolve_manifest_uri_rejects_tampered_lineage
 from tests.test_yaml_store import test_resolve_manifest_uri_accepts_short_hash
 from tests.test_yaml_store import test_resolve_manifest_uri_rejects_ambiguous_short_hash
+from tests.test_cli_commit import test_run_commit_fails_when_no_project_root
+from tests.test_cli_commit import test_run_commit_fails_on_invalid_yaml
+from tests.test_cli_commit import test_run_commit_rejects_development_mode
+from tests.test_cli_commit import test_run_commit_succeeds_for_production_yaml
+from tests.test_cli_commit import test_run_commit_is_idempotent
+from tests.test_cli_commit import test_run_commit_uses_custom_message
+from tests.test_cli_ls import test_run_ls_fails_when_no_project_root
+from tests.test_cli_ls import test_run_ls_returns_true_when_no_index
+from tests.test_cli_ls import test_run_ls_returns_true_when_empty_manifests
+from tests.test_cli_ls import test_run_ls_lists_committed_manifests
+from tests.test_cli_ls import test_run_ls_shows_parent_id_when_present
+from tests.test_cli_git_utils import test_git_executable_returns_path
+from tests.test_cli_git_utils import test_git_add_and_commit_creates_commit
+from tests.test_cli_new import test_run_new_fails_when_directory_exists
+from tests.test_cli_new import test_run_new_succeeds_with_mocked_clone
+from tests.test_cli_new import test_run_new_sets_backup_remote
+from tests.test_cli_new import test_run_new_clone_failure_returns_false
 
 tests = [
     test_param_domain_init,
@@ -1618,6 +1638,9 @@ tests = [
     test_find_project_root_walks_up_from_subdirectory,
     test_find_project_root_returns_none_when_not_found,
     test_get_store_path_raises_when_no_project_root,
+    test_get_store_path_returns_committed_dir,
+    test_read_limen_toml_returns_parsed_contents,
+    test_read_limen_toml_raises_when_file_missing,
     test_commit_stores_file_in_committed_dir,
     test_commit_is_idempotent,
     test_commit_injects_lineage_section,
@@ -1627,6 +1650,23 @@ tests = [
     test_resolve_manifest_uri_rejects_tampered_lineage,
     test_resolve_manifest_uri_accepts_short_hash,
     test_resolve_manifest_uri_rejects_ambiguous_short_hash,
+    test_run_commit_fails_when_no_project_root,
+    test_run_commit_fails_on_invalid_yaml,
+    test_run_commit_rejects_development_mode,
+    test_run_commit_succeeds_for_production_yaml,
+    test_run_commit_is_idempotent,
+    test_run_commit_uses_custom_message,
+    test_run_ls_fails_when_no_project_root,
+    test_run_ls_returns_true_when_no_index,
+    test_run_ls_returns_true_when_empty_manifests,
+    test_run_ls_lists_committed_manifests,
+    test_run_ls_shows_parent_id_when_present,
+    test_git_executable_returns_path,
+    test_git_add_and_commit_creates_commit,
+    test_run_new_fails_when_directory_exists,
+    test_run_new_succeeds_with_mocked_clone,
+    test_run_new_sets_backup_remote,
+    test_run_new_clone_failure_returns_false,
 ]
 
 # Configure logging

--- a/tests/run.py
+++ b/tests/run.py
@@ -846,6 +846,8 @@ from tests.test_cli_ls import test_run_ls_returns_true_when_index_is_corrupt
 from tests.test_cli_ls import test_run_ls_returns_true_when_index_has_invalid_structure
 from tests.test_cli_ls import test_run_ls_skips_malformed_entries
 from tests.test_cli_ls import test_run_ls_skips_entry_with_non_string_id
+from tests.test_cli_ls import test_run_ls_skips_entry_with_truncated_id
+from tests.test_cli_ls import test_run_ls_skips_entry_with_non_hex_id
 from tests.test_cli_ls import test_run_ls_skips_entry_with_non_string_parent_id
 from tests.test_cli_ls import test_run_ls_skips_entry_with_non_string_name
 from tests.test_cli_ls import test_run_ls_skips_entry_with_non_string_committed_at
@@ -1700,6 +1702,8 @@ tests = [
     test_run_ls_returns_true_when_index_has_invalid_structure,
     test_run_ls_skips_malformed_entries,
     test_run_ls_skips_entry_with_non_string_id,
+    test_run_ls_skips_entry_with_truncated_id,
+    test_run_ls_skips_entry_with_non_hex_id,
     test_run_ls_skips_entry_with_non_string_parent_id,
     test_run_ls_skips_entry_with_non_string_name,
     test_run_ls_skips_entry_with_non_string_committed_at,

--- a/tests/run.py
+++ b/tests/run.py
@@ -817,8 +817,10 @@ from tests.test_yaml_store import test_commit_injects_lineage_section
 from tests.test_yaml_store import test_commit_updates_index_json
 from tests.test_yaml_store import test_commit_repairs_index_when_missing
 from tests.test_yaml_store import test_commit_recovers_from_corrupt_index
+from tests.test_yaml_store import test_commit_recovers_from_structurally_invalid_index
 from tests.test_yaml_store import test_commit_timestamps_are_utc
 from tests.test_yaml_store import test_resolve_manifest_uri_returns_path_and_project_root
+from tests.test_yaml_store import test_resolve_manifest_uri_raises_on_corrupt_manifest_file
 from tests.test_yaml_store import test_resolve_manifest_uri_rejects_malformed_hash
 from tests.test_yaml_store import test_resolve_manifest_uri_rejects_missing_manifest
 from tests.test_yaml_store import test_resolve_manifest_uri_rejects_tampered_lineage
@@ -836,6 +838,8 @@ from tests.test_cli_ls import test_run_ls_returns_true_when_no_index
 from tests.test_cli_ls import test_run_ls_returns_true_when_empty_manifests
 from tests.test_cli_ls import test_run_ls_lists_committed_manifests
 from tests.test_cli_ls import test_run_ls_returns_true_when_index_is_corrupt
+from tests.test_cli_ls import test_run_ls_returns_true_when_index_has_invalid_structure
+from tests.test_cli_ls import test_run_ls_skips_malformed_entries
 from tests.test_cli_ls import test_run_ls_shows_parent_id_when_present
 from tests.test_cli_git_utils import test_git_executable_returns_path
 from tests.test_cli_git_utils import test_git_add_and_commit_creates_commit
@@ -1653,8 +1657,10 @@ tests = [
     test_commit_updates_index_json,
     test_commit_repairs_index_when_missing,
     test_commit_recovers_from_corrupt_index,
+    test_commit_recovers_from_structurally_invalid_index,
     test_commit_timestamps_are_utc,
     test_resolve_manifest_uri_returns_path_and_project_root,
+    test_resolve_manifest_uri_raises_on_corrupt_manifest_file,
     test_resolve_manifest_uri_rejects_malformed_hash,
     test_resolve_manifest_uri_rejects_missing_manifest,
     test_resolve_manifest_uri_rejects_tampered_lineage,
@@ -1672,6 +1678,8 @@ tests = [
     test_run_ls_returns_true_when_empty_manifests,
     test_run_ls_lists_committed_manifests,
     test_run_ls_returns_true_when_index_is_corrupt,
+    test_run_ls_returns_true_when_index_has_invalid_structure,
+    test_run_ls_skips_malformed_entries,
     test_run_ls_shows_parent_id_when_present,
     test_git_executable_returns_path,
     test_git_add_and_commit_creates_commit,

--- a/tests/run.py
+++ b/tests/run.py
@@ -828,6 +828,8 @@ from tests.test_yaml_store import test_resolve_manifest_uri_rejects_tampered_lin
 from tests.test_yaml_store import test_resolve_manifest_uri_accepts_short_hash
 from tests.test_yaml_store import test_resolve_manifest_uri_rejects_ambiguous_short_hash
 from tests.test_yaml_store import test_update_index_deduplicates_pre_existing_entries
+from tests.test_yaml_store import test_commit_manifest_raises_on_invalid_yaml_content
+from tests.test_yaml_store import test_commit_manifest_raises_when_yaml_is_not_a_dict
 from tests.test_cli_commit import test_run_commit_fails_when_no_project_root
 from tests.test_cli_commit import test_run_commit_fails_on_invalid_yaml
 from tests.test_cli_commit import test_run_commit_rejects_development_mode
@@ -844,6 +846,8 @@ from tests.test_cli_ls import test_run_ls_returns_true_when_index_has_invalid_st
 from tests.test_cli_ls import test_run_ls_skips_malformed_entries
 from tests.test_cli_ls import test_run_ls_skips_entry_with_non_string_id
 from tests.test_cli_ls import test_run_ls_skips_entry_with_non_string_parent_id
+from tests.test_cli_ls import test_run_ls_skips_entry_with_non_string_name
+from tests.test_cli_ls import test_run_ls_skips_entry_with_non_string_committed_at
 from tests.test_cli_ls import test_run_ls_shows_parent_id_when_present
 from tests.test_cli_git_utils import test_git_executable_returns_path
 from tests.test_cli_git_utils import test_git_add_and_commit_creates_commit
@@ -1674,6 +1678,8 @@ tests = [
     test_resolve_manifest_uri_accepts_short_hash,
     test_resolve_manifest_uri_rejects_ambiguous_short_hash,
     test_update_index_deduplicates_pre_existing_entries,
+    test_commit_manifest_raises_on_invalid_yaml_content,
+    test_commit_manifest_raises_when_yaml_is_not_a_dict,
     test_run_commit_fails_when_no_project_root,
     test_run_commit_fails_on_invalid_yaml,
     test_run_commit_rejects_development_mode,
@@ -1690,6 +1696,8 @@ tests = [
     test_run_ls_skips_malformed_entries,
     test_run_ls_skips_entry_with_non_string_id,
     test_run_ls_skips_entry_with_non_string_parent_id,
+    test_run_ls_skips_entry_with_non_string_name,
+    test_run_ls_skips_entry_with_non_string_committed_at,
     test_run_ls_shows_parent_id_when_present,
     test_git_executable_returns_path,
     test_git_add_and_commit_creates_commit,

--- a/tests/test_cli_commit.py
+++ b/tests/test_cli_commit.py
@@ -79,6 +79,7 @@ def test_run_commit_rejects_invalid_parent_id() -> None:
         with patch('limen.cli.commands.commit.load_and_validate', return_value=(_PROD_DICT, True)):
             assert run_commit(yaml_path, 'not-a-valid-id', None) is False
             assert run_commit(yaml_path, 'sha256:short', None) is False
+            assert run_commit(yaml_path, 'sha256:' + 'z' * 64, None) is False
 
 
 def test_run_commit_uses_custom_message() -> None:

--- a/tests/test_cli_commit.py
+++ b/tests/test_cli_commit.py
@@ -70,6 +70,17 @@ def test_run_commit_is_idempotent() -> None:
             assert run_commit(yaml_path, None, None) is True
 
 
+def test_run_commit_rejects_invalid_parent_id() -> None:
+    with tempfile.TemporaryDirectory() as d:
+        root = Path(d)
+        _make_project(root)
+        yaml_path = root / 'test.yaml'
+        yaml_path.write_text(_MINIMAL_YAML)
+        with patch('limen.cli.commands.commit.load_and_validate', return_value=(_PROD_DICT, True)):
+            assert run_commit(yaml_path, 'not-a-valid-id', None) is False
+            assert run_commit(yaml_path, 'sha256:short', None) is False
+
+
 def test_run_commit_uses_custom_message() -> None:
     with tempfile.TemporaryDirectory() as d:
         root = Path(d)

--- a/tests/test_cli_commit.py
+++ b/tests/test_cli_commit.py
@@ -1,0 +1,80 @@
+import subprocess
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+from limen.cli.commands.commit import run_commit
+from limen.cli.git_utils import git_executable
+
+
+_DEV_DICT = {'metadata': {'name': 'test', 'mode': 'development'}}
+_PROD_DICT = {'metadata': {'name': 'test', 'mode': 'production'}}
+
+_MINIMAL_YAML = 'schema_version: "1.0"\nmetadata:\n  name: test\n  mode: production\n'
+
+
+def _make_project(root: Path) -> None:
+    git = git_executable()
+    (root / 'limen.toml').write_text('')
+    subprocess.run([git, 'init'], cwd=root, capture_output=True, check=False)
+    subprocess.run([git, 'config', 'user.email', 'test@test.com'], cwd=root, capture_output=True, check=False)
+    subprocess.run([git, 'config', 'user.name', 'Test'], cwd=root, capture_output=True, check=False)
+    (root / 'manifests' / 'committed').mkdir(parents=True)
+
+
+def test_run_commit_fails_when_no_project_root() -> None:
+    with tempfile.TemporaryDirectory() as d:
+        yaml_path = Path(d) / 'test.yaml'
+        yaml_path.write_text(_MINIMAL_YAML)
+        assert run_commit(yaml_path, None, None) is False
+
+
+def test_run_commit_fails_on_invalid_yaml() -> None:
+    with tempfile.TemporaryDirectory() as d:
+        root = Path(d)
+        _make_project(root)
+        yaml_path = root / 'test.yaml'
+        yaml_path.write_text(_MINIMAL_YAML)
+        with patch('limen.cli.commands.commit.load_and_validate', return_value=({}, False)):
+            assert run_commit(yaml_path, None, None) is False
+
+
+def test_run_commit_rejects_development_mode() -> None:
+    with tempfile.TemporaryDirectory() as d:
+        root = Path(d)
+        _make_project(root)
+        yaml_path = root / 'test.yaml'
+        yaml_path.write_text(_MINIMAL_YAML)
+        with patch('limen.cli.commands.commit.load_and_validate', return_value=(_DEV_DICT, True)):
+            assert run_commit(yaml_path, None, None) is False
+
+
+def test_run_commit_succeeds_for_production_yaml() -> None:
+    with tempfile.TemporaryDirectory() as d:
+        root = Path(d)
+        _make_project(root)
+        yaml_path = root / 'test.yaml'
+        yaml_path.write_text(_MINIMAL_YAML)
+        with patch('limen.cli.commands.commit.load_and_validate', return_value=(_PROD_DICT, True)):
+            assert run_commit(yaml_path, None, None) is True
+
+
+def test_run_commit_is_idempotent() -> None:
+    with tempfile.TemporaryDirectory() as d:
+        root = Path(d)
+        _make_project(root)
+        yaml_path = root / 'test.yaml'
+        yaml_path.write_text(_MINIMAL_YAML)
+        with patch('limen.cli.commands.commit.load_and_validate', return_value=(_PROD_DICT, True)):
+            run_commit(yaml_path, None, None)
+            assert run_commit(yaml_path, None, None) is True
+
+
+def test_run_commit_uses_custom_message() -> None:
+    with tempfile.TemporaryDirectory() as d:
+        root = Path(d)
+        _make_project(root)
+        yaml_path = root / 'test.yaml'
+        yaml_path.write_text(_MINIMAL_YAML)
+        with patch('limen.cli.commands.commit.load_and_validate', return_value=(_PROD_DICT, True)):
+            assert run_commit(yaml_path, None, 'my custom message') is True

--- a/tests/test_cli_git_utils.py
+++ b/tests/test_cli_git_utils.py
@@ -13,9 +13,9 @@ def test_git_executable_returns_path() -> None:
 
 
 def test_git_add_and_commit_returns_false_when_git_not_found() -> None:
-    with tempfile.TemporaryDirectory() as d:
-        with patch('limen.cli.git_utils.git_executable', side_effect=FileNotFoundError):
-            result = git_add_and_commit(Path(d), Path('file.txt'), 'msg')
+    with tempfile.TemporaryDirectory() as d, \
+         patch('limen.cli.git_utils.git_executable', side_effect=FileNotFoundError):
+        result = git_add_and_commit(Path(d), Path('file.txt'), 'msg')
     assert result is False
 
 

--- a/tests/test_cli_git_utils.py
+++ b/tests/test_cli_git_utils.py
@@ -1,6 +1,7 @@
 import subprocess
 import tempfile
 from pathlib import Path
+from unittest.mock import patch
 
 from limen.cli.git_utils import git_add_and_commit
 from limen.cli.git_utils import git_executable
@@ -9,6 +10,13 @@ from limen.cli.git_utils import git_executable
 def test_git_executable_returns_path() -> None:
     path = git_executable()
     assert 'git' in path
+
+
+def test_git_add_and_commit_returns_false_when_git_not_found() -> None:
+    with tempfile.TemporaryDirectory() as d:
+        with patch('limen.cli.git_utils.git_executable', side_effect=FileNotFoundError):
+            result = git_add_and_commit(Path(d), Path('file.txt'), 'msg')
+    assert result is False
 
 
 def test_git_add_and_commit_creates_commit() -> None:

--- a/tests/test_cli_git_utils.py
+++ b/tests/test_cli_git_utils.py
@@ -1,0 +1,24 @@
+import subprocess
+import tempfile
+from pathlib import Path
+
+from limen.cli.git_utils import git_add_and_commit
+from limen.cli.git_utils import git_executable
+
+
+def test_git_executable_returns_path() -> None:
+    path = git_executable()
+    assert 'git' in path
+
+
+def test_git_add_and_commit_creates_commit() -> None:
+    git = git_executable()
+    with tempfile.TemporaryDirectory() as d:
+        repo = Path(d)
+        subprocess.run([git, 'init'], cwd=repo, capture_output=True, check=False)
+        subprocess.run([git, 'config', 'user.email', 'test@test.com'], cwd=repo, capture_output=True, check=False)
+        subprocess.run([git, 'config', 'user.name', 'Test'], cwd=repo, capture_output=True, check=False)
+        (repo / 'file.txt').write_text('hello')
+        git_add_and_commit(repo, Path('file.txt'), 'test commit')
+        result = subprocess.run([git, 'log', '--oneline'], cwd=repo, capture_output=True, text=True, check=False)
+        assert 'test commit' in result.stdout

--- a/tests/test_cli_ls.py
+++ b/tests/test_cli_ls.py
@@ -44,6 +44,13 @@ def test_run_ls_lists_committed_manifests() -> None:
         assert run_ls(Path(d)) is True
 
 
+def test_run_ls_returns_true_when_index_is_corrupt() -> None:
+    with tempfile.TemporaryDirectory() as d:
+        store = _make_project(Path(d))
+        (store / 'index.json').write_text('not valid json')
+        assert run_ls(Path(d)) is True
+
+
 def test_run_ls_shows_parent_id_when_present() -> None:
     with tempfile.TemporaryDirectory() as d:
         store = _make_project(Path(d))

--- a/tests/test_cli_ls.py
+++ b/tests/test_cli_ls.py
@@ -83,6 +83,22 @@ def test_run_ls_skips_entry_with_non_string_parent_id() -> None:
         assert run_ls(Path(d)) is True
 
 
+def test_run_ls_skips_entry_with_truncated_id() -> None:
+    with tempfile.TemporaryDirectory() as d:
+        store = _make_project(Path(d))
+        entry = {'id': 'sha256:' + 'a' * 8, 'name': 'ok', 'committed_at': '2026-05-28T10:00:00Z', 'parent_id': None}
+        (store / 'index.json').write_text(json.dumps({'version': 1, 'manifests': [entry]}))
+        assert run_ls(Path(d)) is True
+
+
+def test_run_ls_skips_entry_with_non_hex_id() -> None:
+    with tempfile.TemporaryDirectory() as d:
+        store = _make_project(Path(d))
+        entry = {'id': 'sha256:' + 'z' * 64, 'name': 'ok', 'committed_at': '2026-05-28T10:00:00Z', 'parent_id': None}
+        (store / 'index.json').write_text(json.dumps({'version': 1, 'manifests': [entry]}))
+        assert run_ls(Path(d)) is True
+
+
 def test_run_ls_skips_entry_with_non_string_name() -> None:
     with tempfile.TemporaryDirectory() as d:
         store = _make_project(Path(d))

--- a/tests/test_cli_ls.py
+++ b/tests/test_cli_ls.py
@@ -67,6 +67,22 @@ def test_run_ls_skips_malformed_entries() -> None:
         assert run_ls(Path(d)) is True
 
 
+def test_run_ls_skips_entry_with_non_string_id() -> None:
+    with tempfile.TemporaryDirectory() as d:
+        store = _make_project(Path(d))
+        entry = {'id': 12345, 'name': 'bad_id', 'committed_at': '2026-05-28T10:00:00Z', 'parent_id': None}
+        (store / 'index.json').write_text(json.dumps({'version': 1, 'manifests': [entry]}))
+        assert run_ls(Path(d)) is True
+
+
+def test_run_ls_skips_entry_with_non_string_parent_id() -> None:
+    with tempfile.TemporaryDirectory() as d:
+        store = _make_project(Path(d))
+        entry = {'id': 'sha256:' + 'a' * 64, 'name': 'ok', 'committed_at': '2026-05-28T10:00:00Z', 'parent_id': 999}
+        (store / 'index.json').write_text(json.dumps({'version': 1, 'manifests': [entry]}))
+        assert run_ls(Path(d)) is True
+
+
 def test_run_ls_shows_parent_id_when_present() -> None:
     with tempfile.TemporaryDirectory() as d:
         store = _make_project(Path(d))

--- a/tests/test_cli_ls.py
+++ b/tests/test_cli_ls.py
@@ -51,6 +51,22 @@ def test_run_ls_returns_true_when_index_is_corrupt() -> None:
         assert run_ls(Path(d)) is True
 
 
+def test_run_ls_returns_true_when_index_has_invalid_structure() -> None:
+    with tempfile.TemporaryDirectory() as d:
+        store = _make_project(Path(d))
+        (store / 'index.json').write_text(json.dumps([1, 2, 3]))
+        assert run_ls(Path(d)) is True
+
+
+def test_run_ls_skips_malformed_entries() -> None:
+    with tempfile.TemporaryDirectory() as d:
+        store = _make_project(Path(d))
+        good = {'id': 'sha256:' + 'a' * 64, 'name': 'ok', 'committed_at': '2026-05-28T10:00:00Z', 'parent_id': None}
+        bad = {'broken': True}
+        (store / 'index.json').write_text(json.dumps({'version': 1, 'manifests': [good, bad]}))
+        assert run_ls(Path(d)) is True
+
+
 def test_run_ls_shows_parent_id_when_present() -> None:
     with tempfile.TemporaryDirectory() as d:
         store = _make_project(Path(d))

--- a/tests/test_cli_ls.py
+++ b/tests/test_cli_ls.py
@@ -1,0 +1,57 @@
+import json
+import tempfile
+from pathlib import Path
+
+from limen.cli.commands.ls import run_ls
+from limen.yaml.config import _STORE_RELATIVE
+
+
+def _make_project(root: Path) -> Path:
+    (root / 'limen.toml').write_text('')
+    store = root / _STORE_RELATIVE
+    store.mkdir(parents=True)
+    return store
+
+
+def test_run_ls_fails_when_no_project_root() -> None:
+    with tempfile.TemporaryDirectory() as d:
+        assert run_ls(Path(d)) is False
+
+
+def test_run_ls_returns_true_when_no_index() -> None:
+    with tempfile.TemporaryDirectory() as d:
+        _make_project(Path(d))
+        assert run_ls(Path(d)) is True
+
+
+def test_run_ls_returns_true_when_empty_manifests() -> None:
+    with tempfile.TemporaryDirectory() as d:
+        store = _make_project(Path(d))
+        (store / 'index.json').write_text(json.dumps({'version': 1, 'manifests': []}))
+        assert run_ls(Path(d)) is True
+
+
+def test_run_ls_lists_committed_manifests() -> None:
+    with tempfile.TemporaryDirectory() as d:
+        store = _make_project(Path(d))
+        entry = {
+            'id': 'sha256:' + 'a' * 64,
+            'name': 'my_experiment',
+            'committed_at': '2026-05-27T12:00:00',
+            'parent_id': None,
+        }
+        (store / 'index.json').write_text(json.dumps({'version': 1, 'manifests': [entry]}))
+        assert run_ls(Path(d)) is True
+
+
+def test_run_ls_shows_parent_id_when_present() -> None:
+    with tempfile.TemporaryDirectory() as d:
+        store = _make_project(Path(d))
+        entry = {
+            'id': 'sha256:' + 'b' * 64,
+            'name': 'child_experiment',
+            'committed_at': '2026-05-27T13:00:00',
+            'parent_id': 'sha256:' + 'a' * 64,
+        }
+        (store / 'index.json').write_text(json.dumps({'version': 1, 'manifests': [entry]}))
+        assert run_ls(Path(d)) is True

--- a/tests/test_cli_ls.py
+++ b/tests/test_cli_ls.py
@@ -83,6 +83,22 @@ def test_run_ls_skips_entry_with_non_string_parent_id() -> None:
         assert run_ls(Path(d)) is True
 
 
+def test_run_ls_skips_entry_with_non_string_name() -> None:
+    with tempfile.TemporaryDirectory() as d:
+        store = _make_project(Path(d))
+        entry = {'id': 'sha256:' + 'a' * 64, 'name': 99, 'committed_at': '2026-05-28T10:00:00Z', 'parent_id': None}
+        (store / 'index.json').write_text(json.dumps({'version': 1, 'manifests': [entry]}))
+        assert run_ls(Path(d)) is True
+
+
+def test_run_ls_skips_entry_with_non_string_committed_at() -> None:
+    with tempfile.TemporaryDirectory() as d:
+        store = _make_project(Path(d))
+        entry = {'id': 'sha256:' + 'a' * 64, 'name': 'ok', 'committed_at': 12345, 'parent_id': None}
+        (store / 'index.json').write_text(json.dumps({'version': 1, 'manifests': [entry]}))
+        assert run_ls(Path(d)) is True
+
+
 def test_run_ls_shows_parent_id_when_present() -> None:
     with tempfile.TemporaryDirectory() as d:
         store = _make_project(Path(d))

--- a/tests/test_cli_new.py
+++ b/tests/test_cli_new.py
@@ -71,6 +71,30 @@ def test_run_new_warns_when_backup_remote_placeholder_missing() -> None:
         assert 'git@github.com:user/repo.git' not in (project_path / 'limen.toml').read_text()
 
 
+def test_run_new_fails_when_git_not_found() -> None:
+    with tempfile.TemporaryDirectory() as d:
+        project_path = Path(d) / 'new-project'
+        with patch('limen.cli.commands.new.git_executable', side_effect=FileNotFoundError):
+            result = run_new(str(project_path), None)
+    assert result is False
+
+
+def test_run_new_skips_backup_remote_with_invalid_chars() -> None:
+    with tempfile.TemporaryDirectory() as d:
+        project_path = Path(d) / 'new-project'
+
+        def fake_clone(path: Path) -> bool:
+            path.mkdir(parents=True, exist_ok=True)
+            (path / 'limen.toml').write_text('backup_remote = ""\n')
+            return True
+
+        with patch('limen.cli.commands.new._clone_template', side_effect=fake_clone):
+            result = run_new(str(project_path), 'git@github.com:user/"bad".git')
+
+        assert result is True
+        assert '"bad"' not in (project_path / 'limen.toml').read_text()
+
+
 def test_clone_template_fails_fast_on_git_init_failure() -> None:
     with tempfile.TemporaryDirectory() as d:
         project_path = Path(d) / 'new-project'

--- a/tests/test_cli_new.py
+++ b/tests/test_cli_new.py
@@ -1,0 +1,54 @@
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+from limen.cli.commands.new import run_new
+
+
+def test_run_new_fails_when_directory_exists() -> None:
+    with tempfile.TemporaryDirectory() as d:
+        existing = Path(d) / 'my-project'
+        existing.mkdir()
+        assert run_new(str(existing), None) is False
+
+
+def test_run_new_succeeds_with_mocked_clone() -> None:
+    with tempfile.TemporaryDirectory() as d:
+        project_path = Path(d) / 'my-project'
+        project_path.mkdir()
+        (project_path / 'limen.toml').write_text('backup_remote = ""\n')
+
+        def fake_clone(path: Path) -> bool:
+            return True
+
+        with patch('limen.cli.commands.new._clone_template', side_effect=fake_clone), \
+             patch('click.prompt', return_value=''):
+            result = run_new(str(project_path.parent / 'new-project'), None)
+
+        assert result is True
+
+
+def test_run_new_sets_backup_remote() -> None:
+    with tempfile.TemporaryDirectory() as d:
+        project_path = Path(d) / 'new-project'
+
+        def fake_clone(path: Path) -> bool:
+            path.mkdir(parents=True, exist_ok=True)
+            (path / 'limen.toml').write_text('backup_remote = ""\n')
+            return True
+
+        with patch('limen.cli.commands.new._clone_template', side_effect=fake_clone):
+            result = run_new(str(project_path), 'git@github.com:user/repo.git')
+
+        assert result is True
+        assert 'git@github.com:user/repo.git' in (project_path / 'limen.toml').read_text()
+
+
+def test_run_new_clone_failure_returns_false() -> None:
+    with tempfile.TemporaryDirectory() as d:
+        project_path = Path(d) / 'new-project'
+
+        with patch('limen.cli.commands.new._clone_template', return_value=False):
+            result = run_new(str(project_path), None)
+
+        assert result is False

--- a/tests/test_cli_new.py
+++ b/tests/test_cli_new.py
@@ -1,5 +1,6 @@
 import tempfile
 from pathlib import Path
+from unittest.mock import MagicMock
 from unittest.mock import patch
 
 from limen.cli.commands.new import run_new
@@ -49,6 +50,47 @@ def test_run_new_clone_failure_returns_false() -> None:
         project_path = Path(d) / 'new-project'
 
         with patch('limen.cli.commands.new._clone_template', return_value=False):
+            result = run_new(str(project_path), None)
+
+        assert result is False
+
+
+def test_run_new_warns_when_backup_remote_placeholder_missing() -> None:
+    with tempfile.TemporaryDirectory() as d:
+        project_path = Path(d) / 'new-project'
+
+        def fake_clone(path: Path) -> bool:
+            path.mkdir(parents=True, exist_ok=True)
+            (path / 'limen.toml').write_text('# no placeholder here\n')
+            return True
+
+        with patch('limen.cli.commands.new._clone_template', side_effect=fake_clone):
+            result = run_new(str(project_path), 'git@github.com:user/repo.git')
+
+        assert result is True
+        assert 'git@github.com:user/repo.git' not in (project_path / 'limen.toml').read_text()
+
+
+def test_clone_template_fails_fast_on_git_init_failure() -> None:
+    with tempfile.TemporaryDirectory() as d:
+        project_path = Path(d) / 'new-project'
+
+        def fake_subprocess(args: list, **kwargs: object) -> MagicMock:
+            result = MagicMock()
+            if 'clone' in args:
+                project_path.mkdir(parents=True, exist_ok=True)
+                (project_path / '.git').mkdir()
+                result.returncode = 0
+                result.stderr = ''
+            elif 'init' in args:
+                result.returncode = 1
+                result.stderr = 'init failed'
+            else:
+                result.returncode = 0
+            return result
+
+        with patch('limen.cli.commands.new.subprocess.run', side_effect=fake_subprocess), \
+             patch('limen.cli.commands.new.shutil.rmtree'):
             result = run_new(str(project_path), None)
 
         assert result is False

--- a/tests/test_cli_new.py
+++ b/tests/test_cli_new.py
@@ -76,7 +76,7 @@ def test_run_new_fails_when_git_not_found() -> None:
         project_path = Path(d) / 'new-project'
         with patch('limen.cli.commands.new.git_executable', side_effect=FileNotFoundError):
             result = run_new(str(project_path), None)
-    assert result is False
+        assert result is False
 
 
 def test_run_new_skips_backup_remote_with_invalid_chars() -> None:

--- a/tests/test_runtime_tracking.py
+++ b/tests/test_runtime_tracking.py
@@ -97,7 +97,7 @@ def test_runtime_gate_writes_summary_and_passes_when_within_budget() -> None:
         profile_path.write_text(json.dumps(profile), encoding='utf-8')
         budget_path.write_text(json.dumps(budget), encoding='utf-8')
 
-        result = subprocess.run(  # noqa: S603
+        result = subprocess.run(
             [
                 sys.executable,
                 '-m',
@@ -161,7 +161,7 @@ def test_runtime_gate_fails_when_profile_exceeds_budget() -> None:
         profile_path.write_text(json.dumps(profile), encoding='utf-8')
         budget_path.write_text(json.dumps(budget), encoding='utf-8')
 
-        result = subprocess.run(  # noqa: S603
+        result = subprocess.run(
             [
                 sys.executable,
                 '-m',

--- a/tests/test_yaml.py
+++ b/tests/test_yaml.py
@@ -740,6 +740,13 @@ def test_validate_error_for_uel_checkpoint_interval_wrong_type() -> None:
         assert any('checkpoint_interval' in e.path for e in result.errors)
 
 
+def test_validate_warns_for_uel_experiment_dir() -> None:
+    yaml_dict, _ = parse(_MINIMAL_ML_YAML)
+    yaml_dict['uel']['experiment_dir'] = '/some/path'
+    result = validate(yaml_dict)
+    assert any('experiment_dir' in w.path for w in result.warnings)
+
+
 def test_validate_error_for_manifest_ref_not_in_sfd_params() -> None:
     yaml_dict, _ = parse(_MINIMAL_ML_YAML)
     yaml_dict['sfd']['manifest']['indicators'][0]['params']['period'] = '{unknown_param}'

--- a/tests/test_yaml_config.py
+++ b/tests/test_yaml_config.py
@@ -1,0 +1,28 @@
+import tempfile
+from pathlib import Path
+
+from limen.yaml.config import find_project_root
+from limen.yaml.config import get_store_path
+
+
+def test_find_project_root_walks_up_from_subdirectory() -> None:
+    with tempfile.TemporaryDirectory() as d:
+        root = Path(d)
+        (root / 'limen.toml').write_text('')
+        subdir = root / 'manifests' / 'examples'
+        subdir.mkdir(parents=True)
+        assert find_project_root(subdir) == root
+
+
+def test_find_project_root_returns_none_when_not_found() -> None:
+    with tempfile.TemporaryDirectory() as d:
+        assert find_project_root(Path(d)) is None
+
+
+def test_get_store_path_raises_when_no_project_root() -> None:
+    with tempfile.TemporaryDirectory() as d:
+        try:
+            get_store_path(Path(d))
+            assert False, 'expected FileNotFoundError'
+        except FileNotFoundError:
+            pass

--- a/tests/test_yaml_config.py
+++ b/tests/test_yaml_config.py
@@ -3,6 +3,8 @@ from pathlib import Path
 
 from limen.yaml.config import find_project_root
 from limen.yaml.config import get_store_path
+from limen.yaml.config import read_limen_toml
+from limen.yaml.config import _STORE_RELATIVE
 
 
 def test_find_project_root_walks_up_from_subdirectory() -> None:
@@ -23,6 +25,30 @@ def test_get_store_path_raises_when_no_project_root() -> None:
     with tempfile.TemporaryDirectory() as d:
         try:
             get_store_path(Path(d))
+            assert False, 'expected FileNotFoundError'
+        except FileNotFoundError:
+            pass
+
+
+def test_get_store_path_returns_committed_dir() -> None:
+    with tempfile.TemporaryDirectory() as d:
+        root = Path(d)
+        (root / 'limen.toml').write_text('')
+        assert get_store_path(root) == root / _STORE_RELATIVE
+
+
+def test_read_limen_toml_returns_parsed_contents() -> None:
+    with tempfile.TemporaryDirectory() as d:
+        root = Path(d)
+        (root / 'limen.toml').write_text('[project]\nname = "my-project"\n')
+        data = read_limen_toml(root)
+        assert data['project']['name'] == 'my-project'
+
+
+def test_read_limen_toml_raises_when_file_missing() -> None:
+    with tempfile.TemporaryDirectory() as d:
+        try:
+            read_limen_toml(Path(d))
             assert False, 'expected FileNotFoundError'
         except FileNotFoundError:
             pass

--- a/tests/test_yaml_store.py
+++ b/tests/test_yaml_store.py
@@ -77,13 +77,14 @@ def test_commit_updates_index_json() -> None:
         assert index['manifests'][0]['name'] == 'test_experiment'
 
 
-def test_resolve_manifest_uri_returns_path() -> None:
+def test_resolve_manifest_uri_returns_path_and_project_root() -> None:
     with tempfile.TemporaryDirectory() as d:
         project_root, yaml_path = _make_project(Path(d))
         manifest_id, _ = commit_manifest(yaml_path, project_root)
         uri = f'manifest://{manifest_id}'
-        resolved = resolve_manifest_uri(uri, project_root)
+        resolved, returned_root = resolve_manifest_uri(uri, project_root)
         assert resolved.exists()
+        assert returned_root == project_root
 
 
 def test_resolve_manifest_uri_rejects_missing_manifest() -> None:
@@ -110,7 +111,7 @@ def test_resolve_manifest_uri_accepts_short_hash() -> None:
         project_root, yaml_path = _make_project(Path(d))
         manifest_id, _ = commit_manifest(yaml_path, project_root)
         short = manifest_id[len(_SHA256_PREFIX):len(_SHA256_PREFIX) + 8]
-        resolved = resolve_manifest_uri(f'manifest://sha256:{short}', project_root)
+        resolved, _ = resolve_manifest_uri(f'manifest://sha256:{short}', project_root)
         assert resolved.exists()
 
 

--- a/tests/test_yaml_store.py
+++ b/tests/test_yaml_store.py
@@ -77,6 +77,18 @@ def test_commit_updates_index_json() -> None:
         assert index['manifests'][0]['name'] == 'test_experiment'
 
 
+def test_commit_recovers_from_corrupt_index() -> None:
+    with tempfile.TemporaryDirectory() as d:
+        project_root, yaml_path = _make_project(Path(d))
+        commit_manifest(yaml_path, project_root)
+        (project_root / 'manifests' / 'committed' / 'index.json').write_text('not valid json')
+        yaml_path2 = project_root / 'manifests' / 'examples' / 'test2.yaml'
+        yaml_path2.write_text(_SAMPLE_YAML + '\n# extra\n')
+        manifest_id2, _ = commit_manifest(yaml_path2, project_root)
+        index = json.loads((project_root / 'manifests' / 'committed' / 'index.json').read_text())
+        assert any(m['id'] == manifest_id2 for m in index['manifests'])
+
+
 def test_commit_repairs_index_when_missing() -> None:
     with tempfile.TemporaryDirectory() as d:
         project_root, yaml_path = _make_project(Path(d))
@@ -104,6 +116,17 @@ def test_resolve_manifest_uri_returns_path_and_project_root() -> None:
         resolved, returned_root = resolve_manifest_uri(uri, project_root)
         assert resolved.exists()
         assert returned_root == project_root
+
+
+def test_resolve_manifest_uri_rejects_malformed_hash() -> None:
+    with tempfile.TemporaryDirectory() as d:
+        project_root, _ = _make_project(Path(d))
+        with pytest.raises(ValueError, match='Malformed hash'):
+            resolve_manifest_uri('manifest://sha256:*', project_root)
+        with pytest.raises(ValueError, match='Malformed hash'):
+            resolve_manifest_uri('manifest://sha256:', project_root)
+        with pytest.raises(ValueError, match='Malformed hash'):
+            resolve_manifest_uri('manifest://sha256:' + 'a' * 65, project_root)
 
 
 def test_resolve_manifest_uri_rejects_missing_manifest() -> None:

--- a/tests/test_yaml_store.py
+++ b/tests/test_yaml_store.py
@@ -210,6 +210,17 @@ def test_commit_manifest_raises_when_yaml_is_not_a_dict() -> None:
             commit_manifest(list_yaml, project_root)
 
 
+def test_commit_manifest_raises_when_existing_committed_file_is_not_a_dict() -> None:
+    with tempfile.TemporaryDirectory() as d:
+        project_root, yaml_path = _make_project(Path(d))
+        manifest_id, _ = commit_manifest(yaml_path, project_root)
+        hex_hash = manifest_id[len(_SHA256_PREFIX):]
+        store = project_root / 'manifests' / 'committed'
+        (store / f'{hex_hash}.yaml').write_text('- corrupted\n- list\n', encoding='utf-8')
+        with pytest.raises(ValueError, match='expected a mapping'):
+            commit_manifest(yaml_path, project_root)
+
+
 def test_update_index_deduplicates_pre_existing_entries() -> None:
     with tempfile.TemporaryDirectory() as d:
         project_root, yaml_path = _make_project(Path(d))

--- a/tests/test_yaml_store.py
+++ b/tests/test_yaml_store.py
@@ -77,6 +77,25 @@ def test_commit_updates_index_json() -> None:
         assert index['manifests'][0]['name'] == 'test_experiment'
 
 
+def test_commit_repairs_index_when_missing() -> None:
+    with tempfile.TemporaryDirectory() as d:
+        project_root, yaml_path = _make_project(Path(d))
+        manifest_id, _ = commit_manifest(yaml_path, project_root)
+        (project_root / 'manifests' / 'committed' / 'index.json').unlink()
+        _, already_existed = commit_manifest(yaml_path, project_root)
+        assert already_existed
+        index = json.loads((project_root / 'manifests' / 'committed' / 'index.json').read_text())
+        assert any(m['id'] == manifest_id for m in index['manifests'])
+
+
+def test_commit_timestamps_are_utc() -> None:
+    with tempfile.TemporaryDirectory() as d:
+        project_root, yaml_path = _make_project(Path(d))
+        commit_manifest(yaml_path, project_root)
+        index = json.loads((project_root / 'manifests' / 'committed' / 'index.json').read_text())
+        assert index['manifests'][0]['committed_at'].endswith('Z')
+
+
 def test_resolve_manifest_uri_returns_path_and_project_root() -> None:
     with tempfile.TemporaryDirectory() as d:
         project_root, yaml_path = _make_project(Path(d))

--- a/tests/test_yaml_store.py
+++ b/tests/test_yaml_store.py
@@ -190,3 +190,21 @@ def test_resolve_manifest_uri_rejects_ambiguous_short_hash() -> None:
         (store / f'{clone_stem}.yaml').write_text(existing.read_text())
         with pytest.raises(ValueError, match='Ambiguous'):
             resolve_manifest_uri(f'manifest://sha256:{first_char}', project_root)
+
+
+def test_update_index_deduplicates_pre_existing_entries() -> None:
+    with tempfile.TemporaryDirectory() as d:
+        project_root, yaml_path = _make_project(Path(d))
+        manifest_id, _ = commit_manifest(yaml_path, project_root)
+        store = project_root / 'manifests' / 'committed'
+        index_path = store / 'index.json'
+        index = json.loads(index_path.read_text())
+        # manually inject a duplicate entry
+        index['manifests'].append(index['manifests'][0])
+        index_path.write_text(json.dumps(index))
+        assert len(json.loads(index_path.read_text())['manifests']) == 2
+        # re-committing the same YAML should deduplicate
+        commit_manifest(yaml_path, project_root)
+        result = json.loads(index_path.read_text())
+        ids = [m['id'] for m in result['manifests']]
+        assert ids.count(manifest_id) == 1

--- a/tests/test_yaml_store.py
+++ b/tests/test_yaml_store.py
@@ -2,7 +2,11 @@ import json
 import tempfile
 from pathlib import Path
 
+import pytest
+
+from limen.yaml.store import _SHA256_PREFIX
 from limen.yaml.store import commit_manifest
+from limen.yaml.store import resolve_manifest_uri
 
 
 _SAMPLE_YAML = '''\
@@ -39,7 +43,7 @@ def test_commit_stores_file_in_committed_dir() -> None:
     with tempfile.TemporaryDirectory() as d:
         project_root, yaml_path = _make_project(Path(d))
         manifest_id, _ = commit_manifest(yaml_path, project_root)
-        hex_hash = manifest_id.replace('sha256:', '')
+        hex_hash = manifest_id[len(_SHA256_PREFIX):]
         assert (project_root / 'manifests' / 'committed' / f'{hex_hash}.yaml').exists()
 
 
@@ -57,7 +61,7 @@ def test_commit_injects_lineage_section() -> None:
     with tempfile.TemporaryDirectory() as d:
         project_root, yaml_path = _make_project(Path(d))
         manifest_id, _ = commit_manifest(yaml_path, project_root)
-        hex_hash = manifest_id.replace('sha256:', '')
+        hex_hash = manifest_id[len(_SHA256_PREFIX):]
         committed = (project_root / 'manifests' / 'committed' / f'{hex_hash}.yaml').read_text()
         assert 'lineage:' in committed
         assert manifest_id in committed
@@ -71,3 +75,54 @@ def test_commit_updates_index_json() -> None:
         assert index['version'] == 1
         assert index['manifests'][0]['id'] == manifest_id
         assert index['manifests'][0]['name'] == 'test_experiment'
+
+
+def test_resolve_manifest_uri_returns_path() -> None:
+    with tempfile.TemporaryDirectory() as d:
+        project_root, yaml_path = _make_project(Path(d))
+        manifest_id, _ = commit_manifest(yaml_path, project_root)
+        uri = f'manifest://{manifest_id}'
+        resolved = resolve_manifest_uri(uri, project_root)
+        assert resolved.exists()
+
+
+def test_resolve_manifest_uri_rejects_missing_manifest() -> None:
+    with tempfile.TemporaryDirectory() as d:
+        project_root, _ = _make_project(Path(d))
+        with pytest.raises(ValueError, match='not found in store'):
+            resolve_manifest_uri('manifest://sha256:' + 'a' * 64, project_root)
+
+
+def test_resolve_manifest_uri_rejects_tampered_lineage() -> None:
+    with tempfile.TemporaryDirectory() as d:
+        project_root, yaml_path = _make_project(Path(d))
+        manifest_id, _ = commit_manifest(yaml_path, project_root)
+        hex_hash = manifest_id[len(_SHA256_PREFIX):]
+        committed_path = project_root / 'manifests' / 'committed' / f'{hex_hash}.yaml'
+        tampered = committed_path.read_text().replace(manifest_id, 'sha256:' + 'b' * 64)
+        committed_path.write_text(tampered)
+        with pytest.raises(ValueError, match='Integrity check failed'):
+            resolve_manifest_uri(f'manifest://{manifest_id}', project_root)
+
+
+def test_resolve_manifest_uri_accepts_short_hash() -> None:
+    with tempfile.TemporaryDirectory() as d:
+        project_root, yaml_path = _make_project(Path(d))
+        manifest_id, _ = commit_manifest(yaml_path, project_root)
+        short = manifest_id[len(_SHA256_PREFIX):len(_SHA256_PREFIX) + 8]
+        resolved = resolve_manifest_uri(f'manifest://sha256:{short}', project_root)
+        assert resolved.exists()
+
+
+def test_resolve_manifest_uri_rejects_ambiguous_short_hash() -> None:
+    with tempfile.TemporaryDirectory() as d:
+        project_root, yaml_path = _make_project(Path(d))
+        commit_manifest(yaml_path, project_root)
+        store = project_root / 'manifests' / 'committed'
+        existing = next(store.glob('*.yaml'))
+        first_char = existing.stem[0]
+        # plant a second file starting with the same char but a different full hash
+        clone_stem = first_char + ('0' * 63 if existing.stem != first_char + '0' * 63 else 'f' * 63)
+        (store / f'{clone_stem}.yaml').write_text(existing.read_text())
+        with pytest.raises(ValueError, match='Ambiguous'):
+            resolve_manifest_uri(f'manifest://sha256:{first_char}', project_root)

--- a/tests/test_yaml_store.py
+++ b/tests/test_yaml_store.py
@@ -192,6 +192,24 @@ def test_resolve_manifest_uri_rejects_ambiguous_short_hash() -> None:
             resolve_manifest_uri(f'manifest://sha256:{first_char}', project_root)
 
 
+def test_commit_manifest_raises_on_invalid_yaml_content() -> None:
+    with tempfile.TemporaryDirectory() as d:
+        project_root, _ = _make_project(Path(d))
+        bad_yaml = project_root / 'bad.yaml'
+        bad_yaml.write_text(': invalid: yaml: {', encoding='utf-8')
+        with pytest.raises(ValueError, match='Cannot parse YAML'):
+            commit_manifest(bad_yaml, project_root)
+
+
+def test_commit_manifest_raises_when_yaml_is_not_a_dict() -> None:
+    with tempfile.TemporaryDirectory() as d:
+        project_root, _ = _make_project(Path(d))
+        list_yaml = project_root / 'list.yaml'
+        list_yaml.write_text('- item1\n- item2\n', encoding='utf-8')
+        with pytest.raises(ValueError, match='expected a mapping'):
+            commit_manifest(list_yaml, project_root)
+
+
 def test_update_index_deduplicates_pre_existing_entries() -> None:
     with tempfile.TemporaryDirectory() as d:
         project_root, yaml_path = _make_project(Path(d))

--- a/tests/test_yaml_store.py
+++ b/tests/test_yaml_store.py
@@ -118,6 +118,27 @@ def test_resolve_manifest_uri_returns_path_and_project_root() -> None:
         assert returned_root == project_root
 
 
+def test_commit_recovers_from_structurally_invalid_index() -> None:
+    with tempfile.TemporaryDirectory() as d:
+        project_root, yaml_path = _make_project(Path(d))
+        index_path = project_root / 'manifests' / 'committed' / 'index.json'
+        index_path.write_text(json.dumps([1, 2, 3]))
+        manifest_id, _ = commit_manifest(yaml_path, project_root)
+        index = json.loads(index_path.read_text())
+        assert any(m['id'] == manifest_id for m in index['manifests'])
+
+
+def test_resolve_manifest_uri_raises_on_corrupt_manifest_file() -> None:
+    with tempfile.TemporaryDirectory() as d:
+        project_root, yaml_path = _make_project(Path(d))
+        manifest_id, _ = commit_manifest(yaml_path, project_root)
+        hex_hash = manifest_id[len(_SHA256_PREFIX):]
+        committed_path = project_root / 'manifests' / 'committed' / f'{hex_hash}.yaml'
+        committed_path.write_text(': invalid: yaml: {{{')
+        with pytest.raises(ValueError, match='Cannot read manifest'):
+            resolve_manifest_uri(f'manifest://{manifest_id}', project_root)
+
+
 def test_resolve_manifest_uri_rejects_malformed_hash() -> None:
     with tempfile.TemporaryDirectory() as d:
         project_root, _ = _make_project(Path(d))

--- a/tests/test_yaml_store.py
+++ b/tests/test_yaml_store.py
@@ -1,0 +1,73 @@
+import json
+import tempfile
+from pathlib import Path
+
+from limen.yaml.store import commit_manifest
+
+
+_SAMPLE_YAML = '''\
+schema_version: "1.0"
+metadata:
+  name: test_experiment
+  mode: development
+sfd:
+  manifest:
+    type: ml
+    data_source:
+      method: limen.data.get_spot_klines
+    reference_architecture: limen.sfd.reference_architecture.logreg_binary.logreg_binary
+    target:
+      name: target
+      class: limen.targets.QuantileBinaryTarget
+  params:
+    lookback: [12, 24]
+uel:
+  n_permutations: 4
+'''
+
+
+def _make_project(tmp: Path) -> tuple[Path, Path]:
+    (tmp / 'limen.toml').write_text('[store]\nbackup_remote = ""\n')
+    (tmp / 'manifests' / 'committed').mkdir(parents=True)
+    yaml_path = tmp / 'manifests' / 'examples' / 'test.yaml'
+    yaml_path.parent.mkdir(parents=True)
+    yaml_path.write_text(_SAMPLE_YAML)
+    return tmp, yaml_path
+
+
+def test_commit_stores_file_in_committed_dir() -> None:
+    with tempfile.TemporaryDirectory() as d:
+        project_root, yaml_path = _make_project(Path(d))
+        manifest_id, _ = commit_manifest(yaml_path, project_root)
+        hex_hash = manifest_id.replace('sha256:', '')
+        assert (project_root / 'manifests' / 'committed' / f'{hex_hash}.yaml').exists()
+
+
+def test_commit_is_idempotent() -> None:
+    with tempfile.TemporaryDirectory() as d:
+        project_root, yaml_path = _make_project(Path(d))
+        id1, existed1 = commit_manifest(yaml_path, project_root)
+        id2, existed2 = commit_manifest(yaml_path, project_root)
+        assert id1 == id2
+        assert not existed1
+        assert existed2
+
+
+def test_commit_injects_lineage_section() -> None:
+    with tempfile.TemporaryDirectory() as d:
+        project_root, yaml_path = _make_project(Path(d))
+        manifest_id, _ = commit_manifest(yaml_path, project_root)
+        hex_hash = manifest_id.replace('sha256:', '')
+        committed = (project_root / 'manifests' / 'committed' / f'{hex_hash}.yaml').read_text()
+        assert 'lineage:' in committed
+        assert manifest_id in committed
+
+
+def test_commit_updates_index_json() -> None:
+    with tempfile.TemporaryDirectory() as d:
+        project_root, yaml_path = _make_project(Path(d))
+        manifest_id, _ = commit_manifest(yaml_path, project_root)
+        index = json.loads((project_root / 'manifests' / 'committed' / 'index.json').read_text())
+        assert index['version'] == 1
+        assert index['manifests'][0]['id'] == manifest_id
+        assert index['manifests'][0]['name'] == 'test_experiment'


### PR DESCRIPTION
**NOTE:** The author must always **first review the PR themselves**, before requesting review from others, that means carefully having reviewed the full diff in GitHub.

## What does this PR change?

- Add `limen new <project-name>` CLI command — scaffolds a new Limen project by cloning the official project template and optionally setting a backup remote
- Add `limen commit <yaml>` CLI command — content-addresses a YAML manifest into `manifests/committed/`, injects a `lineage` block, updates `index.json`, and git-commits the store; gates on `metadata.mode: production`
- Add `limen ls` CLI command — lists all committed manifests with copy-pasteable `manifest://sha256:<short>` URIs
- Add `manifest://sha256:<hex>` URI support to `limen run` — resolves a committed manifest by full or unambiguous short hash, verifies `lineage.id` integrity, and routes results to `results/<short_id>/<timestamp>/`
- Route development-mode results to `results/dev/` (gitignored in project template) and production-mode results to `results/`
- Add `limen/yaml/config.py` with `find_project_root()`, `read_limen_toml()`, and `get_store_path()`
- Add `limen/cli/git_utils.py` with `git_executable()` and `git_add_and_commit()`

Implements cli utils for manifest storage  #506  

## Checklist

- [x] I have reviewed full diff in “Files changed”
- [x] I left no unnecessary files in the changes
- [x] I ran `python tests/run.py` locally without errors (where applicable)
- [ ] I updated `/docs` (if behavior/API/config/user/etc changed)
- [x] I added and/or updated docstrings as per [Writing Docstrings](https://github.com/Vaquum/Limen/blob/main/docs/Developer/Writing-Docstrings.md) (for any changed public functions/classes)
- [x] I updated CHANGELOG.md (unless only docs or other non-code aspect was changed)
- [x] I updated pyproject.toml (unless only docs or other non-code aspect was changed)
- [x] I added and/or updated tests (if behavior changed or new code paths added)
- [x] I validated changes manually
- [x] I validated changes with LLM
- [x] I removed any extraneous examples/comments
- [x] I linked issue to auto-close on merge (e.g., “Fixes #123”) when applicable
