### PR TITLE
refactor: sensor inference support with calibration-aware Trainer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1011,10 +1011,12 @@ Note: add all new changelog entries to the bottom of this file.
 
 ## v3.14.0 on 2nd of June, 2026
 
-- Add `fit_calibrator(model, config, x_val, y_val)` to `limen/calibration/pipeline.py` and export from `limen.calibration` — separates the fit step from the apply step so calibrators can be stored and reused
-- Fix calibration at inference: `LogRegBinary` and `TabPFNBinary` now store the fitted calibrator on first `predict()` call and reuse it on subsequent calls, enabling sensor inference without validation data
-- Reset stored calibrator state when `train()` is called again on an existing model instance, preventing stale-calibrator bugs on reuse
-- Add `random_state` parameter to `RandomBinaryTarget` for reproducible label generation across training and evaluation
-- Fix `test_xgboost_inline_and_post_backtest_metrics_match`: use NaN-aware comparison (`math.isnan`) consistent with the logreg equivalent
-- Add e2e integration test covering the full experiment loop → Trainer → Sensor pipeline with three inference window sizes per sensor
-- Remove "Pass 1 / Pass 2" terminology from Trainer docstrings and documentation; there is only one training pass
+- Refactor `Trainer` to a single training pass: drop the second all-data retraining run; the validated training-run model is promoted directly to a `Sensor`; enforce YAML-only experiment input
+- Add `sensor_input_prep` to `MLManifest` — the canonical preparation step for sensor inference: applies fitted scaler/PCA, guards against bars inside the training window, and enforces indicator and decoder lookback requirements
+- Rewrite `Sensor` with a YAML-only constructor; `predict()` and `predict_all()` both wrap `sensor_input_prep` so feature preparation is never done outside the sensor
+- Add `Sensor.predict_all(raw_klines)` — returns one `BarPrediction` per input bar with `reason` set for warm-up and inside-training-window bars; valid bars carry `prediction` and `probability`
+- Add `decoder_lookback` to the YAML schema, validator, compiler, and `MLManifest` for architectures that require a multi-bar inference window
+- Fix calibration at inference: `LogRegBinary` and `TabPFNBinary` fit the calibrator once during training evaluation and store it on the model; subsequent sensor inference calls reuse the stored calibrator without requiring validation data
+- Add `fit_calibrator` to `limen.calibration` as a public API separating the calibrator fit step from the apply step
+- Add `random_state` parameter to `RandomBinaryTarget` for reproducible label generation
+- Remove split_config percentage-based splits from the YAML layer; all experiments use explicit `split_dates`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1012,10 +1012,10 @@ Note: add all new changelog entries to the bottom of this file.
 ## v3.14.0 on 2nd of June, 2026
 
 - Refactor `Trainer` to a single training pass: drop the second all-data retraining run; the validated training-run model is promoted directly to a `Sensor`; enforce YAML-only experiment input
-- Add `sensor_input_prep` to `MLManifest` — the canonical preparation step for sensor inference: applies fitted scaler/PCA, guards against bars inside the training window, and enforces indicator and decoder lookback requirements
-- Rewrite `Sensor` with a YAML-only constructor; `predict()` and `predict_all()` both wrap `sensor_input_prep` so feature preparation is never done outside the sensor
-- Add `Sensor.predict_all(raw_klines)` — returns one `BarPrediction` per input bar with `reason` set for warm-up and inside-training-window bars; valid bars carry `prediction` and `probability`
-- Add `decoder_lookback` to the YAML schema, validator, compiler, and `MLManifest` for architectures that require a multi-bar inference window
+- Add `sensor_input_prep` to `MLManifest` — the canonical preparation step for sensor inference: applies fitted scaler/PCA, drops ablated features, and preserves null rows so datetime alignment is maintained
+- Rewrite `Sensor` with a YAML-only constructor; `predict()` and `predict_all()` both wrap `sensor_input_prep` so feature preparation is never done outside the sensor; training-window and lookback guards live in the sensor methods
+- Add `Sensor.predict_all(raw_klines)` — returns one `BarPrediction` per input bar with `reason` set for warm-up, inside-training-window, and null-features bars; valid bars carry `prediction` and `probability`
+- Add `decoder_lookback` to the YAML schema, validator, compiler, and `MLManifest`; only `decoder_lookback: 1` (the default) is currently supported — values greater than 1 are rejected at validation time
 - Fix calibration at inference: `LogRegBinary` and `TabPFNBinary` fit the calibrator once during training evaluation and store it on the model; subsequent sensor inference calls reuse the stored calibrator without requiring validation data
 - Add `fit_calibrator` to `limen.calibration` as a public API separating the calibrator fit step from the apply step
 - Add `random_state` parameter to `RandomBinaryTarget` for reproducible label generation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1008,3 +1008,13 @@ Note: add all new changelog entries to the bottom of this file.
 - Add `limen/yaml/config.py` with `find_project_root()`, `read_limen_toml()`, and `get_store_path()`
 - Add `limen/cli/git_utils.py` with `git_executable()` and `git_add_and_commit()`
 
+
+## v3.14.0 on 2nd of June, 2026
+
+- Add `fit_calibrator(model, config, x_val, y_val)` to `limen/calibration/pipeline.py` and export from `limen.calibration` — separates the fit step from the apply step so calibrators can be stored and reused
+- Fix calibration at inference: `LogRegBinary` and `TabPFNBinary` now store the fitted calibrator on first `predict()` call and reuse it on subsequent calls, enabling sensor inference without validation data
+- Reset stored calibrator state when `train()` is called again on an existing model instance, preventing stale-calibrator bugs on reuse
+- Add `random_state` parameter to `RandomBinaryTarget` for reproducible label generation across training and evaluation
+- Fix `test_xgboost_inline_and_post_backtest_metrics_match`: use NaN-aware comparison (`math.isnan`) consistent with the logreg equivalent
+- Add e2e integration test covering the full experiment loop → Trainer → Sensor pipeline with three inference window sizes per sensor
+- Remove "Pass 1 / Pass 2" terminology from Trainer docstrings and documentation; there is only one training pass

--- a/docs/Calibration.md
+++ b/docs/Calibration.md
@@ -173,9 +173,15 @@ NOTE: `predict()` only includes these keys when calibration is active for the ro
 
 The optimizer returns the `default_threshold` with score `0.0` when every candidate threshold predicts all negatives.
 
+## Calibration at Inference
+
+When a calibrated model is promoted to a `Sensor`, the calibrator is fitted once during training evaluation (on validation data) and stored inside the model instance. Subsequent `predict()` calls — including all sensor inference calls — reuse the stored calibrator without needing `x_val` or `y_val`. Calibrated sensors therefore work identically to uncalibrated ones from the caller's perspective: pass `x_test`, receive predictions.
+
+`fit_calibrator` is the low-level function that encapsulates this fit step. It is called internally by `LogRegBinary.predict()` and `TabPFNBinary.predict()` on first use, and is also available as a public API if you need to fit a calibrator outside the standard pipeline.
+
 ## Where To Look
 
-- `limen/calibration/` — `sklearn_probability_calibrator`, `grid_threshold_optimizer`, `apply_calibrated_predict`, `CalibratorProtocol`, `ThresholdOptimizerProtocol`
+- `limen/calibration/` — `fit_calibrator`, `sklearn_probability_calibrator`, `grid_threshold_optimizer`, `apply_calibrated_predict`, `CalibratorProtocol`, `ThresholdOptimizerProtocol`
 - `limen.experiment.CalibrationConfig` — the resolved config dataclass injected into the architecture
 - `CalibrationBuilder` — the fluent builder returned by `MLManifest.with_calibration()`; not a public import, obtain it only via the fluent chain
 

--- a/docs/Trainer.md
+++ b/docs/Trainer.md
@@ -18,21 +18,8 @@ If `results.csv` is also present, Trainer validates the retrained metrics agains
 ## Prerequisites
 
 - the experiment must have been created with `experiment_dir=...`
-- the SFD must be manifest-driven
-- the experiment directory must be trusted
-
-The trust warning matters because Trainer imports the SFD module path stored in `metadata.json` and executes its top-level code.
-
-## SFD Module Resolution
-
-`Trainer.__init__` reads `metadata.json["sfd_module"]` and resolves it in two stages:
-
-1. **Experiment-local file** — if `<experiment_dir>/<sfd_module>.py` exists, it is loaded via `importlib.util.spec_from_file_location` + `module_from_spec`. The SFD module is **not** added to `sys.path` and is **not** registered in `sys.modules` under its bare name, so each Trainer construction loads the SFD freshly without polluting global import state. This is the path used by self-contained experiment bundles produced by tools like Praxis's `trainer_prep.py`.
-2. **`importlib.import_module` fallback** — if no experiment-local file is present, the name is passed to `importlib.import_module` and resolved against `sys.path` like any other Python import. This is the legacy path used by experiments referencing built-in SFDs by fully-qualified package path (e.g. `limen.sfd.foundational_sfd.logreg_binary`).
-
-Names are validated up-front: `sfd_module` must be a dotted sequence of valid Python identifiers (`name.split('.')` and `str.isidentifier()` per segment). Anything else — `..`, `/`, `\`, leading/trailing dots, empty segments — raises `ValueError` before either branch runs, so a malicious `metadata.json` cannot path-traverse out of `experiment_dir` via the local-file branch.
-
-The `import_module` fallback still trusts any module name that resolves on `sys.path`, including arbitrary site-packages modules. That residual surface is documented as TD-001 in [`docs/TechnicalDebt.md`](TechnicalDebt.md) and should be tightened (e.g. allowlisted) before any live-trading deploy where the upstream bundle pipeline is not under the same trust boundary as the deploy operator.
+- the experiment must be YAML-based (created via `limen run`)
+- the SFD must be a manifest-driven ML architecture (rule-based architectures are not supported)
 
 ## Typical Workflow
 
@@ -64,9 +51,9 @@ Experiment runs are usually done on train/validation/test splits. Promotion is d
 
 Trainer handles that transition cleanly by:
 
-- reconstructing the original experiment logic
-- validating that the pipeline still reproduces the logged round
-- retraining on all data with `split_config=(1,0,0)`
+- reconstructing the original experiment logic from `yaml_reference`
+- validating that the pipeline still reproduces the logged round metrics
+- wrapping the validated model in a `Sensor` ready for inference
 
 ## Training and Validation
 
@@ -157,13 +144,10 @@ Raises:
 
 A `Sensor` is the promoted form of a trained round.
 
-Each sensor stores:
+Each sensor exposes:
 
-- `permutation_id`
-- `model`
-- `round_params`
-- `metadata`
-- `results`
+- `permutation_id` — round ID from the experiment log; required for cohort binding
+- `round_params` — parameter values used for this permutation
 
 ### Example
 
@@ -172,15 +156,14 @@ sensor = sensors[0]
 
 print(sensor.permutation_id)
 print(sensor.round_params)
-print(sensor.metadata['sfd_module'])
 
-pred = sensor.predict({'x_test': live_features})
+pred = sensor.predict(raw_klines)
 ```
 
 Sensors are also callable:
 
 ```python
-pred = sensor({'x_test': live_features})
+pred = sensor(raw_klines)
 ```
 
 ### What `predict()` expects
@@ -191,22 +174,9 @@ All reference models need only `x_test` for inference. Calibrated models (those 
 
 Trainer uses:
 
-- `metadata.json` to discover the SFD module and experiment metadata
-- `round_data.jsonl` to load `round_params`, stored predictions, and alignment metadata
-- `results.csv` when available for metric validation
-
-On a live local artifact-rich run in this repo, `metadata.json` contained:
-
-- `sfd_module`
-- `limen_version`
-- `created_at`
-
-and `round_data.jsonl` contained entries with:
-
-- `round_id`
-- `round_params`
-- `preds`
-- `alignment`
+- `metadata.json` — reads `yaml_reference` to reconstruct the manifest; `sfd_module` may be present in older experiments but is not used by the YAML-only Trainer
+- `round_data.jsonl` — loads `round_params` for each permutation
+- `results.csv` — when available, validates retrained metrics against the original experiment log
 
 ## Scope Note
 

--- a/docs/Trainer.md
+++ b/docs/Trainer.md
@@ -13,7 +13,7 @@ At minimum, the directory must contain:
 - `metadata.json`
 - `round_data.jsonl`
 
-If `results.csv` is also present, Trainer performs Pass 1 validation against the original metrics. If it is missing, Trainer skips validation and proceeds directly to retraining.
+If `results.csv` is also present, Trainer validates the retrained metrics against the original experiment log. If it is missing, Trainer skips validation and proceeds directly to creating sensors.
 
 ## Prerequisites
 
@@ -68,16 +68,14 @@ Trainer handles that transition cleanly by:
 - validating that the pipeline still reproduces the logged round
 - retraining on all data with `split_config=(1,0,0)`
 
-## Two-Pass Training
-
-### Pass 1: Validation
+## Training and Validation
 
 Trainer reruns:
 
 - `manifest.prepare_data(...)`
 - `manifest.run_model(...)`
 
-with the original round parameters and compares the resulting metrics against the original experiment log.
+with the original round parameters and wraps the resulting model in a `Sensor`. If `results.csv` is present, it also compares the resulting metrics against the original experiment log.
 
 If the model is deterministic, validation expects an exact match within a very small float tolerance. If the model is stochastic, Trainer uses a looser scaled tolerance.
 
@@ -93,18 +91,6 @@ except ReconstructionError as e:
 ```
 
 This is Limen's guard against pipeline drift.
-
-### Pass 2: Retraining
-
-After validation, Trainer deep-copies the manifest with:
-
-```python
-split_config=(1, 0, 0)
-```
-
-and retrains the resolved `ReferenceModel` on the full dataset.
-
-That trained model is then wrapped in a `Sensor`.
 
 ## Deterministic Vs Stochastic Models
 
@@ -130,8 +116,7 @@ That means the promotion stack depends on the [Reference Architecture](Reference
 
 On a live local `logreg_binary` promotion run in this repo:
 
-- Pass 1 validation completed with `validation_mismatches == []`
-- the promoted `Sensor.results` included task metrics plus `backtest_*` keys
+- validation completed with no metric mismatches
 - `Sensor.predict()` returned `_preds` and `_probs`
 - the promoted sensor produced predictions for `884` test bars
 
@@ -200,31 +185,7 @@ pred = sensor({'x_test': live_features})
 
 ### What `predict()` expects
 
-Most reference models only need:
-
-- `x_test`
-
-Some models may require more. The requirement comes from the underlying model class, not from the `Sensor` wrapper itself.
-
-### What `results` contains
-
-`Sensor.results` comes from the Pass 1 evaluation result, not from a stripped-down inference-only payload.
-
-In a live local logreg promotion run in this repo, the stored keys included:
-
-- `_preds`
-- `accuracy`
-- `auc`
-- `backtest_edge_per_signal_bps_p50`
-- `backtest_trade_pnl_net_bps_p50`
-- `backtest_cvar_95_return_bps`
-
-When the promoted round used calibration, `results` also includes:
-
-- `optimal_threshold` — the threshold chosen during the validation pass
-- `val_score` — the metric score at that threshold
-
-That is why `Sensor.results` is useful for provenance and review, while `Sensor.predict()` is the smaller live inference surface.
+All reference models need only `x_test` for inference. Calibrated models (those trained with `use_calibration: true`) store the fitted calibrator internally during the training evaluation step; subsequent `predict()` calls reuse it without needing `x_val` or `y_val`. The caller never needs to supply validation data at inference time.
 
 ## What Trainer Reads From Disk
 
@@ -232,7 +193,7 @@ Trainer uses:
 
 - `metadata.json` to discover the SFD module and experiment metadata
 - `round_data.jsonl` to load `round_params`, stored predictions, and alignment metadata
-- `results.csv` when available for Pass 1 metric validation
+- `results.csv` when available for metric validation
 
 On a live local artifact-rich run in this repo, `metadata.json` contained:
 

--- a/limen/calibration/__init__.py
+++ b/limen/calibration/__init__.py
@@ -1,6 +1,7 @@
 from limen.calibration.pipeline import CalibratorProtocol
 from limen.calibration.pipeline import ThresholdOptimizerProtocol
 from limen.calibration.pipeline import apply_calibrated_predict
+from limen.calibration.pipeline import fit_calibrator
 from limen.calibration.probability import sklearn_probability_calibrator
 from limen.calibration.threshold import grid_threshold_optimizer
 
@@ -8,6 +9,7 @@ __all__ = [
     'CalibratorProtocol',
     'ThresholdOptimizerProtocol',
     'apply_calibrated_predict',
+    'fit_calibrator',
     'grid_threshold_optimizer',
     'sklearn_probability_calibrator',
 ]

--- a/limen/calibration/pipeline.py
+++ b/limen/calibration/pipeline.py
@@ -38,7 +38,7 @@ def fit_calibrator(model: Any,
     Fit calibrator on validation data.
 
     Args:
-        model: Fitted classifier with predict_proba method
+        model (Any): Fitted classifier with predict_proba method
         config (CalibrationConfig): Resolved calibration configuration
         x_val (np.ndarray): Validation features
         y_val (np.ndarray): Validation labels

--- a/limen/calibration/pipeline.py
+++ b/limen/calibration/pipeline.py
@@ -29,6 +29,37 @@ class ThresholdOptimizerProtocol(Protocol):
         ...
 
 
+def fit_calibrator(model: Any,
+                   config: 'CalibrationConfig',
+                   x_val: np.ndarray,
+                   y_val: np.ndarray) -> tuple[Any, float, float | None]:
+
+    '''
+    Fit calibrator on validation data.
+
+    Args:
+        model: Fitted classifier with predict_proba method
+        config (CalibrationConfig): Resolved calibration configuration
+        x_val (np.ndarray): Validation features
+        y_val (np.ndarray): Validation labels
+
+    Returns:
+        tuple: (fitted_calibrator, optimal_threshold, val_score)
+            val_score is None when no threshold_func is configured
+    '''
+
+    fitted = (config.calibration_func(model, x_val, y_val, **config.calibration_params)
+              if config.calibration_func is not None else model)
+    val_proba = fitted.predict_proba(x_val)[:, 1]
+
+    if config.threshold_func is not None:
+        threshold, score = config.threshold_func(y_val, val_proba, **config.threshold_params)
+    else:
+        threshold, score = 0.5, None
+
+    return fitted, threshold, score
+
+
 def apply_calibrated_predict(model: Any,
                               config: 'CalibrationConfig',
                               data: dict[str, Any]) -> dict:
@@ -46,15 +77,7 @@ def apply_calibrated_predict(model: Any,
             (val_score is None when no threshold_func is configured)
     '''
 
-    fitted = (config.calibration_func(model, data['x_val'], data['y_val'], **config.calibration_params)
-              if config.calibration_func is not None else model)
-    val_proba = fitted.predict_proba(data['x_val'])[:, 1]
+    fitted, threshold, score = fit_calibrator(model, config, data['x_val'], data['y_val'])
     test_proba = fitted.predict_proba(data['x_test'])[:, 1]
-
-    if config.threshold_func is not None:
-        threshold, score = config.threshold_func(data['y_val'], val_proba, **config.threshold_params)
-    else:
-        threshold, score = 0.5, None
-
     preds = (test_proba >= threshold).astype(np.int8)
     return {'_preds': preds, '_probs': test_proba, 'optimal_threshold': threshold, 'val_score': score}

--- a/limen/experiment/experiment_core.py
+++ b/limen/experiment/experiment_core.py
@@ -274,6 +274,11 @@ class UniversalExperimentLoop:
                     self.preds.append(round_results['_preds'])
                 round_results.pop('_preds')
 
+            if '_model' in round_results:
+                if retain_round_artifacts:
+                    self.models.append(round_results['_model'])
+                round_results.pop('_model')
+
             if retain_round_artifacts and '_scaler' in data_dict:
                 self.scalers.append(data_dict['_scaler'])
 

--- a/limen/experiment/experiment_core.py
+++ b/limen/experiment/experiment_core.py
@@ -526,6 +526,10 @@ class UniversalExperimentLoop:
                 models = round_results.pop('models')
                 if post_processing:
                     self.models.append(models)
+            if '_model' in round_results:
+                model = round_results.pop('_model')
+                if post_processing:
+                    self.models.append(model)
             current_preds = round_results.pop('_preds', None)
             if current_preds is None:
                 current_preds = []

--- a/limen/experiment/manifest_core.py
+++ b/limen/experiment/manifest_core.py
@@ -1307,14 +1307,11 @@ def _count_leading_nulls(data: pl.DataFrame) -> int:
     if not feature_cols:
         return 0
     null_mask = pl.any_horizontal([pl.col(c).is_null() for c in feature_cols])
-    has_null = data.select(null_mask.alias('_has_null'))['_has_null'].to_list()
-    count = 0
-    for val in has_null:
-        if val:
-            count += 1
-        else:
-            break
-    return count
+    has_null = data.select(null_mask.alias('_has_null'))['_has_null'].cast(pl.UInt8)
+    first_valid = has_null.arg_min()
+    if first_valid is None or bool(has_null[first_valid]):
+        return len(data)
+    return int(first_valid)
 
 
 def _apply_sensor_pca(

--- a/limen/experiment/manifest_core.py
+++ b/limen/experiment/manifest_core.py
@@ -777,6 +777,7 @@ class MLManifest(Manifest):
     pca_compression_config: PCACompressionConfig | None = None
     data_dict_extension: Callable = None
     prediction_calibration_config: CalibrationConfig | None = None
+    decoder_lookback: int = 1
 
     def set_scaler(self, transform_class: Any, param_name: str = '_scaler') -> 'MLManifest':
 

--- a/limen/experiment/manifest_core.py
+++ b/limen/experiment/manifest_core.py
@@ -1032,6 +1032,50 @@ class MLManifest(Manifest):
                 model_kwargs['prediction_calibration_config'] = config
         return self.architecture_function(data, **model_kwargs)
 
+    def sensor_input_prep(
+            self,
+            raw_klines: pl.DataFrame,
+            fitted_params: dict[str, Any],
+            round_params: dict[str, Any],
+    ) -> tuple[pl.DataFrame, int]:
+
+        '''
+        Prepare raw klines for live inference without splitting or dropping nulls.
+
+        Args:
+            raw_klines (pl.DataFrame): Raw klines covering at least indicator warm-up + decoder window
+            fitted_params (dict[str, Any]): Scaler and PCA state stored from training
+            round_params (dict[str, Any]): Parameter values from the winning round
+
+        Returns:
+            tuple[pl.DataFrame, int]: Prepared feature DataFrame and indicator_lookback count
+
+        NOTE: Does not call drop_nulls. Leading null rows represent indicator warm-up bars.
+        The returned indicator_lookback count is the number of leading null rows so the
+        caller can determine which bars are valid for prediction.
+        '''
+
+        _, data = _process_bars(self, raw_klines, round_params)
+
+        lazy = data.lazy()
+        lazy = _apply_feature_transforms(self, lazy, round_params)
+        data = lazy.collect()
+
+        dropped_features = round_params.get('_dropped_features') or []
+        if dropped_features:
+            data = data.drop([c for c in dropped_features if c in data.columns])
+
+        data = data.fill_nan(None)
+        indicator_lookback = _count_leading_nulls(data)
+
+        all_fitted_params = dict(fitted_params)
+        data, _ = _apply_scaler(self, data, round_params, all_fitted_params, is_training=False)
+        data = data.fill_nan(None)
+
+        data = _apply_sensor_pca(self, data, round_params, all_fitted_params)
+
+        return data, indicator_lookback
+
 
 @dataclass
 class RuleBasedManifest(Manifest):
@@ -1255,6 +1299,68 @@ def _is_group_active(group: str, round_params: dict[str, Any]) -> bool:
         )
 
     return group in feature_groups.split('|')
+
+
+def _count_leading_nulls(data: pl.DataFrame) -> int:
+
+    feature_cols = [c for c in data.columns if c != 'datetime']
+    if not feature_cols:
+        return 0
+    null_mask = pl.any_horizontal([pl.col(c).is_null() for c in feature_cols])
+    has_null = data.select(null_mask.alias('_has_null'))['_has_null'].to_list()
+    count = 0
+    for val in has_null:
+        if val:
+            count += 1
+        else:
+            break
+    return count
+
+
+def _apply_sensor_pca(
+        manifest: 'MLManifest',
+        data: pl.DataFrame,
+        round_params: dict[str, Any],
+        all_fitted_params: dict[str, Any],
+) -> pl.DataFrame:
+
+    config = manifest.pca_compression_config
+    if config is None:
+        return data
+
+    enabled = round_params.get(config.enabled_param, False)
+    if not enabled:
+        return data
+
+    pca = all_fitted_params.get('_pca')
+    input_feature_names = all_fitted_params.get('_pca_input_feature_names')
+    component_cols = all_fitted_params.get('_pca_feature_names')
+
+    if pca is None or input_feature_names is None or component_cols is None:
+        raise ValueError(
+            'PCA was not fitted — fitted_params missing _pca, '
+            '_pca_input_feature_names, or _pca_feature_names'
+        )
+
+    target_col = manifest.target_column
+    null_mask = data.select(
+        pl.any_horizontal([pl.col(c).is_null() for c in input_feature_names]).alias('_is_null')
+    )['_is_null'].to_list()
+    valid_indices = [i for i, is_null in enumerate(null_mask) if not is_null]
+
+    n_rows = len(data)
+    component_arrays: dict[str, list] = {col: [None] * n_rows for col in component_cols}
+    if valid_indices:
+        valid_np = data[valid_indices].select(input_feature_names).to_numpy()
+        components = pca.transform(valid_np)
+        for arr_idx, row_idx in enumerate(valid_indices):
+            for col_idx, col in enumerate(component_cols):
+                component_arrays[col][row_idx] = float(components[arr_idx, col_idx])
+
+    out = data.select('datetime').hstack(pl.DataFrame(component_arrays))
+    if target_col and target_col in data.columns:
+        out = out.with_columns(data[target_col])
+    return out
 
 
 def _apply_feature_ablation(

--- a/limen/experiment/manifest_core.py
+++ b/limen/experiment/manifest_core.py
@@ -1679,6 +1679,7 @@ def _finalize_to_data_dict(
         data_dict[param_name] = param_value
 
     data_dict['_feature_names'] = cols
+    data_dict['_fitted_params'] = dict(fitted_params)
 
     if price_data_for_backtest is not None:
         data_dict['price_data_for_backtest'] = price_data_for_backtest

--- a/limen/experiment/trainer/errors.py
+++ b/limen/experiment/trainer/errors.py
@@ -1,3 +1,3 @@
 class ReconstructionError(Exception):
 
-    '''Raised when Pass 1 validation detects metric deviation beyond tolerance.'''
+    '''Raised when metric validation detects deviation beyond tolerance.'''

--- a/limen/experiment/trainer/sensor.py
+++ b/limen/experiment/trainer/sensor.py
@@ -19,7 +19,9 @@ class BarPrediction:
     datetime: Any
     prediction: int | float | None
     probability: float | None
-    reason: str | None  # None = valid prediction; 'warm-up', 'inside-training-window' = invalid
+    reason: str | None  # None = valid prediction; 'warm-up' = leading null rows from indicator lookback;
+                        # 'inside-training-window' = bar falls within the train/test window;
+                        # 'null-features' = mid-stream null feature values (data gap or transform anomaly)
 
 
 class Sensor:
@@ -120,7 +122,7 @@ class Sensor:
         feature_cols = [c for c in data.columns if c != 'datetime']
         last_row = data[-1]
         if any(last_row[c][0] is None for c in feature_cols):
-            raise ValueError('Last bar is a warm-up bar — cannot predict')
+            raise ValueError('Last bar has null feature values — cannot predict')
 
         x = np.array(last_row.select(feature_cols).row(0), dtype=float).reshape(1, -1)
         pred_result = self._model.predict({'x_test': x})
@@ -170,6 +172,16 @@ class Sensor:
         feature_cols = [c for c in data.columns if c != 'datetime']
         datetimes = data['datetime'].to_list() if 'datetime' in data.columns else [None] * len(data)
 
+        if feature_cols:
+            row_has_null = (
+                data.select(feature_cols)
+                .select(pl.any_horizontal(pl.col(c).is_null() for c in feature_cols))
+                .to_series()
+                .to_list()
+            )
+        else:
+            row_has_null = [False] * len(data)
+
         results: list[BarPrediction | None] = [None] * len(data)
         valid_indices: list[int] = []
 
@@ -187,6 +199,13 @@ class Sensor:
                     prediction=None,
                     probability=None,
                     reason='warm-up',
+                )
+            elif row_has_null[i]:
+                results[i] = BarPrediction(
+                    datetime=datetimes[i],
+                    prediction=None,
+                    probability=None,
+                    reason='null-features',
                 )
             else:
                 valid_indices.append(i)

--- a/limen/experiment/trainer/sensor.py
+++ b/limen/experiment/trainer/sensor.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 from dataclasses import dataclass
 from typing import Any
 
@@ -42,7 +43,7 @@ class Sensor:
 
         '''
 
-        self._yaml_reference = dict(yaml_reference)
+        self._yaml_reference = copy.deepcopy(yaml_reference)
         self._model = model
         self._fitted_params = dict(fitted_params)
         self._round_params = dict(round_params)
@@ -139,7 +140,10 @@ class Sensor:
                 the manifest data source
 
         Returns:
-            list[BarPrediction]: One entry per input bar
+            list[BarPrediction]: One entry per bar in the post-bar-formation data.
+                Length equals len(raw_klines) when bar_type is 'base' (no bar
+                aggregation). When bar formation is active, length equals the
+                aggregated bar count, which is smaller than len(raw_klines).
 
         '''
 
@@ -156,22 +160,22 @@ class Sensor:
 
         inside_window = self._inside_training_window_mask(data, manifest)
         feature_cols = [c for c in data.columns if c != 'datetime']
+        datetimes = data['datetime'].to_list() if 'datetime' in data.columns else [None] * len(data)
 
         results: list[BarPrediction | None] = [None] * len(data)
         valid_indices: list[int] = []
 
         for i in range(len(data)):
-            dt = data[i]['datetime'][0] if 'datetime' in data.columns else None
             if inside_window[i]:
                 results[i] = BarPrediction(
-                    datetime=dt,
+                    datetime=datetimes[i],
                     prediction=None,
                     probability=None,
                     reason='inside-training-window',
                 )
             elif i < indicator_lookback:
                 results[i] = BarPrediction(
-                    datetime=dt,
+                    datetime=datetimes[i],
                     prediction=None,
                     probability=None,
                     reason='warm-up',
@@ -186,11 +190,10 @@ class Sensor:
             probs = pred_result.get('_probs')
 
             for j, idx in enumerate(valid_indices):
-                dt = data[idx]['datetime'][0] if 'datetime' in data.columns else None
                 results[idx] = BarPrediction(
-                    datetime=dt,
-                    prediction=_extract_scalar([preds[j]]),
-                    probability=_extract_scalar([probs[j]]) if probs is not None else None,
+                    datetime=datetimes[idx],
+                    prediction=_extract_scalar(preds[j]),
+                    probability=_extract_scalar(probs[j]) if probs is not None else None,
                     reason=None,
                 )
 
@@ -233,11 +236,13 @@ class Sensor:
 
 def _extract_scalar(arr: Any) -> int | float | None:
 
-    '''Extract a Python scalar from the first element of an array-like.'''
+    '''Extract a Python scalar from an array-like or from a scalar directly.'''
 
     if arr is None:
         return None
     try:
+        if hasattr(arr, 'ndim') and arr.ndim == 0:
+            return arr.item()
         val = arr[0]
         return val.item() if hasattr(val, 'item') else val
     except (IndexError, TypeError):

--- a/limen/experiment/trainer/sensor.py
+++ b/limen/experiment/trainer/sensor.py
@@ -90,7 +90,7 @@ class Sensor:
 
         Raises:
             ValueError: If the window is too small, the last bar is a warm-up bar,
-                or any bar falls inside the training/test window
+                or the last bar (the prediction target) falls inside the training/test window
 
         '''
 
@@ -141,7 +141,7 @@ class Sensor:
 
         Warm-up bars and bars inside the training window have prediction=None
         with reason set. Valid bars have predictions populated. Output length
-        always equals len(raw_klines) for alignment with the input.
+        equals the post-bar-formation row count, not necessarily len(raw_klines).
 
         Args:
             raw_klines (pl.DataFrame): Raw klines from live feed, same schema as

--- a/limen/experiment/trainer/sensor.py
+++ b/limen/experiment/trainer/sensor.py
@@ -26,10 +26,10 @@ class Sensor:
     '''Inference wrapper around a trained YAML model for live bar-by-bar prediction.'''
 
     def __init__(self,
-                 yaml_reference: dict,
+                 yaml_reference: dict[str, Any],
                  model: ReferenceModel,
-                 fitted_params: dict,
-                 round_params: dict) -> None:
+                 fitted_params: dict[str, Any],
+                 round_params: dict[str, Any]) -> None:
 
         '''
         Create a Sensor from a validated Pass 1 model.
@@ -50,7 +50,7 @@ class Sensor:
 
 
     @property
-    def round_params(self) -> dict:
+    def round_params(self) -> dict[str, Any]:
 
         return self._round_params
 

--- a/limen/experiment/trainer/sensor.py
+++ b/limen/experiment/trainer/sensor.py
@@ -251,6 +251,8 @@ def _extract_scalar(arr: Any) -> int | float | None:
 
     if arr is None:
         return None
+    if isinstance(arr, (int, float)) and not isinstance(arr, bool):
+        return arr
     try:
         if hasattr(arr, 'ndim') and arr.ndim == 0:
             return arr.item()

--- a/limen/experiment/trainer/sensor.py
+++ b/limen/experiment/trainer/sensor.py
@@ -32,11 +32,11 @@ class Sensor:
                  round_params: dict[str, Any]) -> None:
 
         '''
-        Create a Sensor from a validated Pass 1 model.
+        Create a Sensor from a validated trained model.
 
         Args:
             yaml_reference (dict): Parsed YAML experiment dict from metadata.json
-            model (ReferenceModel): Trained model from Pass 1
+            model (ReferenceModel): Validated trained model
             fitted_params (dict): Fitted scaler/PCA state from the winning round
             round_params (dict): Full parameter dict from the winning round
 

--- a/limen/experiment/trainer/sensor.py
+++ b/limen/experiment/trainer/sensor.py
@@ -215,11 +215,14 @@ class Sensor:
         if manifest.split_dates is None or 'datetime' not in data.columns:
             return
         train_start, _, _, _, _, test_end = manifest.split_dates
-        inside = self._inside_training_window_mask(data, manifest)
-        if any(inside):
+        last_dt = data[-1]['datetime'][0]
+        if last_dt is None:
+            return
+        dt_date = last_dt.date() if hasattr(last_dt, 'date') else last_dt
+        if train_start <= dt_date < test_end:
             raise ValueError(
-                f"Input data contains bars inside the training/test window "
-                f"[{train_start}, {test_end}). Sensor expects data strictly "
+                f"Prediction bar {dt_date} falls inside the training/test window "
+                f"[{train_start}, {test_end}). Sensor predicts bars strictly "
                 f"after {test_end}."
             )
 

--- a/limen/experiment/trainer/sensor.py
+++ b/limen/experiment/trainer/sensor.py
@@ -49,6 +49,17 @@ class Sensor:
         self._manifest: Any = None
 
 
+    @property
+    def round_params(self) -> dict:
+
+        return self._round_params
+
+
+    def __call__(self, data: Any) -> Any:
+
+        return self.predict(data)
+
+
     def _get_manifest(self) -> Any:
 
         if self._manifest is None:
@@ -56,23 +67,30 @@ class Sensor:
         return self._manifest
 
 
-    def predict(self, raw_klines: pl.DataFrame) -> BarPrediction:
+    def predict(self, raw_klines: pl.DataFrame | dict) -> BarPrediction | dict:
 
         '''
         Prepare raw klines and return a prediction for the last bar.
 
+        When called with a dict, delegates directly to the underlying model —
+        compatible with the Cohort decoder interface.
+
         Args:
-            raw_klines (pl.DataFrame): Raw klines from live feed, same schema as
-                the manifest data source
+            raw_klines (pl.DataFrame | dict): Raw klines DataFrame for bar-by-bar
+                prediction, or a decoder-style dict for direct model inference
 
         Returns:
-            BarPrediction: Prediction for the last bar with reason=None
+            BarPrediction | dict: BarPrediction for DataFrame input, raw model
+                prediction dict for dict input
 
         Raises:
             ValueError: If the window is too small, the last bar is a warm-up bar,
                 or any bar falls inside the training/test window
 
         '''
+
+        if isinstance(raw_klines, dict):
+            return self._model.predict(raw_klines)
 
         manifest = self._get_manifest()
         data, indicator_lookback = manifest.sensor_input_prep(
@@ -90,11 +108,11 @@ class Sensor:
                 f"window), got {len(data)}"
             )
 
+        feature_cols = [c for c in data.columns if c != 'datetime']
         last_row = data[-1]
-        if last_row.null_count() > 0:
+        if any(last_row[c][0] is None for c in feature_cols):
             raise ValueError('Last bar is a warm-up bar — cannot predict')
 
-        feature_cols = [c for c in data.columns if c != 'datetime']
         x = np.array(last_row.select(feature_cols).row(0), dtype=float).reshape(1, -1)
         pred_result = self._model.predict({'x_test': x})
 
@@ -186,10 +204,7 @@ class Sensor:
         if manifest.split_dates is None or 'datetime' not in data.columns:
             return
         train_start, _, _, _, _, test_end = manifest.split_dates
-        inside = [
-            dt is not None and train_start <= dt < test_end
-            for dt in data['datetime'].to_list()
-        ]
+        inside = self._inside_training_window_mask(data, manifest)
         if any(inside):
             raise ValueError(
                 f"Input data contains bars inside the training/test window "
@@ -205,10 +220,15 @@ class Sensor:
         if manifest.split_dates is None or 'datetime' not in data.columns:
             return [False] * len(data)
         train_start, _, _, _, _, test_end = manifest.split_dates
-        return [
-            dt is not None and train_start <= dt < test_end
-            for dt in data['datetime'].to_list()
-        ]
+        result = []
+        for dt in data['datetime'].to_list():
+            if dt is None:
+                result.append(False)
+                continue
+            # normalise to date for comparison — split_dates stores date objects
+            dt_date = dt.date() if hasattr(dt, 'date') else dt
+            result.append(train_start <= dt_date < test_end)
+        return result
 
 
 def _extract_scalar(arr: Any) -> int | float | None:

--- a/limen/experiment/trainer/sensor.py
+++ b/limen/experiment/trainer/sensor.py
@@ -1,88 +1,224 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
 from typing import Any
+
+import numpy as np
+import polars as pl
+
+from limen.sfd.reference_architecture.base import ReferenceModel
+from limen.yaml.compiler import CompiledSFD
+
+
+@dataclass
+class BarPrediction:
+
+    '''Prediction result for a single bar.'''
+
+    datetime: Any
+    prediction: int | float | None
+    probability: float | None
+    reason: str | None  # None = valid prediction; 'warm-up', 'inside-training-window' = invalid
 
 
 class Sensor:
 
-    '''Callable wrapper around a trained model for live inference.'''
+    '''Inference wrapper around a trained YAML model for live bar-by-bar prediction.'''
 
     def __init__(self,
-                 model: Any,
-                 permutation_id: int,
-                 round_params: dict[str, Any],
-                 metadata: dict[str, Any],
-                 results: dict[str, Any] | None = None) -> None:
+                 yaml_reference: dict,
+                 model: ReferenceModel,
+                 fitted_params: dict,
+                 round_params: dict) -> None:
 
         '''
-        Create a Sensor from a trained model and experiment context.
+        Create a Sensor from a validated Pass 1 model.
 
         Args:
-            model (Any): Trained ReferenceModel instance
-            permutation_id (int): Round ID from experiment log
-            round_params (dict[str, Any]): Parameter values used for this permutation
-            metadata (dict[str, Any]): Experiment metadata from metadata.json
-            results (dict[str, Any] | None): Model evaluation results from Pass 1
+            yaml_reference (dict): Parsed YAML experiment dict from metadata.json
+            model (ReferenceModel): Trained model from Pass 1
+            fitted_params (dict): Fitted scaler/PCA state from the winning round
+            round_params (dict): Full parameter dict from the winning round
 
         '''
 
+        self._yaml_reference = dict(yaml_reference)
         self._model = model
-        self._permutation_id = permutation_id
+        self._fitted_params = dict(fitted_params)
         self._round_params = dict(round_params)
-        self._metadata = dict(metadata)
-        self._results = dict(results) if results is not None else None
+        self._manifest: Any = None
 
 
-    @property
-    def model(self) -> Any:
+    def _get_manifest(self) -> Any:
 
-        return self._model
-
-
-    @property
-    def permutation_id(self) -> int:
-
-        return self._permutation_id
+        if self._manifest is None:
+            self._manifest = CompiledSFD(self._yaml_reference).manifest()
+        return self._manifest
 
 
-    @property
-    def round_params(self) -> dict[str, Any]:
-
-        return dict(self._round_params)
-
-
-    @property
-    def metadata(self) -> dict[str, Any]:
-
-        return dict(self._metadata)
-
-
-    @property
-    def results(self) -> dict[str, Any] | None:
-
-        return dict(self._results) if self._results is not None else None
-
-
-    def predict(self, data: dict) -> dict:
+    def predict(self, raw_klines: pl.DataFrame) -> BarPrediction:
 
         '''
-        Compute predictions from feature data.
+        Prepare raw klines and return a prediction for the last bar.
 
         Args:
-            data (dict): Data dictionary with x_test
+            raw_klines (pl.DataFrame): Raw klines from live feed, same schema as
+                the manifest data source
 
         Returns:
-            dict: Prediction results with '_preds' key
+            BarPrediction: Prediction for the last bar with reason=None
 
         Raises:
-            ValueError: If no trained model is available
+            ValueError: If the window is too small, the last bar is a warm-up bar,
+                or any bar falls inside the training/test window
 
         '''
 
-        if self._model is None:
-            raise ValueError('Sensor has no trained model.')
+        manifest = self._get_manifest()
+        data, indicator_lookback = manifest.sensor_input_prep(
+            raw_klines, self._fitted_params, self._round_params
+        )
+        decoder_lookback = getattr(manifest, 'decoder_lookback', 1)
 
-        return self._model.predict(data)
+        self._raise_if_inside_training_window(data, manifest)
+
+        valid_rows = len(data) - indicator_lookback
+        if valid_rows < decoder_lookback:
+            raise ValueError(
+                f"Insufficient data: need {indicator_lookback + decoder_lookback} bars "
+                f"({indicator_lookback} indicator warm-up + {decoder_lookback} decoder "
+                f"window), got {len(data)}"
+            )
+
+        last_row = data[-1]
+        if last_row.null_count() > 0:
+            raise ValueError('Last bar is a warm-up bar — cannot predict')
+
+        feature_cols = [c for c in data.columns if c != 'datetime']
+        x = np.array(last_row.select(feature_cols).row(0), dtype=float).reshape(1, -1)
+        pred_result = self._model.predict({'x_test': x})
+
+        dt = last_row['datetime'][0] if 'datetime' in data.columns else None
+        return BarPrediction(
+            datetime=dt,
+            prediction=_extract_scalar(pred_result.get('_preds')),
+            probability=_extract_scalar(pred_result.get('_probs')),
+            reason=None,
+        )
 
 
-    def __call__(self, data: dict) -> dict:
+    def predict_all(self, raw_klines: pl.DataFrame) -> list[BarPrediction]:
 
-        return self.predict(data)
+        '''
+        Prepare raw klines and return one prediction per input bar.
+
+        Warm-up bars and bars inside the training window have prediction=None
+        with reason set. Valid bars have predictions populated. Output length
+        always equals len(raw_klines) for alignment with the input.
+
+        Args:
+            raw_klines (pl.DataFrame): Raw klines from live feed, same schema as
+                the manifest data source
+
+        Returns:
+            list[BarPrediction]: One entry per input bar
+
+        '''
+
+        manifest = self._get_manifest()
+        data, indicator_lookback = manifest.sensor_input_prep(
+            raw_klines, self._fitted_params, self._round_params
+        )
+        decoder_lookback = getattr(manifest, 'decoder_lookback', 1)
+
+        if decoder_lookback > 1:
+            raise NotImplementedError(
+                'predict_all does not yet support decoder_lookback > 1'
+            )
+
+        inside_window = self._inside_training_window_mask(data, manifest)
+        feature_cols = [c for c in data.columns if c != 'datetime']
+
+        results: list[BarPrediction | None] = [None] * len(data)
+        valid_indices: list[int] = []
+
+        for i in range(len(data)):
+            dt = data[i]['datetime'][0] if 'datetime' in data.columns else None
+            if inside_window[i]:
+                results[i] = BarPrediction(
+                    datetime=dt,
+                    prediction=None,
+                    probability=None,
+                    reason='inside-training-window',
+                )
+            elif i < indicator_lookback:
+                results[i] = BarPrediction(
+                    datetime=dt,
+                    prediction=None,
+                    probability=None,
+                    reason='warm-up',
+                )
+            else:
+                valid_indices.append(i)
+
+        if valid_indices:
+            x = data[valid_indices].select(feature_cols).to_numpy().astype(float)
+            pred_result = self._model.predict({'x_test': x})
+            preds = pred_result.get('_preds', [])
+            probs = pred_result.get('_probs')
+
+            for j, idx in enumerate(valid_indices):
+                dt = data[idx]['datetime'][0] if 'datetime' in data.columns else None
+                results[idx] = BarPrediction(
+                    datetime=dt,
+                    prediction=_extract_scalar([preds[j]]),
+                    probability=_extract_scalar([probs[j]]) if probs is not None else None,
+                    reason=None,
+                )
+
+        return results  # type: ignore[return-value]
+
+
+    def _raise_if_inside_training_window(self,
+                                         data: pl.DataFrame,
+                                         manifest: Any) -> None:
+
+        if manifest.split_dates is None or 'datetime' not in data.columns:
+            return
+        train_start, _, _, _, _, test_end = manifest.split_dates
+        inside = [
+            dt is not None and train_start <= dt < test_end
+            for dt in data['datetime'].to_list()
+        ]
+        if any(inside):
+            raise ValueError(
+                f"Input data contains bars inside the training/test window "
+                f"[{train_start}, {test_end}). Sensor expects data strictly "
+                f"after {test_end}."
+            )
+
+
+    def _inside_training_window_mask(self,
+                                     data: pl.DataFrame,
+                                     manifest: Any) -> list[bool]:
+
+        if manifest.split_dates is None or 'datetime' not in data.columns:
+            return [False] * len(data)
+        train_start, _, _, _, _, test_end = manifest.split_dates
+        return [
+            dt is not None and train_start <= dt < test_end
+            for dt in data['datetime'].to_list()
+        ]
+
+
+def _extract_scalar(arr: Any) -> int | float | None:
+
+    '''Extract a Python scalar from the first element of an array-like.'''
+
+    if arr is None:
+        return None
+    try:
+        val = arr[0]
+        return val.item() if hasattr(val, 'item') else val
+    except (IndexError, TypeError):
+        return None

--- a/limen/experiment/trainer/sensor.py
+++ b/limen/experiment/trainer/sensor.py
@@ -30,7 +30,8 @@ class Sensor:
                  yaml_reference: dict[str, Any],
                  model: ReferenceModel,
                  fitted_params: dict[str, Any],
-                 round_params: dict[str, Any]) -> None:
+                 round_params: dict[str, Any],
+                 permutation_id: int | None = None) -> None:
 
         '''
         Create a Sensor from a validated trained model.
@@ -40,6 +41,8 @@ class Sensor:
             model (ReferenceModel): Validated trained model
             fitted_params (dict): Fitted scaler/PCA state from the winning round
             round_params (dict): Full parameter dict from the winning round
+            permutation_id (int | None): Round ID from the experiment log — required
+                for cohort binding via Cohort.set_members
 
         '''
 
@@ -48,6 +51,7 @@ class Sensor:
         self._fitted_params = dict(fitted_params)
         self._round_params = dict(round_params)
         self._manifest: Any = None
+        self.permutation_id = permutation_id
 
 
     @property
@@ -98,6 +102,10 @@ class Sensor:
             raw_klines, self._fitted_params, self._round_params
         )
         decoder_lookback = getattr(manifest, 'decoder_lookback', 1)
+        if decoder_lookback > 1:
+            raise NotImplementedError(
+                'predict does not yet support decoder_lookback > 1'
+            )
 
         self._raise_if_inside_training_window(data, manifest)
 

--- a/limen/experiment/trainer/trainer.py
+++ b/limen/experiment/trainer/trainer.py
@@ -1,18 +1,12 @@
-import importlib
-import importlib.util
-import inspect
 import json
 import logging
-import sys
 from pathlib import Path
-from types import ModuleType
 from typing import Any
 
 import polars as pl
 
 from limen.experiment.trainer.errors import ReconstructionError
 from limen.experiment.trainer.sensor import Sensor
-from limen.sfd.reference_architecture.base import ReferenceModel
 from limen.yaml.compiler import CompiledSFD
 from limen.yaml.errors import ResolutionError
 
@@ -29,13 +23,12 @@ _STOCHASTIC_TOLERANCE = 0.01
 class Trainer:
 
     '''
-    Retrain selected permutations from a completed experiment.
+    Retrain selected permutations from a completed YAML experiment.
 
     Pass 1 validates permutations by re-running manifest.prepare_data()
     and manifest.run_model(), comparing metrics against the original
-    experiment log. Pass 2 retrains on the full dataset with
-    split_config=(1,0,0) using the model class directly. Returns Sensor
-    instances wrapping trained ReferenceModel objects.
+    experiment log. The validated Pass 1 model is used directly as the
+    Sensor model — no second training pass is performed.
     '''
 
     def __init__(self,
@@ -43,27 +36,16 @@ class Trainer:
                  data: pl.DataFrame | None = None) -> None:
 
         '''
-        Create a Trainer from a completed experiment directory.
-
-        If metadata.json includes `yaml_reference`, Trainer rebuilds the
-        SFD from that declarative YAML payload without importing or
-        executing an experiment-provided SFD module. Otherwise, the SFD
-        module named by
-        `metadata.json["sfd_module"]` is loaded in two stages: first the
-        experiment_dir is searched for a file of the same name
-        (`<sfd_module>.py`); only when that file is absent is the name
-        resolved via `importlib.import_module` against `sys.path` (the
-        legacy mode for built-in SFDs referenced by a fully-qualified
-        package path).
-
-        NOTE: experiment_dir must be trusted when the Python SFD module
-        path is used. That path imports Python and executes arbitrary code
-        from the module.
+        Create a Trainer from a completed YAML experiment directory.
 
         Args:
             experiment_dir (str | Path): Path to completed experiment directory
             data (pl.DataFrame | None): Data to use for training. If None,
                 fetches from manifest data source config
+
+        Raises:
+            FileNotFoundError: If metadata.json is not found
+            ValueError: If metadata.json does not contain a valid yaml_reference
 
         '''
 
@@ -80,44 +62,40 @@ class Trainer:
             ) from None
 
         yaml_reference = self._metadata.get('yaml_reference')
-        if yaml_reference is not None:
-            if not isinstance(yaml_reference, dict):
-                raise ValueError(
-                    'metadata.json key \'yaml_reference\' must be an object'
-                )
-            sfd_module_name = self._metadata.get('sfd_module', 'yaml_reference')
-            try:
-                sfd = CompiledSFD(yaml_reference)
-            except (KeyError, TypeError, ValueError) as exc:
-                raise ValueError(
-                    'metadata.json key \'yaml_reference\' is not a valid '
-                    'YAML SFD reference'
-                ) from exc
-        else:
-            if 'sfd_module' not in self._metadata:
-                raise ValueError(
-                    'metadata.json missing required key: sfd_module'
-                )
+        if yaml_reference is None:
+            raise ValueError(
+                'metadata.json missing required key: yaml_reference. '
+                'Trainer requires a YAML-based experiment.'
+            )
+        if not isinstance(yaml_reference, dict):
+            raise ValueError(
+                'metadata.json key \'yaml_reference\' must be an object'
+            )
+        self._yaml_reference = yaml_reference
 
-            sfd_module_name = self._metadata['sfd_module']
-            sfd = self._load_sfd_module(sfd_module_name)
+        try:
+            sfd = CompiledSFD(yaml_reference)
+        except (KeyError, TypeError, ValueError) as exc:
+            raise ValueError(
+                'metadata.json key \'yaml_reference\' is not a valid '
+                'YAML SFD reference'
+            ) from exc
 
         if not hasattr(sfd, 'manifest') or not hasattr(sfd, 'params'):
             raise ValueError(
-                f"SFD module '{sfd_module_name}' does not have manifest() and "
-                f"params(). Trainer requires a manifest-based SFD."
+                'yaml_reference does not produce a manifest-based SFD. '
+                'Trainer requires a manifest-based SFD.'
             )
 
         try:
             self._manifest = sfd.manifest()
             params = sfd.params()
         except (KeyError, ResolutionError, TypeError, ValueError) as exc:
-            if yaml_reference is not None:
-                raise ValueError(
-                    'metadata.json key \'yaml_reference\' is not a valid '
-                    'YAML SFD reference'
-                ) from exc
-            raise
+            raise ValueError(
+                'metadata.json key \'yaml_reference\' is not a valid '
+                'YAML SFD reference'
+            ) from exc
+
         self._param_keys = frozenset(params.keys())
         self._round_data = self._load_round_data()
         self._original_log = self._load_original_log()
@@ -126,91 +104,6 @@ class Trainer:
             self._data = data
         else:
             self._data = self._manifest.fetch_data()
-
-
-    def _load_sfd_module(self, sfd_module_name: str) -> ModuleType:
-
-        '''
-        Load the SFD module by name.
-
-        Prefers a `<sfd_module_name>.py` file inside `experiment_dir`
-        (self-contained experiment), falls back to
-        `importlib.import_module(sfd_module_name)` against `sys.path`
-        when no such file exists (built-in SFDs referenced by fully
-        qualified package path).
-
-        After loading via the experiment-local branch the resulting
-        module is registered in `sys.modules` under `sfd_module_name`
-        before `exec_module` runs. This allows downstream code that
-        resolves the SFD's classes/functions by name — most notably
-        `Trainer._resolve_model_class`, which re-imports the
-        architecture function's module via
-        `importlib.import_module(architecture_function.__module__)` —
-        to see the same module instance loaded here. Without the
-        registration, a self-contained bundle whose architecture
-        function is defined in the SFD file itself fails sensor
-        wiring with `ModuleNotFoundError` at the
-        `_resolve_model_class` call. If `exec_module` raises, any
-        prior `sys.modules` entry under that name is restored (or
-        the key removed if there was no prior entry) so a partially
-        initialised module is never visible to other code and an
-        unrelated module that happened to share the name is not
-        clobbered.
-
-        Rejects any name whose dot-separated segments are not valid
-        Python identifiers, so `..`, `/`, `\\`, leading/trailing dots
-        and empty segments cannot escape `experiment_dir` via the
-        local-file branch (TD-001 documents the residual hardening
-        needed on the `import_module` fallback's site-packages
-        surface).
-
-        Args:
-            sfd_module_name (str): Module name from metadata.json
-
-        Returns:
-            ModuleType: The loaded SFD module
-
-        Raises:
-            ValueError: If `sfd_module_name` is not a dotted sequence
-                of valid Python identifiers
-            ImportError: If `spec_from_file_location` cannot build a
-                spec for the experiment-local file, or if
-                `import_module` cannot resolve the name on `sys.path`
-            Exception: Any exception raised by the SFD module's own
-                top-level code during `exec_module` is propagated
-
-        '''
-
-        segments = sfd_module_name.split('.')
-        if not sfd_module_name or not all(seg.isidentifier() for seg in segments):
-            msg = (
-                f"sfd_module name {sfd_module_name!r} is not a dotted "
-                f"sequence of valid Python identifiers"
-            )
-            raise ValueError(msg)
-
-        sfd_path = self._experiment_dir / f'{sfd_module_name}.py'
-        if sfd_path.is_file():
-            spec = importlib.util.spec_from_file_location(
-                sfd_module_name, sfd_path,
-            )
-            if spec is None or spec.loader is None:
-                raise ImportError(
-                    f"Cannot create import spec for SFD file {sfd_path}"
-                )
-            module = importlib.util.module_from_spec(spec)
-            previous = sys.modules.get(sfd_module_name)
-            sys.modules[sfd_module_name] = module
-            try:
-                spec.loader.exec_module(module)
-            except BaseException:
-                if previous is None:
-                    sys.modules.pop(sfd_module_name, None)
-                else:
-                    sys.modules[sfd_module_name] = previous
-                raise
-            return module
-        return importlib.import_module(sfd_module_name)
 
 
     def _load_round_data(self) -> dict[int, dict[str, Any]]:
@@ -278,48 +171,6 @@ class Trainer:
         return result
 
 
-    def _resolve_model_class(self) -> type[ReferenceModel]:
-
-        '''
-        Resolve the ReferenceModel subclass from the model function's module.
-
-        Returns:
-            type[ReferenceModel]: The model class
-
-        Raises:
-            ValueError: If zero or multiple ReferenceModel subclasses found
-
-        '''
-
-        if self._manifest.architecture_function is None:
-            raise ValueError(
-                'Architecture function not configured on manifest. '
-                'Cannot resolve model class.'
-            )
-
-        module_name = self._manifest.architecture_function.__module__
-        module = importlib.import_module(module_name)
-
-        classes = [
-            cls for _, cls in inspect.getmembers(module, inspect.isclass)
-            if issubclass(cls, ReferenceModel) and cls is not ReferenceModel
-        ]
-
-        if len(classes) == 0:
-            raise ValueError(
-                f"No ReferenceModel subclass found in '{module_name}'. "
-                'The model module must define exactly one ReferenceModel '
-                'subclass with train(), predict(), and evaluate() methods.'
-            )
-        if len(classes) > 1:
-            raise ValueError(
-                f"Multiple ReferenceModel subclasses found in '{module_name}': "
-                f"{[c.__name__ for c in classes]}"
-            )
-
-        return classes[0]
-
-
     def _validate_metrics(self,
                           permutation_id: int,
                           results: dict[str, Any],
@@ -385,18 +236,17 @@ class Trainer:
     def train(self, permutation_ids: list[int]) -> list[Sensor]:
 
         '''
-        Run 2-pass training for selected permutations.
+        Run Pass 1 training for selected permutations and return Sensor instances.
 
-        Pass 1 re-runs the pipeline and compares metrics against the
-        original experiment log. Raises ReconstructionError on mismatch.
-        Pass 2 retrains on the full dataset with split_config=(1,0,0)
-        using the model class directly.
+        Pass 1 re-runs the pipeline and compares metrics against the original
+        experiment log. Raises ReconstructionError on mismatch. The validated
+        Pass 1 model is used directly as the Sensor model without retraining.
 
         Args:
             permutation_ids (list[int]): Round IDs from experiment_log to retrain
 
         Returns:
-            list[Sensor]: Sensor instances wrapping trained models
+            list[Sensor]: Sensor instances wrapping validated Pass 1 models
 
         Raises:
             ValueError: If any permutation ID is not found in round_data
@@ -413,35 +263,29 @@ class Trainer:
                 f"Permutation IDs not found in round_data: {missing}"
             )
 
-        model_class = self._resolve_model_class()
-        manifest_full = self._manifest.with_params_override(split_config=(1, 0, 0))
         sensors: list[Sensor] = []
 
         for pid in permutation_ids:
             round_params = dict(self._round_data[pid]['round_params'])
 
-            # Pass 1: validate with original split
             data_dict = self._manifest.prepare_data(self._data, round_params)
             results = self._manifest.run_model(data_dict, round_params)
 
-            mismatches = self._validate_metrics(pid, results, model_class.deterministic)
+            model = results.pop('_model')
+            fitted_params = data_dict.pop('_fitted_params', {})
+
+            mismatches = self._validate_metrics(pid, results, model.deterministic)
             if mismatches:
                 raise ReconstructionError(
                     f"Permutation {pid}: metric mismatch detected — "
                     + '; '.join(mismatches)
                 )
 
-            # Pass 2: retrain on full data
-            full_data = manifest_full.prepare_data(self._data, round_params)
-            model_kwargs = self._manifest.resolve_model_kwargs(round_params)
-            trained_model = model_class().train(full_data, **model_kwargs)
-
             sensor = Sensor(
-                model=trained_model,
-                permutation_id=pid,
+                yaml_reference=self._yaml_reference,
+                model=model,
+                fitted_params=fitted_params,
                 round_params=round_params,
-                metadata=self._metadata,
-                results=results,
             )
             sensors.append(sensor)
 

--- a/limen/experiment/trainer/trainer.py
+++ b/limen/experiment/trainer/trainer.py
@@ -25,10 +25,9 @@ class Trainer:
     '''
     Retrain selected permutations from a completed YAML experiment.
 
-    Pass 1 validates permutations by re-running manifest.prepare_data()
-    and manifest.run_model(), comparing metrics against the original
-    experiment log. The validated Pass 1 model is used directly as the
-    Sensor model — no second training pass is performed.
+    Validates permutations by re-running manifest.prepare_data() and
+    manifest.run_model(), comparing metrics against the original experiment
+    log. The validated model is used directly as the Sensor model.
     '''
 
     def __init__(self,
@@ -177,11 +176,11 @@ class Trainer:
                           is_deterministic: bool) -> list[str]:
 
         '''
-        Compare Pass 1 results against original experiment log entry.
+        Compare retrained results against original experiment log entry.
 
         Args:
             permutation_id (int): Round ID to validate
-            results (dict[str, Any]): Pass 1 results from run_model
+            results (dict[str, Any]): Results from run_model
             is_deterministic (bool): Whether to use exact-match tolerance
 
         Returns:
@@ -236,21 +235,21 @@ class Trainer:
     def train(self, permutation_ids: list[int]) -> list[Sensor]:
 
         '''
-        Run Pass 1 training for selected permutations and return Sensor instances.
+        Retrain selected permutations and return Sensor instances.
 
-        Pass 1 re-runs the pipeline and compares metrics against the original
-        experiment log. Raises ReconstructionError on mismatch. The validated
-        Pass 1 model is used directly as the Sensor model without retraining.
+        Re-runs the pipeline and compares metrics against the original experiment
+        log. Raises ReconstructionError on mismatch. The validated model is used
+        directly as the Sensor model.
 
         Args:
             permutation_ids (list[int]): Round IDs from experiment_log to retrain
 
         Returns:
-            list[Sensor]: Sensor instances wrapping validated Pass 1 models
+            list[Sensor]: Sensor instances wrapping validated models
 
         Raises:
             ValueError: If any permutation ID is not found in round_data
-            ReconstructionError: If Pass 1 metrics deviate beyond tolerance
+            ReconstructionError: If metrics deviate beyond tolerance
 
         '''
 

--- a/limen/experiment/trainer/trainer.py
+++ b/limen/experiment/trainer/trainer.py
@@ -287,6 +287,7 @@ class Trainer:
                 fitted_params=fitted_params,
                 round_params=round_params,
             )
+            sensor.permutation_id = pid
             sensors.append(sensor)
 
             logger.info('Trained sensor for permutation %d', pid)

--- a/limen/experiment/trainer/trainer.py
+++ b/limen/experiment/trainer/trainer.py
@@ -270,7 +270,13 @@ class Trainer:
             data_dict = self._manifest.prepare_data(self._data, round_params)
             results = self._manifest.run_model(data_dict, round_params)
 
-            model = results.pop('_model')
+            model = results.pop('_model', None)
+            if model is None:
+                raise ValueError(
+                    f"Permutation {pid}: architecture result does not contain '_model'. "
+                    f"Trainer requires a reference architecture that returns the trained "
+                    f"model via result['_model']. Rule-based architectures are not supported."
+                )
             fitted_params = data_dict.pop('_fitted_params', {})
 
             mismatches = self._validate_metrics(pid, results, model.deterministic)

--- a/limen/experiment/trainer/trainer.py
+++ b/limen/experiment/trainer/trainer.py
@@ -285,8 +285,8 @@ class Trainer:
                 model=model,
                 fitted_params=fitted_params,
                 round_params=round_params,
+                permutation_id=pid,
             )
-            sensor.permutation_id = pid
             sensors.append(sensor)
 
             logger.info('Trained sensor for permutation %d', pid)

--- a/limen/sfd/reference_architecture/logreg_binary.py
+++ b/limen/sfd/reference_architecture/logreg_binary.py
@@ -184,4 +184,6 @@ def logreg_binary(data: dict,
         l1_ratio=l1_ratio,
     )
 
-    return model.evaluate(data, inline_metrics=True)
+    result = model.evaluate(data, inline_metrics=True)
+    result['_model'] = model
+    return result

--- a/limen/sfd/reference_architecture/logreg_binary.py
+++ b/limen/sfd/reference_architecture/logreg_binary.py
@@ -69,8 +69,12 @@ class LogRegBinary(ReferenceModel):
         params = _drop_removed_sklearn_params(params)
         self.model = LogisticRegression(**params)
         self.model.fit(data['x_train'], data['y_train'])
+        self._fitted_calibrator = None
+        self._calibration_threshold = 0.5
+        self._val_score = None
 
         return self
+
 
     def predict(self, data: dict) -> dict:
 

--- a/limen/sfd/reference_architecture/logreg_binary.py
+++ b/limen/sfd/reference_architecture/logreg_binary.py
@@ -1,9 +1,10 @@
 import inspect
 from typing import TYPE_CHECKING, Any
 
+import numpy as np
 from sklearn.linear_model import LogisticRegression
 
-from limen.calibration import apply_calibrated_predict
+from limen.calibration import fit_calibrator
 from limen.metrics.binary_metrics import binary_metrics
 from limen.sfd.reference_architecture.base import ReferenceModel
 
@@ -41,6 +42,9 @@ class LogRegBinary(ReferenceModel):
 
         super().__init__()
         self.prediction_calibration_config = prediction_calibration_config
+        self._fitted_calibrator: Any = None
+        self._calibration_threshold: float = 0.5
+        self._val_score: float | None = None
 
     def train(self, data: dict, **params: Any) -> 'LogRegBinary':
 
@@ -73,8 +77,13 @@ class LogRegBinary(ReferenceModel):
         '''
         Compute binary predictions from feature data.
 
+        On the first call with calibration configured, fits the calibrator on
+        validation data and stores it for reuse. Subsequent calls (including
+        inference without val data) use the stored calibrator directly.
+
         Args:
-            data (dict): Data dictionary with x_val, y_val, x_test
+            data (dict): Data dictionary. Training call requires x_val, y_val, x_test;
+                inference call requires only x_test
 
         Returns:
             dict: Prediction results with '_preds' and '_probs' keys; calibrated path
@@ -82,7 +91,18 @@ class LogRegBinary(ReferenceModel):
         '''
 
         if self.prediction_calibration_config is not None:
-            return apply_calibrated_predict(self.model, self.prediction_calibration_config, data)
+            if self._fitted_calibrator is None:
+                self._fitted_calibrator, self._calibration_threshold, self._val_score = fit_calibrator(
+                    self.model, self.prediction_calibration_config, data['x_val'], data['y_val']
+                )
+            test_proba = self._fitted_calibrator.predict_proba(data['x_test'])[:, 1]
+            preds = (test_proba >= self._calibration_threshold).astype(np.int8)
+            return {
+                '_preds': preds,
+                '_probs': test_proba,
+                'optimal_threshold': self._calibration_threshold,
+                'val_score': self._val_score,
+            }
 
         preds = self.model.predict(data['x_test'])
         probs = self.model.predict_proba(data['x_test'])[:, 1]

--- a/limen/sfd/reference_architecture/random_binary.py
+++ b/limen/sfd/reference_architecture/random_binary.py
@@ -97,4 +97,7 @@ def random_binary(data: dict,
             and backtest metrics when price_data_for_backtest is in data
     '''
 
-    return RandomBinary().train(data, random_weights=random_weights).evaluate(data, inline_metrics=True)
+    model = RandomBinary().train(data, random_weights=random_weights)
+    result = model.evaluate(data, inline_metrics=True)
+    result['_model'] = model
+    return result

--- a/limen/sfd/reference_architecture/tabpfn_binary.py
+++ b/limen/sfd/reference_architecture/tabpfn_binary.py
@@ -61,8 +61,12 @@ class TabPFNBinary(ReferenceModel):
         )
 
         self.model.fit(arrays['x_train'], arrays['y_train'])
+        self._fitted_calibrator = None
+        self._calibration_threshold = 0.5
+        self._val_score = None
 
         return self
+
 
     def predict(self, data: dict) -> dict:
 

--- a/limen/sfd/reference_architecture/tabpfn_binary.py
+++ b/limen/sfd/reference_architecture/tabpfn_binary.py
@@ -4,7 +4,7 @@ import numpy as np
 
 from tabpfn import TabPFNClassifier
 
-from limen.calibration import apply_calibrated_predict
+from limen.calibration import fit_calibrator
 from limen.metrics.binary_metrics import binary_metrics
 from limen.sfd.reference_architecture.base import ReferenceModel
 from limen.utils.data_dict_to_numpy import data_dict_to_numpy
@@ -26,6 +26,9 @@ class TabPFNBinary(ReferenceModel):
 
         super().__init__()
         self.prediction_calibration_config = prediction_calibration_config
+        self._fitted_calibrator: Any = None
+        self._calibration_threshold: float = 0.5
+        self._val_score: float | None = None
 
     def train(self, data: dict, **params: Any) -> 'TabPFNBinary':
 
@@ -66,21 +69,38 @@ class TabPFNBinary(ReferenceModel):
         '''
         Compute binary predictions with optional calibration and threshold tuning.
 
+        On the first call with calibration configured, fits the calibrator on
+        validation data and stores it for reuse. Subsequent calls (including
+        inference without val data) use the stored calibrator directly.
+
         Args:
-            data (dict): Data dictionary with x_val, y_val, x_test
+            data (dict): Data dictionary. Training call requires x_val, y_val, x_test;
+                inference call requires only x_test
 
         Returns:
             dict: Prediction results with '_preds' and '_probs' keys; calibrated path
                 also includes 'optimal_threshold' and 'val_score'
         '''
 
-        arrays = data_dict_to_numpy(data, ['x_val', 'y_val', 'x_test'])
+        x_test = data_dict_to_numpy(data, ['x_test'])['x_test']
 
         if self.prediction_calibration_config is not None:
-            return apply_calibrated_predict(self.model, self.prediction_calibration_config, arrays)
+            if self._fitted_calibrator is None:
+                arrays = data_dict_to_numpy(data, ['x_val', 'y_val'])
+                self._fitted_calibrator, self._calibration_threshold, self._val_score = fit_calibrator(
+                    self.model, self.prediction_calibration_config, arrays['x_val'], arrays['y_val']
+                )
+            test_proba = self._fitted_calibrator.predict_proba(x_test)[:, 1]
+            preds = (test_proba >= self._calibration_threshold).astype(np.int8)
+            return {
+                '_preds': preds,
+                '_probs': test_proba,
+                'optimal_threshold': self._calibration_threshold,
+                'val_score': self._val_score,
+            }
 
-        y_test_proba = self.model.predict_proba(arrays['x_test'])[:, 1]
-        y_pred = self.model.predict(arrays['x_test']).astype(np.int8)
+        y_test_proba = self.model.predict_proba(x_test)[:, 1]
+        y_pred = self.model.predict(x_test).astype(np.int8)
         return {'_preds': y_pred, '_probs': y_test_proba}
 
 

--- a/limen/sfd/reference_architecture/tabpfn_binary.py
+++ b/limen/sfd/reference_architecture/tabpfn_binary.py
@@ -141,4 +141,6 @@ def tabpfn_binary(data: dict,
         device=device,
     )
 
-    return model.evaluate(data, inline_metrics=True)
+    result = model.evaluate(data, inline_metrics=True)
+    result['_model'] = model
+    return result

--- a/limen/sfd/reference_architecture/xgboost_regressor.py
+++ b/limen/sfd/reference_architecture/xgboost_regressor.py
@@ -147,4 +147,6 @@ def xgboost_regressor(data: dict,
         random_state=random_state,
     )
 
-    return model.evaluate(data, inline_metrics=True)
+    result = model.evaluate(data, inline_metrics=True)
+    result['_model'] = model
+    return result

--- a/limen/targets/random_binary.py
+++ b/limen/targets/random_binary.py
@@ -6,7 +6,10 @@ class RandomBinaryTarget:
 
     '''Uniformly random binary target, used as a noise benchmark.'''
 
-    def __init__(self, train_data: pl.DataFrame, target_name: str) -> None:
+    def __init__(self,
+                 train_data: pl.DataFrame,
+                 target_name: str,
+                 random_state: int | None = None) -> None:
 
         '''
         Store the target column name; no fitting is performed.
@@ -14,9 +17,12 @@ class RandomBinaryTarget:
         Args:
             train_data (pl.DataFrame): Training split (not used; kept for interface consistency)
             target_name (str): Name of the target column to create
+            random_state (int | None): Seed for the random number generator. When set,
+                labels are reproducible across runs given the same data sizes and call order
         '''
 
         self.target_name = target_name
+        self._rng = np.random.default_rng(random_state)
 
     def transform(self, data: pl.DataFrame) -> pl.DataFrame:
 
@@ -30,6 +36,5 @@ class RandomBinaryTarget:
             pl.DataFrame: Data with target column added
         '''
 
-        return data.with_columns(
-            pl.Series(self.target_name, np.random.randint(0, 2, size=data.height), dtype=pl.UInt8)
-        )
+        labels = self._rng.integers(0, 2, size=data.height, dtype=np.uint8)
+        return data.with_columns(pl.Series(self.target_name, labels, dtype=pl.UInt8))

--- a/limen/yaml/compiler.py
+++ b/limen/yaml/compiler.py
@@ -116,11 +116,11 @@ def _apply_indicators(manifest: Manifest, m: dict[str, Any]) -> None:
 def _apply_base(manifest: Manifest, m: dict[str, Any]) -> None:
 
     ds = m['data_source']
-    manifest.set_data_source(method=resolve(ds['method']), params=dict(ds.get('params') or {}))
-
-    tds = m.get('test_data_source')
-    if tds is not None:
-        manifest.set_test_data_source(method=resolve(tds['method']), params=dict(tds.get('params') or {}))
+    params = dict(ds.get('params') or {})
+    sd = m['split_dates']
+    params['start_date_limit'] = sd['train_start']
+    params['end_date_limit'] = sd['test_end']
+    manifest.set_data_source(method=resolve(ds['method']), params=params)
 
     _apply_split(manifest, m)
 
@@ -133,19 +133,15 @@ def _apply_base(manifest: Manifest, m: dict[str, Any]) -> None:
 
 def _apply_split(manifest: Manifest, m: dict[str, Any]) -> None:
 
-    sd = m.get('split_dates')
-    if sd is not None:
-        manifest.set_split_dates(
-            date.fromisoformat(sd['train_start']),
-            date.fromisoformat(sd['train_end']),
-            date.fromisoformat(sd['val_start']),
-            date.fromisoformat(sd['val_end']),
-            date.fromisoformat(sd['test_start']),
-            date.fromisoformat(sd['test_end']),
-        )
-    else:
-        sc = m['split_config']
-        manifest.set_split_config(sc['train'], sc['val'], sc['test'])
+    sd = m['split_dates']
+    manifest.set_split_dates(
+        date.fromisoformat(sd['train_start']),
+        date.fromisoformat(sd['train_end']),
+        date.fromisoformat(sd['val_start']),
+        date.fromisoformat(sd['val_end']),
+        date.fromisoformat(sd['test_start']),
+        date.fromisoformat(sd['test_end']),
+    )
 
 
 def _apply_transforms(manifest: MLManifest, m: dict[str, Any]) -> None:

--- a/limen/yaml/compiler.py
+++ b/limen/yaml/compiler.py
@@ -1,3 +1,4 @@
+import inspect
 from datetime import date
 from typing import Any
 
@@ -118,9 +119,17 @@ def _apply_base(manifest: Manifest, m: dict[str, Any]) -> None:
     ds = m['data_source']
     params = dict(ds.get('params') or {})
     sd = m['split_dates']
-    params['start_date_limit'] = sd['train_start']
-    params['end_date_limit'] = sd['test_end']
-    manifest.set_data_source(method=resolve(ds['method']), params=params)
+    method = resolve(ds['method'])
+    sig = inspect.signature(method)
+    sig_params = sig.parameters
+    accepts_var_keyword = any(
+        p.kind == inspect.Parameter.VAR_KEYWORD for p in sig_params.values()
+    )
+    if 'start_date_limit' in sig_params or accepts_var_keyword:
+        params['start_date_limit'] = sd['train_start']
+    if 'end_date_limit' in sig_params or accepts_var_keyword:
+        params['end_date_limit'] = sd['test_end']
+    manifest.set_data_source(method=method, params=params)
 
     _apply_split(manifest, m)
 

--- a/limen/yaml/compiler.py
+++ b/limen/yaml/compiler.py
@@ -246,6 +246,8 @@ def _apply_ml_extras(manifest: MLManifest, m: dict[str, Any]) -> None:
     if mp is not None:
         manifest.metrics_params = dict(mp)
 
+    manifest.decoder_lookback = int(m.get('decoder_lookback') or 1)
+
 
 class CompiledSFD:
 

--- a/limen/yaml/rules.py
+++ b/limen/yaml/rules.py
@@ -339,7 +339,7 @@ class SchemaVersion:
 
 class DataSource:
 
-    '''Validate data_source (required) and test_data_source (optional) blocks.'''
+    '''Validate data_source block, reject test_data_source, and forbid reserved date-limit params.'''
 
     def check(self,
               yaml_dict: dict[str, Any],
@@ -348,45 +348,63 @@ class DataSource:
 
         manifest = _get_manifest(yaml_dict)
 
-        for section, required in (('data_source', True), ('test_data_source', False)):
-            src = manifest.get(section)
-            if src is None:
-                if required:
+        if 'test_data_source' in manifest:
+            errors.append(YAMLError(
+                message="'test_data_source' is not supported in YAML experiments — "
+                        "use the Python manifest API for programmatic test-mode data sources",
+                path='sfd.manifest.test_data_source',
+                suggestion='Remove test_data_source; date limits are injected from split_dates automatically',
+            ))
+
+        src = manifest.get('data_source')
+        if src is None:
+            errors.append(YAMLError(
+                message="Missing required field 'data_source'",
+                path='sfd.manifest.data_source',
+            ))
+            return
+
+        if not isinstance(src, dict):
+            errors.append(YAMLError(
+                message="'data_source' must be a mapping",
+                path='sfd.manifest.data_source',
+            ))
+            return
+
+        if 'method' not in src:
+            errors.append(YAMLError(
+                message="Missing required field 'method'",
+                path='sfd.manifest.data_source.method',
+            ))
+            return
+
+        method = src['method']
+        if isinstance(method, str):
+            _check_callable_path(method, 'sfd.manifest.data_source.method', errors)
+        else:
+            errors.append(YAMLError(
+                message=f"'method' must be a string (got {type(method).__name__})",
+                path='sfd.manifest.data_source.method',
+            ))
+
+        params = src.get('params')
+        if params is not None and not isinstance(params, dict):
+            errors.append(YAMLError(
+                message="'params' in 'data_source' must be a mapping",
+                path='sfd.manifest.data_source.params',
+            ))
+            return
+
+        if isinstance(params, dict):
+            for reserved in ('start_date_limit', 'end_date_limit'):
+                if reserved in params:
                     errors.append(YAMLError(
-                        message=f"Missing required field '{section}'",
-                        path=f'sfd.manifest.{section}',
+                        message=f"'{reserved}' must not be set in 'data_source.params' — "
+                                f"it is derived automatically from 'split_dates'",
+                        path=f'sfd.manifest.data_source.params.{reserved}',
+                        suggestion=f"Remove '{reserved}' from data_source.params and set the "
+                                   f"date window via split_dates instead",
                     ))
-                continue
-
-            if not isinstance(src, dict):
-                errors.append(YAMLError(
-                    message=f"'{section}' must be a mapping",
-                    path=f'sfd.manifest.{section}',
-                ))
-                continue
-
-            if 'method' not in src:
-                errors.append(YAMLError(
-                    message="Missing required field 'method'",
-                    path=f'sfd.manifest.{section}.method',
-                ))
-                continue
-
-            method = src['method']
-            if isinstance(method, str):
-                _check_callable_path(method, f'sfd.manifest.{section}.method', errors)
-            else:
-                errors.append(YAMLError(
-                    message=f"'method' must be a string (got {type(method).__name__})",
-                    path=f'sfd.manifest.{section}.method',
-                ))
-
-            params = src.get('params')
-            if params is not None and not isinstance(params, dict):
-                errors.append(YAMLError(
-                    message=f"'params' in '{section}' must be a mapping",
-                    path=f'sfd.manifest.{section}.params',
-                ))
 
 
 class FuncList:
@@ -529,7 +547,7 @@ class ConditionsList:
 
 class SplitSpec:
 
-    '''Exactly one of split_config (ratio) or split_dates (absolute) must be present.'''
+    '''split_dates (absolute date windows) is required; split_config (ratio) is not supported in YAML.'''
 
     def check(self,
               yaml_dict: dict[str, Any],
@@ -537,91 +555,58 @@ class SplitSpec:
               _warnings: list[YAMLError]) -> None:
 
         manifest = _get_manifest(yaml_dict)
-        has_config = 'split_config' in manifest
-        has_dates = 'split_dates' in manifest
 
-        if has_config and has_dates:
+        if 'split_config' in manifest:
             errors.append(YAMLError(
-                message="Cannot specify both 'split_config' and 'split_dates' — use one or the other",
-                path='sfd.manifest',
-                suggestion="Remove 'split_config' to use absolute-date splits, or remove 'split_dates' to use ratio splits",
+                message="'split_config' is not supported — use 'split_dates' with explicit date windows",
+                path='sfd.manifest.split_config',
+                suggestion='Replace with split_dates: {train_start: YYYY-MM-DD, train_end: YYYY-MM-DD, val_start: YYYY-MM-DD, val_end: YYYY-MM-DD, test_start: YYYY-MM-DD, test_end: YYYY-MM-DD}',
             ))
             return
 
-        if not has_config and not has_dates:
+        if 'split_dates' not in manifest:
             errors.append(YAMLError(
-                message="One of 'split_config' or 'split_dates' is required",
+                message="'split_dates' is required",
                 path='sfd.manifest',
-                suggestion='Add split_config: {train: 8, val: 1, test: 2} or split_dates: {train_start: ..., ...}',
+                suggestion='Add split_dates: {train_start: YYYY-MM-DD, train_end: YYYY-MM-DD, val_start: YYYY-MM-DD, val_end: YYYY-MM-DD, test_start: YYYY-MM-DD, test_end: YYYY-MM-DD}',
             ))
             return
 
-        if has_config:
-            sc = manifest['split_config']
-            if not isinstance(sc, dict):
+        sd = manifest['split_dates']
+        if not isinstance(sd, dict):
+            errors.append(YAMLError(
+                message="'split_dates' must be a mapping",
+                path='sfd.manifest.split_dates',
+            ))
+            return
+        parsed: dict[str, date] = {}
+        for key in _SPLIT_DATE_KEYS:
+            if key not in sd:
                 errors.append(YAMLError(
-                    message="'split_config' must be a mapping",
-                    path='sfd.manifest.split_config',
+                    message=f"Missing required field '{key}'",
+                    path=f'sfd.manifest.split_dates.{key}',
                 ))
-                return
-            for key in ('train', 'val', 'test'):
-                if key not in sc:
-                    errors.append(YAMLError(
-                        message=f"Missing required field '{key}'",
-                        path=f'sfd.manifest.split_config.{key}',
-                    ))
-                elif not isinstance(sc[key], int):
-                    errors.append(YAMLError(
-                        message=f"'{key}' must be an int",
-                        path=f'sfd.manifest.split_config.{key}',
-                    ))
-                elif key == 'train' and sc[key] <= 0:
-                    errors.append(YAMLError(
-                        message=f"'train' must be > 0 (got {sc[key]})",
-                        path='sfd.manifest.split_config.train',
-                        suggestion='Use a positive integer e.g. train: 8',
-                    ))
-                elif key in ('val', 'test') and sc[key] < 0:
-                    errors.append(YAMLError(
-                        message=f"'{key}' must be >= 0 (got {sc[key]})",
-                        path=f'sfd.manifest.split_config.{key}',
-                    ))
-        else:
-            sd = manifest['split_dates']
-            if not isinstance(sd, dict):
+            elif not isinstance(sd[key], str):
                 errors.append(YAMLError(
-                    message="'split_dates' must be a mapping",
-                    path='sfd.manifest.split_dates',
+                    message=f"'{key}' must be a date string (e.g. '2022-01-01')",
+                    path=f'sfd.manifest.split_dates.{key}',
                 ))
-                return
-            parsed: dict[str, date] = {}
-            for key in _SPLIT_DATE_KEYS:
-                if key not in sd:
+            else:
+                try:
+                    parsed[key] = date.fromisoformat(sd[key])
+                except ValueError:
                     errors.append(YAMLError(
-                        message=f"Missing required field '{key}'",
+                        message=f"'{key}' is not a valid ISO-8601 date (got '{sd[key]}')",
                         path=f'sfd.manifest.split_dates.{key}',
+                        suggestion="Use format 'YYYY-MM-DD', e.g. '2022-01-01'",
                     ))
-                elif not isinstance(sd[key], str):
+        if len(parsed) == len(_SPLIT_DATE_KEYS):
+            for (a_key, a_val), (b_key, b_val) in pairwise(parsed.items()):
+                if a_val > b_val:
                     errors.append(YAMLError(
-                        message=f"'{key}' must be a date string (e.g. '2022-01-01')",
-                        path=f'sfd.manifest.split_dates.{key}',
-                    ))
-                else:
-                    try:
-                        parsed[key] = date.fromisoformat(sd[key])
-                    except ValueError:
-                        errors.append(YAMLError(
-                            message=f"'{key}' is not a valid ISO-8601 date (got '{sd[key]}')",
-                            path=f'sfd.manifest.split_dates.{key}',
-                            suggestion="Use format 'YYYY-MM-DD', e.g. '2022-01-01'",
-                        ))
-            if len(parsed) == len(_SPLIT_DATE_KEYS):
-                for (a_key, a_val), (b_key, b_val) in pairwise(parsed.items()):
-                    if a_val > b_val:
-                        errors.append(YAMLError(
-                            message=f"split_dates must be non-decreasing: '{a_key}' ({a_val}) > '{b_key}' ({b_val})",
-                            path='sfd.manifest.split_dates',
-                            suggestion='Ensure train_start <= train_end <= val_start <= val_end <= test_start <= test_end',
+                        message=f"split_dates must be non-decreasing: '{a_key}' ({a_val}) > '{b_key}' ({b_val})",
+                        path='sfd.manifest.split_dates',
+                        suggestion='Ensure train_start <= train_end <= val_start <= val_end <= test_start <= test_end',
                         ))
 
 

--- a/limen/yaml/rules.py
+++ b/limen/yaml/rules.py
@@ -495,7 +495,7 @@ class RequiredColumnsSpec:
 
 class DecoderLookbackSpec:
 
-    '''When decoder_lookback is present, it must be an integer >= 1.'''
+    '''When decoder_lookback is present, it must be exactly 1 (the only supported value).'''
 
     def check(self,
               yaml_dict: dict[str, Any],
@@ -510,14 +510,21 @@ class DecoderLookbackSpec:
             errors.append(YAMLError(
                 message=f"'decoder_lookback' must be an integer (got {type(value).__name__})",
                 path='sfd.manifest.decoder_lookback',
-                suggestion='Set decoder_lookback to a positive integer, e.g. decoder_lookback: 30',
+                suggestion='Set decoder_lookback: 1 (the only supported value)',
             ))
             return
         if value < 1:
             errors.append(YAMLError(
                 message=f"'decoder_lookback' must be >= 1 (got {value})",
                 path='sfd.manifest.decoder_lookback',
-                suggestion='Set decoder_lookback to a positive integer, e.g. decoder_lookback: 30',
+                suggestion='Set decoder_lookback: 1 (the only supported value)',
+            ))
+            return
+        if value > 1:
+            errors.append(YAMLError(
+                message=f"'decoder_lookback' > 1 is not yet supported (got {value}); only decoder_lookback: 1 is supported",
+                path='sfd.manifest.decoder_lookback',
+                suggestion='Set decoder_lookback: 1 or omit the field (defaults to 1)',
             ))
 
 

--- a/limen/yaml/rules.py
+++ b/limen/yaml/rules.py
@@ -493,6 +493,34 @@ class RequiredColumnsSpec:
                 ))
 
 
+class DecoderLookbackSpec:
+
+    '''When decoder_lookback is present, it must be an integer >= 1.'''
+
+    def check(self,
+              yaml_dict: dict[str, Any],
+              errors: list[YAMLError],
+              _warnings: list[YAMLError]) -> None:
+
+        manifest = _get_manifest(yaml_dict)
+        value = manifest.get('decoder_lookback')
+        if value is None:
+            return
+        if not isinstance(value, int) or isinstance(value, bool):
+            errors.append(YAMLError(
+                message=f"'decoder_lookback' must be an integer (got {type(value).__name__})",
+                path='sfd.manifest.decoder_lookback',
+                suggestion='Set decoder_lookback to a positive integer, e.g. decoder_lookback: 30',
+            ))
+            return
+        if value < 1:
+            errors.append(YAMLError(
+                message=f"'decoder_lookback' must be >= 1 (got {value})",
+                path='sfd.manifest.decoder_lookback',
+                suggestion='Set decoder_lookback to a positive integer, e.g. decoder_lookback: 30',
+            ))
+
+
 class ConditionsList:
 
     '''Validate the rule_based strategy conditions list structure.'''

--- a/limen/yaml/schema.py
+++ b/limen/yaml/schema.py
@@ -27,6 +27,7 @@ ML_MANIFEST_OPTIONAL = {
     'pca_compression',
     'params_override',
     'metrics_params',
+    'decoder_lookback',
 }
 
 RULE_BASED_MANIFEST_REQUIRED = {'strategy'}

--- a/limen/yaml/schema.py
+++ b/limen/yaml/schema.py
@@ -13,7 +13,7 @@ METADATA_OPTIONAL = {'author', 'created_at', 'description', 'tags', 'limen_versi
 SFD_REQUIRED = {'manifest', 'params'}
 
 MANIFEST_REQUIRED = {'type', 'data_source', 'reference_architecture'}
-MANIFEST_OPTIONAL_SHARED = {'test_data_source', 'required_columns', 'split_config', 'split_dates', 'indicators'}
+MANIFEST_OPTIONAL_SHARED = {'required_columns', 'split_dates', 'indicators'}
 
 ML_MANIFEST_REQUIRED = {'target'}
 ML_MANIFEST_OPTIONAL = {

--- a/limen/yaml/templates/logreg_binary.yaml
+++ b/limen/yaml/templates/logreg_binary.yaml
@@ -14,18 +14,14 @@ sfd:
       method: limen.data.HistoricalData.get_spot_klines
       params:
         kline_size: 3600
-        start_date_limit: "2025-01-01"
 
-    test_data_source:
-      method: limen.data.HistoricalData.get_spot_klines
-      params:
-        kline_size: 7200
-        n_rows: 5000
-
-    split_config:
-      train: 8
-      val: 1
-      test: 2
+    split_dates:
+      train_start: "2024-01-01"
+      train_end:   "2024-09-30"
+      val_start:   "2024-10-01"
+      val_end:     "2024-11-30"
+      test_start:  "2024-12-01"
+      test_end:    "2024-12-31"
 
     indicators:
       - func: limen.indicators.roc

--- a/limen/yaml/templates/rule_based.yaml
+++ b/limen/yaml/templates/rule_based.yaml
@@ -14,18 +14,14 @@ sfd:
       method: limen.data.HistoricalData.get_spot_klines
       params:
         kline_size: 3600
-        start_date_limit: "2025-01-01"
 
-    test_data_source:
-      method: limen.data.HistoricalData.get_spot_klines
-      params:
-        kline_size: 7200
-        n_rows: 5000
-
-    split_config:
-      train: 8
-      val: 1
-      test: 2
+    split_dates:
+      train_start: "2024-01-01"
+      train_end:   "2024-09-30"
+      val_start:   "2024-10-01"
+      val_end:     "2024-11-30"
+      test_start:  "2024-12-01"
+      test_end:    "2024-12-31"
 
     indicators:
       - func: limen.indicators.wilder_rsi

--- a/limen/yaml/templates/tabpfn_binary.yaml
+++ b/limen/yaml/templates/tabpfn_binary.yaml
@@ -14,18 +14,14 @@ sfd:
       method: limen.data.HistoricalData.get_spot_klines
       params:
         kline_size: 3600
-        start_date_limit: "2025-01-01"
 
-    test_data_source:
-      method: limen.data.HistoricalData.get_spot_klines
-      params:
-        kline_size: 7200
-        n_rows: 1000
-
-    split_config:
-      train: 50
-      val: 20
-      test: 30
+    split_dates:
+      train_start: "2024-01-01"
+      train_end:   "2024-09-30"
+      val_start:   "2024-10-01"
+      val_end:     "2024-11-30"
+      test_start:  "2024-12-01"
+      test_end:    "2024-12-31"
 
     indicators:
       - func: limen.indicators.roc

--- a/limen/yaml/templates/xgboost_regressor.yaml
+++ b/limen/yaml/templates/xgboost_regressor.yaml
@@ -14,18 +14,14 @@ sfd:
       method: limen.data.HistoricalData.get_spot_klines
       params:
         kline_size: 3600
-        start_date_limit: "2025-01-01"
 
-    test_data_source:
-      method: limen.data.HistoricalData.get_spot_klines
-      params:
-        kline_size: 7200
-        n_rows: 5000
-
-    split_config:
-      train: 8
-      val: 1
-      test: 2
+    split_dates:
+      train_start: "2024-01-01"
+      train_end:   "2024-09-30"
+      val_start:   "2024-10-01"
+      val_end:     "2024-11-30"
+      test_start:  "2024-12-01"
+      test_end:    "2024-12-31"
 
     indicators:
       - func: limen.indicators.window_return

--- a/limen/yaml/validator.py
+++ b/limen/yaml/validator.py
@@ -46,7 +46,6 @@ from limen.yaml.schema import SCALER_EXPLICIT_OPTIONAL
 from limen.yaml.schema import SCALER_EXPLICIT_REQUIRED
 from limen.yaml.schema import SCALER_FROM_PARAMS_REQUIRED
 from limen.yaml.schema import SEARCH_STRATEGY_REQUIRED
-from limen.yaml.schema import SPLIT_CONFIG_REQUIRED
 from limen.yaml.schema import SPLIT_DATES_REQUIRED
 from limen.yaml.schema import STRATEGY_REQUIRED
 from limen.yaml.schema import TARGET_OPTIONAL
@@ -95,11 +94,9 @@ _MAIN_ENGINE = RuleEngine([
 
     DataSource(),
     NoUnknownKeys('sfd.manifest.data_source', DATA_SOURCE_REQUIRED | DATA_SOURCE_OPTIONAL),
-    NoUnknownKeys('sfd.manifest.test_data_source', DATA_SOURCE_REQUIRED | DATA_SOURCE_OPTIONAL),
 
     SplitSpec(),
     RequiredColumnsSpec(),
-    NoUnknownKeys('sfd.manifest.split_config', SPLIT_CONFIG_REQUIRED),
     NoUnknownKeys('sfd.manifest.split_dates', SPLIT_DATES_REQUIRED),
 
     Required('sfd.manifest.reference_architecture', str),

--- a/limen/yaml/validator.py
+++ b/limen/yaml/validator.py
@@ -7,6 +7,7 @@ from limen.yaml.rules import BlockSpec
 from limen.yaml.rules import CalibrationCrossRef
 from limen.yaml.rules import CalibrationPresence
 from limen.yaml.rules import ConditionsList
+from limen.yaml.rules import DecoderLookbackSpec
 from limen.yaml.rules import DataSource
 from limen.yaml.rules import FuncList
 from limen.yaml.rules import NameSlug
@@ -117,6 +118,7 @@ _MAIN_ENGINE = RuleEngine([
         NoUnknownKeys('sfd.manifest.scaler',
                       SCALER_EXPLICIT_REQUIRED | SCALER_EXPLICIT_OPTIONAL | SCALER_FROM_PARAMS_REQUIRED),
         ScalerSpec(),
+        DecoderLookbackSpec(),
         BlockSpec(
             'sfd.manifest.feature_ablation',
             'sfd.manifest.pca_compression',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaquum_limen"
-version = "3.13.0"
+version = "3.14.0"
 description = "Limen unifies parameter search across machine learning and rule-based strategies, with built-in analytics that show not just what works, but why it works."
 readme = "README.md"
 authors = [

--- a/tests/run.py
+++ b/tests/run.py
@@ -29,10 +29,10 @@ from tests.test_yaml import test_validate_passes_valid_ml_yaml
 from tests.test_yaml import test_validate_passes_valid_rule_based_yaml
 from tests.test_yaml import test_validate_passes_valid_yaml_with_split_dates
 from tests.test_yaml import test_validate_error_for_missing_required_field
-from tests.test_yaml import test_validate_error_when_both_split_config_and_split_dates_present
+from tests.test_yaml import test_validate_error_when_split_config_present
 from tests.test_yaml import test_validate_error_for_invalid_split_date_format
 from tests.test_yaml import test_validate_error_for_split_dates_out_of_order
-from tests.test_yaml import test_validate_error_for_split_config_invalid_value
+from tests.test_yaml import test_validate_error_for_split_config_present
 from tests.test_yaml import test_validate_error_for_missing_mode
 from tests.test_yaml import test_validate_error_for_unsafe_metadata_name
 from tests.test_yaml import test_validate_error_for_empty_sfd_param_list
@@ -41,7 +41,7 @@ from tests.test_yaml import test_validate_error_for_non_string_sfd_param_key
 from tests.test_yaml import test_validate_non_string_sfd_param_key_does_not_crash
 from tests.test_yaml import test_validate_warning_for_unused_sfd_param
 from tests.test_yaml import test_validate_warning_for_unknown_key_in_data_source
-from tests.test_yaml import test_validate_warning_for_unknown_key_in_split_config
+from tests.test_yaml import test_validate_warning_for_unknown_key_in_split_dates
 from tests.test_yaml import test_validate_error_for_unresolvable_reference_architecture
 from tests.test_yaml import test_validate_error_for_unresolvable_target_class
 from tests.test_yaml import test_validate_error_for_callable_path_resolving_to_module
@@ -82,9 +82,13 @@ from tests.test_yaml import test_validate_error_for_manifest_ref_not_in_sfd_para
 from tests.test_yaml import test_validate_no_error_when_manifest_ref_is_in_sfd_params
 from tests.test_yaml import test_validate_no_unused_param_warning_for_pca_defaults
 from tests.test_yaml import test_build_manifest_data_source_method_is_callable_with_correct_params
-from tests.test_yaml import test_build_manifest_test_data_source_method_is_callable
-from tests.test_yaml import test_build_manifest_split_config_tuple_is_correct
-from tests.test_yaml import test_build_manifest_split_dates_calls_set_split_dates
+from tests.test_yaml import test_build_manifest_data_source_date_limits_injected_from_split_dates
+from tests.test_yaml import test_build_manifest_rule_based_data_source_date_limits_injected_from_split_dates
+from tests.test_yaml import test_validate_error_for_test_data_source_in_yaml
+from tests.test_yaml import test_validate_error_for_start_date_limit_in_data_source_params
+from tests.test_yaml import test_validate_error_for_end_date_limit_in_data_source_params
+from tests.test_yaml import test_build_manifest_split_dates_is_correct
+from tests.test_yaml import test_build_manifest_split_dates_all_six_dates_stored
 from tests.test_yaml import test_build_manifest_indicator_include_if_stored_on_entry
 from tests.test_yaml import test_build_manifest_indicator_include_if_none_when_absent
 from tests.test_yaml import test_build_manifest_feature_include_if_stored_on_entry
@@ -1136,10 +1140,10 @@ tests = [
     test_validate_passes_valid_rule_based_yaml,
     test_validate_passes_valid_yaml_with_split_dates,
     test_validate_error_for_missing_required_field,
-    test_validate_error_when_both_split_config_and_split_dates_present,
+    test_validate_error_when_split_config_present,
     test_validate_error_for_invalid_split_date_format,
     test_validate_error_for_split_dates_out_of_order,
-    test_validate_error_for_split_config_invalid_value,
+    test_validate_error_for_split_config_present,
     test_validate_error_for_missing_mode,
     test_validate_error_for_unsafe_metadata_name,
     test_validate_error_for_empty_sfd_param_list,
@@ -1148,7 +1152,7 @@ tests = [
     test_validate_non_string_sfd_param_key_does_not_crash,
     test_validate_warning_for_unused_sfd_param,
     test_validate_warning_for_unknown_key_in_data_source,
-    test_validate_warning_for_unknown_key_in_split_config,
+    test_validate_warning_for_unknown_key_in_split_dates,
     test_validate_error_for_unresolvable_reference_architecture,
     test_validate_error_for_unresolvable_target_class,
     test_validate_error_for_callable_path_resolving_to_module,
@@ -1194,9 +1198,13 @@ tests = [
     test_resolve_func_params_raises_on_unresolvable_limen_path,
     test_resolve_func_params_raises_on_limen_module_path,
     test_build_manifest_data_source_method_is_callable_with_correct_params,
-    test_build_manifest_test_data_source_method_is_callable,
-    test_build_manifest_split_config_tuple_is_correct,
-    test_build_manifest_split_dates_calls_set_split_dates,
+    test_build_manifest_data_source_date_limits_injected_from_split_dates,
+    test_build_manifest_rule_based_data_source_date_limits_injected_from_split_dates,
+    test_validate_error_for_test_data_source_in_yaml,
+    test_validate_error_for_start_date_limit_in_data_source_params,
+    test_validate_error_for_end_date_limit_in_data_source_params,
+    test_build_manifest_split_dates_is_correct,
+    test_build_manifest_split_dates_all_six_dates_stored,
     test_build_manifest_indicator_include_if_stored_on_entry,
     test_build_manifest_indicator_include_if_none_when_absent,
     test_build_manifest_feature_include_if_stored_on_entry,

--- a/tests/run.py
+++ b/tests/run.py
@@ -794,6 +794,7 @@ from tests.test_sensor import test_predict_all_output_length_equals_input
 from tests.test_sensor import test_predict_all_warmup_bars_have_reason_warmup
 from tests.test_sensor import test_predict_all_valid_bars_have_predictions
 from tests.test_sensor import test_predict_all_inside_window_bars_flagged
+from tests.test_sensor import test_predict_all_midstream_null_row_has_reason_null_features
 from tests.test_sensor import test_predict_all_decoder_lookback_gt1_raises
 from tests.test_sensor import test_extract_scalar_returns_none_for_none
 from tests.test_sensor import test_extract_scalar_returns_python_int
@@ -1692,6 +1693,7 @@ tests = [
     test_predict_all_warmup_bars_have_reason_warmup,
     test_predict_all_valid_bars_have_predictions,
     test_predict_all_inside_window_bars_flagged,
+    test_predict_all_midstream_null_row_has_reason_null_features,
     test_predict_all_decoder_lookback_gt1_raises,
     test_extract_scalar_returns_none_for_none,
     test_extract_scalar_returns_python_int,

--- a/tests/run.py
+++ b/tests/run.py
@@ -71,6 +71,9 @@ from tests.test_yaml import test_validate_no_error_when_include_if_key_is_in_sfd
 from tests.test_yaml import test_validate_error_when_include_if_key_not_in_sfd_params
 from tests.test_yaml import test_validate_error_when_include_if_param_values_are_not_bool
 from tests.test_yaml import test_validate_error_for_required_columns_not_a_list
+from tests.test_yaml import test_validate_error_for_decoder_lookback_greater_than_one
+from tests.test_yaml import test_validate_error_for_decoder_lookback_zero
+from tests.test_yaml import test_validate_accepts_decoder_lookback_one
 from tests.test_yaml import test_validate_error_for_data_dict_extension_unknown_key
 from tests.test_yaml import test_validate_error_for_uel_search_strategy_wrong_type
 from tests.test_yaml import test_validate_error_for_uel_output_path_wrong_type
@@ -783,13 +786,22 @@ from tests.test_sensor import test_apply_sensor_pca_skipped_when_disabled
 from tests.test_sensor import test_apply_sensor_pca_skipped_when_no_config
 from tests.test_sensor import test_predict_raises_if_last_bar_is_warmup
 from tests.test_sensor import test_predict_raises_if_insufficient_valid_rows
+from tests.test_sensor import test_predict_raises_not_implemented_for_decoder_lookback_gt_1
 from tests.test_sensor import test_predict_raises_if_inside_training_window
+from tests.test_sensor import test_predict_allows_context_bars_inside_window_when_last_bar_is_valid
 from tests.test_sensor import test_predict_happy_path_returns_bar_prediction
 from tests.test_sensor import test_predict_all_output_length_equals_input
 from tests.test_sensor import test_predict_all_warmup_bars_have_reason_warmup
 from tests.test_sensor import test_predict_all_valid_bars_have_predictions
 from tests.test_sensor import test_predict_all_inside_window_bars_flagged
 from tests.test_sensor import test_predict_all_decoder_lookback_gt1_raises
+from tests.test_sensor import test_extract_scalar_returns_none_for_none
+from tests.test_sensor import test_extract_scalar_returns_python_int
+from tests.test_sensor import test_extract_scalar_returns_python_float
+from tests.test_sensor import test_extract_scalar_rejects_bool
+from tests.test_sensor import test_extract_scalar_from_numpy_array
+from tests.test_sensor import test_extract_scalar_from_zero_dim_numpy
+from tests.test_sensor import test_extract_scalar_from_empty_array_returns_none
 from tests.test_proto_cohort import test_rejects_when_no_source_provided
 from tests.test_proto_cohort import test_rejects_when_both_sources_provided
 from tests.test_proto_cohort import test_rejects_missing_experiment_log_path
@@ -1208,6 +1220,9 @@ tests = [
     test_validate_error_when_include_if_key_not_in_sfd_params,
     test_validate_error_when_include_if_param_values_are_not_bool,
     test_validate_error_for_required_columns_not_a_list,
+    test_validate_error_for_decoder_lookback_greater_than_one,
+    test_validate_error_for_decoder_lookback_zero,
+    test_validate_accepts_decoder_lookback_one,
     test_validate_error_for_data_dict_extension_unknown_key,
     test_validate_error_for_uel_search_strategy_wrong_type,
     test_validate_error_for_uel_output_path_wrong_type,
@@ -1669,13 +1684,22 @@ tests = [
     test_apply_sensor_pca_skipped_when_no_config,
     test_predict_raises_if_last_bar_is_warmup,
     test_predict_raises_if_insufficient_valid_rows,
+    test_predict_raises_not_implemented_for_decoder_lookback_gt_1,
     test_predict_raises_if_inside_training_window,
+    test_predict_allows_context_bars_inside_window_when_last_bar_is_valid,
     test_predict_happy_path_returns_bar_prediction,
     test_predict_all_output_length_equals_input,
     test_predict_all_warmup_bars_have_reason_warmup,
     test_predict_all_valid_bars_have_predictions,
     test_predict_all_inside_window_bars_flagged,
     test_predict_all_decoder_lookback_gt1_raises,
+    test_extract_scalar_returns_none_for_none,
+    test_extract_scalar_returns_python_int,
+    test_extract_scalar_returns_python_float,
+    test_extract_scalar_rejects_bool,
+    test_extract_scalar_from_numpy_array,
+    test_extract_scalar_from_zero_dim_numpy,
+    test_extract_scalar_from_empty_array_returns_none,
     test_rejects_when_no_source_provided,
     test_rejects_when_both_sources_provided,
     test_rejects_missing_experiment_log_path,

--- a/tests/run.py
+++ b/tests/run.py
@@ -749,22 +749,47 @@ from tests.test_fractional_diff import test_find_min_d_small_data_skips
 from tests.test_manifest_prepare_data import test_split_validation_rejects_invalid
 from tests.test_manifest_prepare_data import test_column_consistency_drops_mismatched_columns
 from tests.test_fractional_diff import test_fractional_diff_manifest_integration
-from tests.test_trainer import test_trainer_end_to_end
-from tests.test_trainer import test_reconstruction_error_stochastic
-from tests.test_trainer import test_reconstruction_error_tampered_log
-from tests.test_trainer import test_deterministic_validation
-from tests.test_trainer import test_pass2_uses_full_data
-from tests.test_trainer import test_sensor_inference
-from tests.test_trainer import test_trainer_with_feature_ablation
-from tests.test_trainer import test_trainer_with_fractional_diff
+from tests.test_trainer import test_trainer_requires_yaml_reference
+from tests.test_trainer import test_trainer_rejects_non_dict_yaml_reference
+from tests.test_trainer import test_trainer_rejects_malformed_yaml_reference
 from tests.test_trainer import test_load_round_data_skips_blank_and_malformed_lines
 from tests.test_trainer import test_load_round_data_requires_round_data_file
 from tests.test_trainer import test_load_original_log_returns_none_when_results_csv_is_missing
-from tests.test_trainer import test_resolve_model_class_requires_configured_architecture_function
-from tests.test_trainer import test_resolve_model_class_rejects_modules_without_reference_model_subclasses
-from tests.test_trainer import test_resolve_model_class_rejects_modules_with_multiple_reference_model_subclasses
 from tests.test_trainer import test_validate_metrics_ignores_metadata_fields_and_accepts_small_stochastic_drift
 from tests.test_trainer import test_validate_metrics_reports_missing_permutations_and_large_deterministic_mismatches
+from tests.test_trainer import test_trainer_yaml_end_to_end
+from tests.test_trainer import test_trainer_yaml_reconstruction_error_stochastic
+from tests.test_trainer import test_trainer_yaml_reconstruction_error_tampered_log
+from tests.test_trainer import test_trainer_yaml_deterministic_validation
+from tests.test_trainer import test_trainer_yaml_sensor_inference
+from tests.test_trainer import test_trainer_yaml_feature_ablation
+from tests.test_sensor import test_count_leading_nulls_no_nulls
+from tests.test_sensor import test_count_leading_nulls_leading_nulls
+from tests.test_sensor import test_count_leading_nulls_all_null
+from tests.test_sensor import test_count_leading_nulls_gap_in_middle
+from tests.test_sensor import test_count_leading_nulls_datetime_excluded
+from tests.test_sensor import test_count_leading_nulls_any_null_col_triggers_row
+from tests.test_sensor import test_count_leading_nulls_empty_features
+from tests.test_sensor import test_sensor_input_prep_preserves_row_count
+from tests.test_sensor import test_sensor_input_prep_indicator_lookback_matches_leading_nulls
+from tests.test_sensor import test_sensor_input_prep_no_leading_nulls_returns_zero_lookback
+from tests.test_sensor import test_sensor_input_prep_no_drop_nulls
+from tests.test_sensor import test_sensor_input_prep_drops_ablated_features
+from tests.test_sensor import test_sensor_input_prep_applies_fitted_scaler
+from tests.test_sensor import test_sensor_input_prep_scaler_leaves_null_rows_null
+from tests.test_sensor import test_apply_sensor_pca_transforms_valid_rows
+from tests.test_sensor import test_apply_sensor_pca_preserves_null_rows
+from tests.test_sensor import test_apply_sensor_pca_skipped_when_disabled
+from tests.test_sensor import test_apply_sensor_pca_skipped_when_no_config
+from tests.test_sensor import test_predict_raises_if_last_bar_is_warmup
+from tests.test_sensor import test_predict_raises_if_insufficient_valid_rows
+from tests.test_sensor import test_predict_raises_if_inside_training_window
+from tests.test_sensor import test_predict_happy_path_returns_bar_prediction
+from tests.test_sensor import test_predict_all_output_length_equals_input
+from tests.test_sensor import test_predict_all_warmup_bars_have_reason_warmup
+from tests.test_sensor import test_predict_all_valid_bars_have_predictions
+from tests.test_sensor import test_predict_all_inside_window_bars_flagged
+from tests.test_sensor import test_predict_all_decoder_lookback_gt1_raises
 from tests.test_proto_cohort import test_rejects_when_no_source_provided
 from tests.test_proto_cohort import test_rejects_when_both_sources_provided
 from tests.test_proto_cohort import test_rejects_missing_experiment_log_path
@@ -1609,22 +1634,47 @@ tests = [
     test_pca_compression_rejects_invalid_k,
     test_pca_compression_rejects_nonnumeric_features,
     test_fractional_diff_manifest_integration,
-    test_trainer_end_to_end,
-    test_reconstruction_error_stochastic,
-    test_reconstruction_error_tampered_log,
-    test_deterministic_validation,
-    test_pass2_uses_full_data,
-    test_sensor_inference,
-    test_trainer_with_feature_ablation,
-    test_trainer_with_fractional_diff,
+    test_trainer_requires_yaml_reference,
+    test_trainer_rejects_non_dict_yaml_reference,
+    test_trainer_rejects_malformed_yaml_reference,
     test_load_round_data_skips_blank_and_malformed_lines,
     test_load_round_data_requires_round_data_file,
     test_load_original_log_returns_none_when_results_csv_is_missing,
-    test_resolve_model_class_requires_configured_architecture_function,
-    test_resolve_model_class_rejects_modules_without_reference_model_subclasses,
-    test_resolve_model_class_rejects_modules_with_multiple_reference_model_subclasses,
     test_validate_metrics_ignores_metadata_fields_and_accepts_small_stochastic_drift,
     test_validate_metrics_reports_missing_permutations_and_large_deterministic_mismatches,
+    test_trainer_yaml_end_to_end,
+    test_trainer_yaml_reconstruction_error_stochastic,
+    test_trainer_yaml_reconstruction_error_tampered_log,
+    test_trainer_yaml_deterministic_validation,
+    test_trainer_yaml_sensor_inference,
+    test_trainer_yaml_feature_ablation,
+    test_count_leading_nulls_no_nulls,
+    test_count_leading_nulls_leading_nulls,
+    test_count_leading_nulls_all_null,
+    test_count_leading_nulls_gap_in_middle,
+    test_count_leading_nulls_datetime_excluded,
+    test_count_leading_nulls_any_null_col_triggers_row,
+    test_count_leading_nulls_empty_features,
+    test_sensor_input_prep_preserves_row_count,
+    test_sensor_input_prep_indicator_lookback_matches_leading_nulls,
+    test_sensor_input_prep_no_leading_nulls_returns_zero_lookback,
+    test_sensor_input_prep_no_drop_nulls,
+    test_sensor_input_prep_drops_ablated_features,
+    test_sensor_input_prep_applies_fitted_scaler,
+    test_sensor_input_prep_scaler_leaves_null_rows_null,
+    test_apply_sensor_pca_transforms_valid_rows,
+    test_apply_sensor_pca_preserves_null_rows,
+    test_apply_sensor_pca_skipped_when_disabled,
+    test_apply_sensor_pca_skipped_when_no_config,
+    test_predict_raises_if_last_bar_is_warmup,
+    test_predict_raises_if_insufficient_valid_rows,
+    test_predict_raises_if_inside_training_window,
+    test_predict_happy_path_returns_bar_prediction,
+    test_predict_all_output_length_equals_input,
+    test_predict_all_warmup_bars_have_reason_warmup,
+    test_predict_all_valid_bars_have_predictions,
+    test_predict_all_inside_window_bars_flagged,
+    test_predict_all_decoder_lookback_gt1_raises,
     test_rejects_when_no_source_provided,
     test_rejects_when_both_sources_provided,
     test_rejects_missing_experiment_log_path,

--- a/tests/run.py
+++ b/tests/run.py
@@ -892,6 +892,7 @@ from tests.test_cli_new import test_run_new_skips_backup_remote_with_invalid_cha
 from tests.test_cli_new import test_run_new_clone_failure_returns_false
 from tests.test_cli_new import test_run_new_warns_when_backup_remote_placeholder_missing
 from tests.test_cli_new import test_clone_template_fails_fast_on_git_init_failure
+from tests.test_e2e_loop_trainer_sensor import test_e2e_label_control_trainer_sensor
 
 tests = [
     test_param_domain_init,
@@ -1777,6 +1778,7 @@ tests = [
     test_run_new_clone_failure_returns_false,
     test_run_new_warns_when_backup_remote_placeholder_missing,
     test_clone_template_fails_fast_on_git_init_failure,
+    test_e2e_label_control_trainer_sensor,
 ]
 
 # Configure logging

--- a/tests/test_cli_commit.py
+++ b/tests/test_cli_commit.py
@@ -23,7 +23,7 @@ def _make_project(root: Path) -> None:
 
 
 def test_run_commit_fails_when_no_project_root() -> None:
-    with tempfile.TemporaryDirectory() as d:
+    with tempfile.TemporaryDirectory() as d, patch('click.echo'), patch('click.secho'):
         yaml_path = Path(d) / 'test.yaml'
         yaml_path.write_text(_MINIMAL_YAML)
         assert run_commit(yaml_path, None, None) is False
@@ -35,7 +35,8 @@ def test_run_commit_fails_on_invalid_yaml() -> None:
         _make_project(root)
         yaml_path = root / 'test.yaml'
         yaml_path.write_text(_MINIMAL_YAML)
-        with patch('limen.cli.commands.commit.load_and_validate', return_value=({}, False)):
+        with patch('limen.cli.commands.commit.load_and_validate', return_value=({}, False)), \
+             patch('click.echo'), patch('click.secho'):
             assert run_commit(yaml_path, None, None) is False
 
 
@@ -45,7 +46,8 @@ def test_run_commit_rejects_development_mode() -> None:
         _make_project(root)
         yaml_path = root / 'test.yaml'
         yaml_path.write_text(_MINIMAL_YAML)
-        with patch('limen.cli.commands.commit.load_and_validate', return_value=(_DEV_DICT, True)):
+        with patch('limen.cli.commands.commit.load_and_validate', return_value=(_DEV_DICT, True)), \
+             patch('click.echo'), patch('click.secho'):
             assert run_commit(yaml_path, None, None) is False
 
 
@@ -55,7 +57,8 @@ def test_run_commit_succeeds_for_production_yaml() -> None:
         _make_project(root)
         yaml_path = root / 'test.yaml'
         yaml_path.write_text(_MINIMAL_YAML)
-        with patch('limen.cli.commands.commit.load_and_validate', return_value=(_PROD_DICT, True)):
+        with patch('limen.cli.commands.commit.load_and_validate', return_value=(_PROD_DICT, True)), \
+             patch('click.echo'), patch('click.secho'):
             assert run_commit(yaml_path, None, None) is True
 
 
@@ -65,7 +68,8 @@ def test_run_commit_is_idempotent() -> None:
         _make_project(root)
         yaml_path = root / 'test.yaml'
         yaml_path.write_text(_MINIMAL_YAML)
-        with patch('limen.cli.commands.commit.load_and_validate', return_value=(_PROD_DICT, True)):
+        with patch('limen.cli.commands.commit.load_and_validate', return_value=(_PROD_DICT, True)), \
+             patch('click.echo'), patch('click.secho'):
             run_commit(yaml_path, None, None)
             assert run_commit(yaml_path, None, None) is True
 
@@ -76,7 +80,8 @@ def test_run_commit_rejects_invalid_parent_id() -> None:
         _make_project(root)
         yaml_path = root / 'test.yaml'
         yaml_path.write_text(_MINIMAL_YAML)
-        with patch('limen.cli.commands.commit.load_and_validate', return_value=(_PROD_DICT, True)):
+        with patch('limen.cli.commands.commit.load_and_validate', return_value=(_PROD_DICT, True)), \
+             patch('click.echo'), patch('click.secho'):
             assert run_commit(yaml_path, 'not-a-valid-id', None) is False
             assert run_commit(yaml_path, 'sha256:short', None) is False
             assert run_commit(yaml_path, 'sha256:' + 'z' * 64, None) is False
@@ -88,5 +93,6 @@ def test_run_commit_uses_custom_message() -> None:
         _make_project(root)
         yaml_path = root / 'test.yaml'
         yaml_path.write_text(_MINIMAL_YAML)
-        with patch('limen.cli.commands.commit.load_and_validate', return_value=(_PROD_DICT, True)):
+        with patch('limen.cli.commands.commit.load_and_validate', return_value=(_PROD_DICT, True)), \
+             patch('click.echo'), patch('click.secho'):
             assert run_commit(yaml_path, None, 'my custom message') is True

--- a/tests/test_cli_ls.py
+++ b/tests/test_cli_ls.py
@@ -1,6 +1,7 @@
 import json
 import tempfile
 from pathlib import Path
+from unittest.mock import patch
 
 from limen.cli.commands.ls import run_ls
 from limen.yaml.config import _STORE_RELATIVE
@@ -14,25 +15,25 @@ def _make_project(root: Path) -> Path:
 
 
 def test_run_ls_fails_when_no_project_root() -> None:
-    with tempfile.TemporaryDirectory() as d:
+    with tempfile.TemporaryDirectory() as d, patch('click.echo'), patch('click.secho'):
         assert run_ls(Path(d)) is False
 
 
 def test_run_ls_returns_true_when_no_index() -> None:
-    with tempfile.TemporaryDirectory() as d:
+    with tempfile.TemporaryDirectory() as d, patch('click.echo'), patch('click.secho'):
         _make_project(Path(d))
         assert run_ls(Path(d)) is True
 
 
 def test_run_ls_returns_true_when_empty_manifests() -> None:
-    with tempfile.TemporaryDirectory() as d:
+    with tempfile.TemporaryDirectory() as d, patch('click.echo'), patch('click.secho'):
         store = _make_project(Path(d))
         (store / 'index.json').write_text(json.dumps({'version': 1, 'manifests': []}))
         assert run_ls(Path(d)) is True
 
 
 def test_run_ls_lists_committed_manifests() -> None:
-    with tempfile.TemporaryDirectory() as d:
+    with tempfile.TemporaryDirectory() as d, patch('click.echo'), patch('click.secho'):
         store = _make_project(Path(d))
         entry = {
             'id': 'sha256:' + 'a' * 64,
@@ -45,21 +46,21 @@ def test_run_ls_lists_committed_manifests() -> None:
 
 
 def test_run_ls_returns_true_when_index_is_corrupt() -> None:
-    with tempfile.TemporaryDirectory() as d:
+    with tempfile.TemporaryDirectory() as d, patch('click.echo'), patch('click.secho'):
         store = _make_project(Path(d))
         (store / 'index.json').write_text('not valid json')
         assert run_ls(Path(d)) is True
 
 
 def test_run_ls_returns_true_when_index_has_invalid_structure() -> None:
-    with tempfile.TemporaryDirectory() as d:
+    with tempfile.TemporaryDirectory() as d, patch('click.echo'), patch('click.secho'):
         store = _make_project(Path(d))
         (store / 'index.json').write_text(json.dumps([1, 2, 3]))
         assert run_ls(Path(d)) is True
 
 
 def test_run_ls_skips_malformed_entries() -> None:
-    with tempfile.TemporaryDirectory() as d:
+    with tempfile.TemporaryDirectory() as d, patch('click.echo'), patch('click.secho'):
         store = _make_project(Path(d))
         good = {'id': 'sha256:' + 'a' * 64, 'name': 'ok', 'committed_at': '2026-05-28T10:00:00Z', 'parent_id': None}
         bad = {'broken': True}
@@ -68,7 +69,7 @@ def test_run_ls_skips_malformed_entries() -> None:
 
 
 def test_run_ls_skips_entry_with_non_string_id() -> None:
-    with tempfile.TemporaryDirectory() as d:
+    with tempfile.TemporaryDirectory() as d, patch('click.echo'), patch('click.secho'):
         store = _make_project(Path(d))
         entry = {'id': 12345, 'name': 'bad_id', 'committed_at': '2026-05-28T10:00:00Z', 'parent_id': None}
         (store / 'index.json').write_text(json.dumps({'version': 1, 'manifests': [entry]}))
@@ -76,7 +77,7 @@ def test_run_ls_skips_entry_with_non_string_id() -> None:
 
 
 def test_run_ls_skips_entry_with_non_string_parent_id() -> None:
-    with tempfile.TemporaryDirectory() as d:
+    with tempfile.TemporaryDirectory() as d, patch('click.echo'), patch('click.secho'):
         store = _make_project(Path(d))
         entry = {'id': 'sha256:' + 'a' * 64, 'name': 'ok', 'committed_at': '2026-05-28T10:00:00Z', 'parent_id': 999}
         (store / 'index.json').write_text(json.dumps({'version': 1, 'manifests': [entry]}))
@@ -84,7 +85,7 @@ def test_run_ls_skips_entry_with_non_string_parent_id() -> None:
 
 
 def test_run_ls_skips_entry_with_truncated_id() -> None:
-    with tempfile.TemporaryDirectory() as d:
+    with tempfile.TemporaryDirectory() as d, patch('click.echo'), patch('click.secho'):
         store = _make_project(Path(d))
         entry = {'id': 'sha256:' + 'a' * 8, 'name': 'ok', 'committed_at': '2026-05-28T10:00:00Z', 'parent_id': None}
         (store / 'index.json').write_text(json.dumps({'version': 1, 'manifests': [entry]}))
@@ -92,7 +93,7 @@ def test_run_ls_skips_entry_with_truncated_id() -> None:
 
 
 def test_run_ls_skips_entry_with_non_hex_id() -> None:
-    with tempfile.TemporaryDirectory() as d:
+    with tempfile.TemporaryDirectory() as d, patch('click.echo'), patch('click.secho'):
         store = _make_project(Path(d))
         entry = {'id': 'sha256:' + 'z' * 64, 'name': 'ok', 'committed_at': '2026-05-28T10:00:00Z', 'parent_id': None}
         (store / 'index.json').write_text(json.dumps({'version': 1, 'manifests': [entry]}))
@@ -100,7 +101,7 @@ def test_run_ls_skips_entry_with_non_hex_id() -> None:
 
 
 def test_run_ls_skips_entry_with_non_string_name() -> None:
-    with tempfile.TemporaryDirectory() as d:
+    with tempfile.TemporaryDirectory() as d, patch('click.echo'), patch('click.secho'):
         store = _make_project(Path(d))
         entry = {'id': 'sha256:' + 'a' * 64, 'name': 99, 'committed_at': '2026-05-28T10:00:00Z', 'parent_id': None}
         (store / 'index.json').write_text(json.dumps({'version': 1, 'manifests': [entry]}))
@@ -108,7 +109,7 @@ def test_run_ls_skips_entry_with_non_string_name() -> None:
 
 
 def test_run_ls_skips_entry_with_non_string_committed_at() -> None:
-    with tempfile.TemporaryDirectory() as d:
+    with tempfile.TemporaryDirectory() as d, patch('click.echo'), patch('click.secho'):
         store = _make_project(Path(d))
         entry = {'id': 'sha256:' + 'a' * 64, 'name': 'ok', 'committed_at': 12345, 'parent_id': None}
         (store / 'index.json').write_text(json.dumps({'version': 1, 'manifests': [entry]}))
@@ -116,7 +117,7 @@ def test_run_ls_skips_entry_with_non_string_committed_at() -> None:
 
 
 def test_run_ls_shows_parent_id_when_present() -> None:
-    with tempfile.TemporaryDirectory() as d:
+    with tempfile.TemporaryDirectory() as d, patch('click.echo'), patch('click.secho'):
         store = _make_project(Path(d))
         entry = {
             'id': 'sha256:' + 'b' * 64,

--- a/tests/test_cli_new.py
+++ b/tests/test_cli_new.py
@@ -7,7 +7,7 @@ from limen.cli.commands.new import run_new
 
 
 def test_run_new_fails_when_directory_exists() -> None:
-    with tempfile.TemporaryDirectory() as d:
+    with tempfile.TemporaryDirectory() as d, patch('click.echo'), patch('click.secho'):
         existing = Path(d) / 'my-project'
         existing.mkdir()
         assert run_new(str(existing), None) is False
@@ -23,7 +23,8 @@ def test_run_new_succeeds_with_mocked_clone() -> None:
             return True
 
         with patch('limen.cli.commands.new._clone_template', side_effect=fake_clone), \
-             patch('click.prompt', return_value=''):
+             patch('click.prompt', return_value=''), \
+             patch('click.echo'), patch('click.secho'):
             result = run_new(str(project_path.parent / 'new-project'), None)
 
         assert result is True
@@ -38,7 +39,8 @@ def test_run_new_sets_backup_remote() -> None:
             (path / 'limen.toml').write_text('backup_remote = ""\n')
             return True
 
-        with patch('limen.cli.commands.new._clone_template', side_effect=fake_clone):
+        with patch('limen.cli.commands.new._clone_template', side_effect=fake_clone), \
+             patch('click.echo'), patch('click.secho'):
             result = run_new(str(project_path), 'git@github.com:user/repo.git')
 
         assert result is True
@@ -49,7 +51,8 @@ def test_run_new_clone_failure_returns_false() -> None:
     with tempfile.TemporaryDirectory() as d:
         project_path = Path(d) / 'new-project'
 
-        with patch('limen.cli.commands.new._clone_template', return_value=False):
+        with patch('limen.cli.commands.new._clone_template', return_value=False), \
+             patch('click.echo'), patch('click.secho'):
             result = run_new(str(project_path), None)
 
         assert result is False
@@ -64,7 +67,8 @@ def test_run_new_warns_when_backup_remote_placeholder_missing() -> None:
             (path / 'limen.toml').write_text('# no placeholder here\n')
             return True
 
-        with patch('limen.cli.commands.new._clone_template', side_effect=fake_clone):
+        with patch('limen.cli.commands.new._clone_template', side_effect=fake_clone), \
+             patch('click.echo'), patch('click.secho'):
             result = run_new(str(project_path), 'git@github.com:user/repo.git')
 
         assert result is True
@@ -72,11 +76,12 @@ def test_run_new_warns_when_backup_remote_placeholder_missing() -> None:
 
 
 def test_run_new_fails_when_git_not_found() -> None:
-    with tempfile.TemporaryDirectory() as d:
+    with tempfile.TemporaryDirectory() as d, \
+         patch('limen.cli.commands.new.git_executable', side_effect=FileNotFoundError), \
+         patch('click.echo'), patch('click.secho'):
         project_path = Path(d) / 'new-project'
-        with patch('limen.cli.commands.new.git_executable', side_effect=FileNotFoundError):
-            result = run_new(str(project_path), None)
-        assert result is False
+        result = run_new(str(project_path), None)
+    assert result is False
 
 
 def test_run_new_skips_backup_remote_with_invalid_chars() -> None:
@@ -88,7 +93,8 @@ def test_run_new_skips_backup_remote_with_invalid_chars() -> None:
             (path / 'limen.toml').write_text('backup_remote = ""\n')
             return True
 
-        with patch('limen.cli.commands.new._clone_template', side_effect=fake_clone):
+        with patch('limen.cli.commands.new._clone_template', side_effect=fake_clone), \
+             patch('click.echo'), patch('click.secho'):
             result = run_new(str(project_path), 'git@github.com:user/"bad".git')
 
         assert result is True
@@ -114,7 +120,8 @@ def test_clone_template_fails_fast_on_git_init_failure() -> None:
             return result
 
         with patch('limen.cli.commands.new.subprocess.run', side_effect=fake_subprocess), \
-             patch('limen.cli.commands.new.shutil.rmtree'):
+             patch('limen.cli.commands.new.shutil.rmtree'), \
+             patch('click.echo'), patch('click.secho'):
             result = run_new(str(project_path), None)
 
         assert result is False

--- a/tests/test_e2e_loop_trainer_sensor.py
+++ b/tests/test_e2e_loop_trainer_sensor.py
@@ -243,8 +243,8 @@ def test_e2e_label_control_trainer_sensor() -> None:
 
         # Guarantee at least one calibrated and one uncalibrated sensor so both
         # code paths through LogRegBinary.predict() are exercised.
-        calibrated = results.filter(pl.col('use_calibration') == True)
-        uncalibrated = results.filter(pl.col('use_calibration') == False)
+        calibrated = results.filter(pl.col('use_calibration'))
+        uncalibrated = results.filter(~pl.col('use_calibration'))
         cal_ids = calibrated.sort('accuracy', descending=True).head(2)['id'].to_list()
         uncal_ids = uncalibrated.sort('accuracy', descending=True).head(1)['id'].to_list()
         top_ids = cal_ids + uncal_ids
@@ -291,7 +291,7 @@ def test_e2e_label_control_trainer_sensor() -> None:
             assert n_inside == 0
             assert n_valid > 0
             assert n_warmup + n_valid == len(inference_klines)
-            assert all(p.datetime == dt for p, dt in zip(all_preds, kline_dts))
+            assert all(p.datetime == dt for p, dt in zip(all_preds, kline_dts, strict=True))
 
             valid_preds = [p for p in all_preds if p.reason is None]
             assert all(p.probability is not None for p in valid_preds)
@@ -321,7 +321,7 @@ def test_e2e_label_control_trainer_sensor() -> None:
             assert len(min_preds) == n_warmup + 1
             assert sum(1 for p in min_preds if p.reason == 'warm-up') == n_warmup
             assert sum(1 for p in min_preds if p.reason is None) == 1
-            assert all(p.datetime == dt for p, dt in zip(min_preds, min_dts))
+            assert all(p.datetime == dt for p, dt in zip(min_preds, min_dts, strict=True))
 
             min_bar_pred = sensor.predict(min_klines)
             assert min_bar_pred.reason is None
@@ -341,7 +341,7 @@ def test_e2e_label_control_trainer_sensor() -> None:
             assert len(few_preds) == n_warmup + 5
             assert sum(1 for p in few_preds if p.reason == 'warm-up') == n_warmup
             assert sum(1 for p in few_preds if p.reason is None) == 5
-            assert all(p.datetime == dt for p, dt in zip(few_preds, few_dts))
+            assert all(p.datetime == dt for p, dt in zip(few_preds, few_dts, strict=True))
 
             few_valid = [p for p in few_preds if p.reason is None]
             assert all(p.probability is not None for p in few_valid)

--- a/tests/test_e2e_loop_trainer_sensor.py
+++ b/tests/test_e2e_loop_trainer_sensor.py
@@ -1,4 +1,5 @@
 import json
+import math
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from textwrap import dedent
@@ -285,7 +286,7 @@ def test_e2e_label_control_trainer_sensor() -> None:
             assert bar_pred.datetime == kline_dts[-1]
             last_valid = next(p for p in reversed(all_preds) if p.reason is None)
             assert last_valid.prediction == bar_pred.prediction
-            assert last_valid.probability == bar_pred.probability
+            assert math.isclose(last_valid.probability, bar_pred.probability, rel_tol=1e-6)
 
             assert n_warmup + 5 <= len(inference_klines), (
                 f"inference window too small: {len(inference_klines)} bars, n_warmup={n_warmup}"
@@ -329,4 +330,4 @@ def test_e2e_label_control_trainer_sensor() -> None:
             assert 0.0 <= few_bar_pred.probability <= 1.0
             assert few_bar_pred.datetime == few_dts[-1]
             assert few_bar_pred.prediction == few_preds[-1].prediction
-            assert few_bar_pred.probability == few_preds[-1].probability
+            assert math.isclose(few_bar_pred.probability, few_preds[-1].probability, rel_tol=1e-6)

--- a/tests/test_e2e_loop_trainer_sensor.py
+++ b/tests/test_e2e_loop_trainer_sensor.py
@@ -241,11 +241,20 @@ def test_e2e_label_control_trainer_sensor() -> None:
 
         # ── Trainer ───────────────────────────────────────────────────────────
 
-        top_ids = results.sort('accuracy', descending=True).head(_TOP_N)['id'].to_list()
+        # Guarantee at least one calibrated and one uncalibrated sensor so both
+        # code paths through LogRegBinary.predict() are exercised.
+        calibrated = results.filter(pl.col('use_calibration') == True)
+        uncalibrated = results.filter(pl.col('use_calibration') == False)
+        cal_ids = calibrated.sort('accuracy', descending=True).head(2)['id'].to_list()
+        uncal_ids = uncalibrated.sort('accuracy', descending=True).head(1)['id'].to_list()
+        top_ids = cal_ids + uncal_ids
 
         trainer = Trainer(exp_dir)
         sensors = trainer.train(top_ids)
         assert len(sensors) == _TOP_N
+
+        sensor_pids = [s.permutation_id for s in sensors]
+        assert len(set(sensor_pids)) == _TOP_N, f'duplicate permutation_ids: {sensor_pids}'
 
         for sensor in sensors:
             assert sensor.permutation_id in top_ids
@@ -284,6 +293,10 @@ def test_e2e_label_control_trainer_sensor() -> None:
             assert n_warmup + n_valid == len(inference_klines)
             assert all(p.datetime == dt for p, dt in zip(all_preds, kline_dts))
 
+            valid_preds = [p for p in all_preds if p.reason is None]
+            assert all(p.probability is not None for p in valid_preds)
+            assert all(0.0 <= p.probability <= 1.0 for p in valid_preds)
+
             bar_pred = sensor.predict(inference_klines)
             assert isinstance(bar_pred, BarPrediction)
             assert bar_pred.reason is None
@@ -293,6 +306,7 @@ def test_e2e_label_control_trainer_sensor() -> None:
             assert bar_pred.datetime == kline_dts[-1]
             last_valid = next(p for p in reversed(all_preds) if p.reason is None)
             assert last_valid.prediction == bar_pred.prediction
+            assert last_valid.probability == bar_pred.probability
 
             assert n_warmup + 5 <= len(inference_klines), (
                 f'inference window too small: {len(inference_klines)} bars, n_warmup={n_warmup}'
@@ -312,8 +326,11 @@ def test_e2e_label_control_trainer_sensor() -> None:
             min_bar_pred = sensor.predict(min_klines)
             assert min_bar_pred.reason is None
             assert min_bar_pred.prediction in (0, 1)
+            assert min_bar_pred.probability is not None
+            assert 0.0 <= min_bar_pred.probability <= 1.0
             assert min_bar_pred.datetime == min_dts[-1]
             assert min_bar_pred.prediction == min_preds[-1].prediction
+            assert min_bar_pred.probability == min_preds[-1].probability
 
             # ── Few bars window (n_warmup + 5 bars) ──────────────────────────
 
@@ -326,8 +343,15 @@ def test_e2e_label_control_trainer_sensor() -> None:
             assert sum(1 for p in few_preds if p.reason is None) == 5
             assert all(p.datetime == dt for p, dt in zip(few_preds, few_dts))
 
+            few_valid = [p for p in few_preds if p.reason is None]
+            assert all(p.probability is not None for p in few_valid)
+            assert all(0.0 <= p.probability <= 1.0 for p in few_valid)
+
             few_bar_pred = sensor.predict(few_klines)
             assert few_bar_pred.reason is None
             assert few_bar_pred.prediction in (0, 1)
+            assert few_bar_pred.probability is not None
+            assert 0.0 <= few_bar_pred.probability <= 1.0
             assert few_bar_pred.datetime == few_dts[-1]
             assert few_bar_pred.prediction == few_preds[-1].prediction
+            assert few_bar_pred.probability == few_preds[-1].probability

--- a/tests/test_e2e_loop_trainer_sensor.py
+++ b/tests/test_e2e_loop_trainer_sensor.py
@@ -1,9 +1,3 @@
-'''
-End-to-end integration tests: experiment loop → Trainer → Sensor inference.
-
-These tests use real HistoricalData API calls (network required) and cover the
-full pipeline from YAML experiment to trained sensors with live bar prediction.
-'''
 import json
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -18,11 +12,6 @@ from limen.experiment.trainer import Trainer
 from limen.experiment.trainer.sensor import BarPrediction
 
 
-# Adapted from logreg_label_control.yaml:
-#   - split_config replaced with explicit split_dates
-#   - start_date_limit/end_date_limit removed from data_source.params (blocked by validator)
-#   - mode: development for testing
-#   - n_permutations reduced to 10
 _LABEL_CONTROL_YAML = dedent('''\
     schema_version: "1.0"
     metadata:
@@ -205,8 +194,6 @@ def test_e2e_label_control_trainer_sensor() -> None:
         exp_dir = Path(tmpdir) / 'label_control'
         exp_dir.mkdir()
 
-        # ── Experiment ────────────────────────────────────────────────────────
-
         with TemporaryDirectory() as yaml_dir, patch('click.echo'), patch('click.secho'):
             yaml_path = Path(yaml_dir) / 'label_control.yaml'
             yaml_path.write_text(_LABEL_CONTROL_YAML.replace(
@@ -239,8 +226,6 @@ def test_e2e_label_control_trainer_sensor() -> None:
                     round_ids.append(json.loads(stripped)['round_id'])
         assert len(round_ids) == _N_PERMUTATIONS
 
-        # ── Trainer ───────────────────────────────────────────────────────────
-
         # Guarantee at least one calibrated and one uncalibrated sensor so both
         # code paths through LogRegBinary.predict() are exercised.
         calibrated = results.filter(pl.col('use_calibration'))
@@ -254,7 +239,7 @@ def test_e2e_label_control_trainer_sensor() -> None:
         assert len(sensors) == _TOP_N
 
         sensor_pids = [s.permutation_id for s in sensors]
-        assert len(set(sensor_pids)) == _TOP_N, f'duplicate permutation_ids: {sensor_pids}'
+        assert len(set(sensor_pids)) == _TOP_N, f"duplicate permutation_ids: {sensor_pids}"
 
         for sensor in sensors:
             assert sensor.permutation_id in top_ids
@@ -265,8 +250,6 @@ def test_e2e_label_control_trainer_sensor() -> None:
             assert 'feature_drop_seed' in rp
             assert 'auto_pca' in rp
 
-        # ── Inference data ────────────────────────────────────────────────────
-
         inference_klines = historical_data.HistoricalData().get_spot_klines(
             kline_size=900,
             start_date_limit=_INFERENCE_START,
@@ -275,18 +258,14 @@ def test_e2e_label_control_trainer_sensor() -> None:
         assert len(inference_klines) > 50
         kline_dts = inference_klines['datetime'].to_list()
 
-        # ── Sensor inference — three windows per sensor ───────────────────────
-
         for sensor in sensors:
-
-            # ── Full window ───────────────────────────────────────────────────
 
             all_preds = sensor.predict_all(inference_klines)
             assert len(all_preds) == len(inference_klines)
 
             n_warmup = sum(1 for p in all_preds if p.reason == 'warm-up')
             n_inside = sum(1 for p in all_preds if p.reason == 'inside-training-window')
-            n_valid  = sum(1 for p in all_preds if p.reason is None)
+            n_valid = sum(1 for p in all_preds if p.reason is None)
 
             assert n_inside == 0
             assert n_valid > 0
@@ -309,10 +288,8 @@ def test_e2e_label_control_trainer_sensor() -> None:
             assert last_valid.probability == bar_pred.probability
 
             assert n_warmup + 5 <= len(inference_klines), (
-                f'inference window too small: {len(inference_klines)} bars, n_warmup={n_warmup}'
+                f"inference window too small: {len(inference_klines)} bars, n_warmup={n_warmup}"
             )
-
-            # ── Minimum window (n_warmup + 1 bars) ───────────────────────────
 
             min_klines = inference_klines[:n_warmup + 1]
             min_dts = min_klines['datetime'].to_list()
@@ -331,8 +308,6 @@ def test_e2e_label_control_trainer_sensor() -> None:
             assert min_bar_pred.datetime == min_dts[-1]
             assert min_bar_pred.prediction == min_preds[-1].prediction
             assert min_bar_pred.probability == min_preds[-1].probability
-
-            # ── Few bars window (n_warmup + 5 bars) ──────────────────────────
 
             few_klines = inference_klines[:n_warmup + 5]
             few_dts = few_klines['datetime'].to_list()

--- a/tests/test_e2e_loop_trainer_sensor.py
+++ b/tests/test_e2e_loop_trainer_sensor.py
@@ -1,0 +1,333 @@
+'''
+End-to-end integration tests: experiment loop → Trainer → Sensor inference.
+
+These tests use real HistoricalData API calls (network required) and cover the
+full pipeline from YAML experiment to trained sensors with live bar prediction.
+'''
+import json
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from textwrap import dedent
+from unittest.mock import patch
+
+import polars as pl
+
+from limen.cli.commands.run import run_experiment
+from limen.data import historical_data
+from limen.experiment.trainer import Trainer
+from limen.experiment.trainer.sensor import BarPrediction
+
+
+# Adapted from logreg_label_control.yaml:
+#   - split_config replaced with explicit split_dates
+#   - start_date_limit/end_date_limit removed from data_source.params (blocked by validator)
+#   - mode: development for testing
+#   - n_permutations reduced to 10
+_LABEL_CONTROL_YAML = dedent('''\
+    schema_version: "1.0"
+    metadata:
+      name: btc_logreg_15m_random_ctrl
+      limen_version: "3.8.0"
+      mode: development
+      description: Random-label control (noise floor) for the 15m logreg pipeline
+    sfd:
+      manifest:
+        type: ml
+        data_source:
+          method: limen.data.HistoricalData.get_spot_klines
+          params:
+            kline_size: 900
+        split_dates:
+          train_start: "2025-01-01"
+          train_end: "2025-04-30"
+          val_start: "2025-04-30"
+          val_end: "2025-05-14"
+          test_start: "2025-05-14"
+          test_end: "2025-05-28"
+        features:
+          - func: limen.features.fractional_diff
+            params:
+              d: "{frac_diff_d}"
+              cols: [close]
+              threshold: 0.001
+          - func: limen.features.log_returns.log_returns
+            params:
+              group: momentum
+          - func: limen.indicators.roc
+            params:
+              period: "{roc_period}"
+              group: momentum
+          - func: limen.indicators.ppo
+            params:
+              group: momentum
+          - func: limen.indicators.wilder_rsi
+            params:
+              period: "{rsi_period}"
+              group: momentum
+          - func: limen.indicators.cci
+            params:
+              group: momentum
+          - func: limen.indicators.willr
+            params:
+              group: momentum
+          - func: limen.indicators.mom
+            params:
+              group: momentum
+          - func: limen.indicators.atr
+            params:
+              period: "{atr_period}"
+              group: volatility
+          - func: limen.indicators.natr
+            params:
+              group: volatility
+          - func: limen.indicators.bbands
+            params:
+              period: "{bbands_period}"
+              group: volatility
+          - func: limen.indicators.stddev
+            params:
+              group: volatility
+          - func: limen.indicators.rolling_volatility
+            params:
+              group: volatility
+          - func: limen.indicators.obv
+            params:
+              group: volume
+          - func: limen.indicators.mfi
+            params:
+              group: volume
+          - func: limen.features.vwap
+            params:
+              group: volume
+          - func: limen.features.kline_imbalance
+            params:
+              group: volume
+          - func: limen.features.dollar_volume
+            params:
+              group: volume
+          - func: limen.features.volume_regime
+            params:
+              group: volume
+          - func: limen.indicators.ema
+            params:
+              period: "{ema_period}"
+              group: trend
+          - func: limen.indicators.sma
+            params:
+              group: trend
+          - func: limen.features.trend_strength
+            params:
+              group: trend
+          - func: limen.features.range_pct
+            params:
+              group: microstructure
+          - func: limen.features.body_to_range
+            params:
+              group: microstructure
+          - func: limen.features.close_position
+            params:
+              group: microstructure
+        target:
+          name: random_binary
+          class: limen.targets.RandomBinaryTarget
+          fit_params:
+            random_state: "{random_state}"
+        scaler:
+          from_params: scaler_type
+        feature_ablation:
+          drop_count_key: feature_drop_count
+          seed_key: feature_drop_seed
+        pca_compression: {}
+        reference_architecture: limen.sfd.reference_architecture.logreg_binary
+        calibration:
+          probability_calibration:
+            func: limen.calibration.sklearn_probability_calibrator
+            params:
+              method: "{cal_method}"
+          threshold_function:
+            func: limen.calibration.grid_threshold_optimizer
+            params:
+              metric: limen.metrics.balanced_metric.balanced_metric
+              threshold_min: "{threshold_min}"
+              threshold_max: "{threshold_max}"
+              threshold_step: "{threshold_step}"
+      params:
+        frac_diff_d: [0.0, 0.1, 0.2, 0.3, 0.4]
+        roc_period: [1, 4, 8, 16, 48, 96]
+        atr_period: [7, 14, 28]
+        rsi_period: [7, 14, 28]
+        ema_period: [12, 26, 96]
+        bbands_period: [20, 48, 96]
+        scaler_type: [robust]
+        feature_groups: [all, momentum, volatility, volume, "momentum|volatility", "momentum|volume"]
+        feature_drop_count: [1, 2, 3, 4, 5]
+        feature_drop_seed: [42]
+        auto_pca: [true, false]
+        pca_k: [15, 16, 17, 18]
+        use_calibration: [true, false]
+        use_threshold: [true, false]
+        cal_method: [isotonic, sigmoid]
+        threshold_min: [0.20, 0.30, 0.40]
+        threshold_max: [0.55, 0.65, 0.75]
+        threshold_step: [0.02, 0.05]
+        solver: [lbfgs, liblinear, saga]
+        penalty: [l2]
+        dual: [false]
+        tol: [0.0001, 0.001, 0.01]
+        C: [0.01, 0.05, 0.1, 0.5, 1.0, 3.0, 10.0]
+        fit_intercept: [true, false]
+        intercept_scaling: [1.0]
+        class_weight: [0.40, 0.50, 0.60, 0.75, 0.90]
+        random_state: [42]
+        max_iter: [60, 120, 240, 500]
+        multi_class: [deprecated]
+        verbose: [0]
+        warm_start: [false]
+        n_jobs: [-1]
+        l1_ratio: [null]
+    uel:
+      n_permutations: 10
+      search_strategy:
+        type: random
+      prep_each_round: true
+      output_format: csv
+''')
+
+_N_PERMUTATIONS = 10
+_TOP_N = 3
+_INFERENCE_START = '2025-05-29'
+_INFERENCE_END = '2025-05-31'
+
+
+def test_e2e_label_control_trainer_sensor() -> None:
+
+    with TemporaryDirectory() as tmpdir:
+        exp_dir = Path(tmpdir) / 'label_control'
+        exp_dir.mkdir()
+
+        # ── Experiment ────────────────────────────────────────────────────────
+
+        with TemporaryDirectory() as yaml_dir, patch('click.echo'), patch('click.secho'):
+            yaml_path = Path(yaml_dir) / 'label_control.yaml'
+            yaml_path.write_text(_LABEL_CONTROL_YAML.replace(
+                'output_format: csv',
+                f'output_format: csv\n  output_path: "{exp_dir}"',
+            ))
+            ok = run_experiment(yaml_path)
+
+        assert ok
+        assert (exp_dir / 'results.csv').exists()
+        assert (exp_dir / 'round_data.jsonl').exists()
+        assert (exp_dir / 'metadata.json').exists()
+
+        results = pl.read_csv(exp_dir / 'results.csv')
+        assert len(results) == _N_PERMUTATIONS
+        assert results['id'].n_unique() == _N_PERMUTATIONS
+        assert 'accuracy' in results.columns
+        assert 'auc' in results.columns
+
+        metadata = json.loads((exp_dir / 'metadata.json').read_text())
+        assert 'yaml_reference' in metadata
+        assert 'limen_version' in metadata
+        assert metadata['yaml_reference']['metadata']['name'] == 'btc_logreg_15m_random_ctrl'
+
+        round_ids: list[int] = []
+        with (exp_dir / 'round_data.jsonl').open() as f:
+            for line in f:
+                stripped = line.strip()
+                if stripped:
+                    round_ids.append(json.loads(stripped)['round_id'])
+        assert len(round_ids) == _N_PERMUTATIONS
+
+        # ── Trainer ───────────────────────────────────────────────────────────
+
+        top_ids = results.sort('accuracy', descending=True).head(_TOP_N)['id'].to_list()
+
+        trainer = Trainer(exp_dir)
+        sensors = trainer.train(top_ids)
+        assert len(sensors) == _TOP_N
+
+        for sensor in sensors:
+            assert sensor.permutation_id in top_ids
+            rp = sensor.round_params
+            assert '_dropped_features' in rp
+            assert isinstance(rp['_dropped_features'], list)
+            assert 'feature_drop_count' in rp
+            assert 'feature_drop_seed' in rp
+            assert 'auto_pca' in rp
+
+        # ── Inference data ────────────────────────────────────────────────────
+
+        inference_klines = historical_data.HistoricalData().get_spot_klines(
+            kline_size=900,
+            start_date_limit=_INFERENCE_START,
+            end_date_limit=_INFERENCE_END,
+        )
+        assert len(inference_klines) > 50
+        kline_dts = inference_klines['datetime'].to_list()
+
+        # ── Sensor inference — three windows per sensor ───────────────────────
+
+        for sensor in sensors:
+
+            # ── Full window ───────────────────────────────────────────────────
+
+            all_preds = sensor.predict_all(inference_klines)
+            assert len(all_preds) == len(inference_klines)
+
+            n_warmup = sum(1 for p in all_preds if p.reason == 'warm-up')
+            n_inside = sum(1 for p in all_preds if p.reason == 'inside-training-window')
+            n_valid  = sum(1 for p in all_preds if p.reason is None)
+
+            assert n_inside == 0
+            assert n_valid > 0
+            assert n_warmup + n_valid == len(inference_klines)
+            assert all(p.datetime == dt for p, dt in zip(all_preds, kline_dts))
+
+            bar_pred = sensor.predict(inference_klines)
+            assert isinstance(bar_pred, BarPrediction)
+            assert bar_pred.reason is None
+            assert bar_pred.prediction in (0, 1)
+            assert bar_pred.probability is not None
+            assert 0.0 <= bar_pred.probability <= 1.0
+            assert bar_pred.datetime == kline_dts[-1]
+            last_valid = next(p for p in reversed(all_preds) if p.reason is None)
+            assert last_valid.prediction == bar_pred.prediction
+
+            assert n_warmup + 5 <= len(inference_klines), (
+                f'inference window too small: {len(inference_klines)} bars, n_warmup={n_warmup}'
+            )
+
+            # ── Minimum window (n_warmup + 1 bars) ───────────────────────────
+
+            min_klines = inference_klines[:n_warmup + 1]
+            min_dts = min_klines['datetime'].to_list()
+
+            min_preds = sensor.predict_all(min_klines)
+            assert len(min_preds) == n_warmup + 1
+            assert sum(1 for p in min_preds if p.reason == 'warm-up') == n_warmup
+            assert sum(1 for p in min_preds if p.reason is None) == 1
+            assert all(p.datetime == dt for p, dt in zip(min_preds, min_dts))
+
+            min_bar_pred = sensor.predict(min_klines)
+            assert min_bar_pred.reason is None
+            assert min_bar_pred.prediction in (0, 1)
+            assert min_bar_pred.datetime == min_dts[-1]
+            assert min_bar_pred.prediction == min_preds[-1].prediction
+
+            # ── Few bars window (n_warmup + 5 bars) ──────────────────────────
+
+            few_klines = inference_klines[:n_warmup + 5]
+            few_dts = few_klines['datetime'].to_list()
+
+            few_preds = sensor.predict_all(few_klines)
+            assert len(few_preds) == n_warmup + 5
+            assert sum(1 for p in few_preds if p.reason == 'warm-up') == n_warmup
+            assert sum(1 for p in few_preds if p.reason is None) == 5
+            assert all(p.datetime == dt for p, dt in zip(few_preds, few_dts))
+
+            few_bar_pred = sensor.predict(few_klines)
+            assert few_bar_pred.reason is None
+            assert few_bar_pred.prediction in (0, 1)
+            assert few_bar_pred.datetime == few_dts[-1]
+            assert few_bar_pred.prediction == few_preds[-1].prediction

--- a/tests/test_inline_metrics.py
+++ b/tests/test_inline_metrics.py
@@ -93,5 +93,11 @@ def test_xgboost_inline_and_post_backtest_metrics_match() -> None:
 
     uel = _run_uel(sfd_module=xgboost_sfd, n_permutations=1)
 
-    assert uel.experiment_log['backtest_trade_pnl_net_bps_p50'].to_list() == \
-        uel.experiment_backtest_results['trade_pnl_net_bps_p50'].tolist()
+    for inline_value, post_value in zip(
+        uel.experiment_log['backtest_trade_pnl_net_bps_p50'].to_list(),
+        uel.experiment_backtest_results['trade_pnl_net_bps_p50'].tolist(),
+        strict=True,
+    ):
+        if math.isnan(inline_value) and math.isnan(post_value):
+            continue
+        assert inline_value == post_value

--- a/tests/test_profiler.py
+++ b/tests/test_profiler.py
@@ -172,10 +172,13 @@ def test_profile_warns_when_test_data_source_absent() -> None:
               method: limen.data.HistoricalData.get_spot_klines
               params:
                 kline_size: 3600
-            split_config:
-              train: 8
-              val: 1
-              test: 2
+            split_dates:
+              train_start: "2024-01-01"
+              train_end: "2024-09-30"
+              val_start: "2024-10-01"
+              val_end: "2024-11-30"
+              test_start: "2024-12-01"
+              test_end: "2024-12-31"
             target:
               name: quantile_flag
               class: limen.targets.QuantileBinaryTarget

--- a/tests/test_proto_cohort.py
+++ b/tests/test_proto_cohort.py
@@ -4,6 +4,8 @@ from datetime import datetime
 from datetime import timedelta
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from textwrap import dedent
+from unittest.mock import patch
 
 import numpy as np
 import pandas as pd
@@ -13,12 +15,53 @@ from limen.cli.commands.run import run_experiment
 from limen.cohort import Cohort
 from limen.cohort.sfc.top_n import select as select_top_n
 from limen.data import historical_data
-from limen.experiment.experiment_core import UniversalExperimentLoop
-from limen.experiment.param_domain import ParamDomain
-from limen.experiment.param_search import GridStrategy
 from limen.experiment.trainer import Trainer
-from limen.sfd.foundational_sfd import logreg_binary as logreg_sfd
-from tests.test_yaml import _MINIMAL_ML_YAML
+
+_COHORT_CONTRACT_YAML = dedent('''\
+    schema_version: "1.0"
+    metadata:
+      name: test_exp
+      mode: development
+    sfd:
+      manifest:
+        type: ml
+        data_source:
+          method: limen.data.HistoricalData.get_spot_klines
+          params:
+            kline_size: 3600
+        split_dates:
+          train_start: "2025-01-01"
+          train_end: "2025-01-15"
+          val_start: "2025-01-15"
+          val_end: "2025-01-18"
+          test_start: "2025-01-18"
+          test_end: "2025-01-22"
+        indicators:
+          - func: limen.indicators.roc
+            params:
+              period: 1
+              group: momentum
+        target:
+          name: quantile_flag
+          class: limen.targets.QuantileBinaryTarget
+          fit_params:
+            source_column: roc_1
+            quantile: 0.5
+          transform_params:
+            shift: -1
+        scaler:
+          from_params: scaler_type
+        reference_architecture: limen.sfd.reference_architecture.logreg_binary
+      params:
+        scaler_type: [logreg]
+        C: [1.0, 0.5]
+        random_state: [42]
+    uel:
+      n_permutations: 2
+      search_strategy:
+        type: random
+      output_format: csv
+''')
 
 
 class _RaisingMember:
@@ -40,8 +83,7 @@ class _FallbackContinuousMember:
         self.permutation_id = permutation_id
         self._preds = np.asarray(preds, dtype=float)
         self._round_params = {'model_architecture': architecture}
-        self._metadata = {
-            'sfd_module': 'limen.sfd.foundational_sfd.logreg_binary'}
+        self._metadata = {}
 
     @property
     def round_params(self) -> dict:
@@ -61,20 +103,18 @@ class _FallbackContinuousMember:
 def _run_real_experiment(experiment_dir: Path,
                          n_permutations: int = 2) -> list[int]:
 
-    params = logreg_sfd.params()
-    domain = ParamDomain(params)
-    strategy = GridStrategy(domain)
-
-    uel = UniversalExperimentLoop(
-        sfd=logreg_sfd,
-        search_strategy=strategy,
-        experiment_dir=experiment_dir,
-    )
-
-    uel.run(
-        experiment_name='test_proto_cohort',
-        n_permutations=n_permutations,
-    )
+    experiment_dir = Path(experiment_dir).resolve()
+    original = historical_data.HistoricalData.get_spot_klines
+    historical_data.HistoricalData.get_spot_klines = staticmethod(_make_yaml_contract_data)
+    try:
+        with TemporaryDirectory() as tmpdir, patch('click.echo'), patch('click.secho'):
+            yaml_path = Path(tmpdir) / 'exp.yaml'
+            yaml_text = _minimal_yaml_cli_contract_text(experiment_dir)
+            yaml_text = yaml_text.replace('n_permutations: 2', f'n_permutations: {n_permutations}')
+            yaml_path.write_text(yaml_text)
+            run_experiment(yaml_path)
+    finally:
+        historical_data.HistoricalData.get_spot_klines = original
 
     round_ids: list[int] = []
     with (experiment_dir / 'round_data.jsonl').open('r') as f:
@@ -148,20 +188,26 @@ def _patch_round_architecture(experiment_dir: Path,
 def _train_real_members_and_input(experiment_dir: Path,
                                   permutation_ids: list[int]) -> tuple[list, np.ndarray]:
 
-    trainer = Trainer(experiment_dir)
-    sensors = trainer.train(permutation_ids)
-
-    data_dict = trainer._manifest.prepare_data(
-        trainer._data, sensors[0].round_params)
-    x_test = data_dict['x_test']
+    original = historical_data.HistoricalData.get_spot_klines
+    historical_data.HistoricalData.get_spot_klines = staticmethod(_make_yaml_contract_data)
+    try:
+        trainer = Trainer(experiment_dir)
+        sensors = trainer.train(permutation_ids)
+        data_dict = trainer._manifest.prepare_data(
+            trainer._data, sensors[0].round_params)
+        x_test = data_dict['x_test']
+    finally:
+        historical_data.HistoricalData.get_spot_klines = original
 
     return sensors, x_test
 
 
 def _make_yaml_contract_data(kline_size: int = 3600,
-                             n_rows: int | None = None) -> pl.DataFrame:
+                             n_rows: int | None = None,
+                             start_date_limit: object = None,
+                             end_date_limit: object = None) -> pl.DataFrame:
 
-    _ = kline_size
+    _ = kline_size, start_date_limit, end_date_limit
     n = int(n_rows or 500)
     timestamps = [datetime(2025, 1, 1) + timedelta(hours=i) for i in range(n)]
     close = [100.0 + 0.02 * i + math.sin(i / 7.0) for i in range(n)]
@@ -178,17 +224,7 @@ def _make_yaml_contract_data(kline_size: int = 3600,
 
 def _minimal_yaml_cli_contract_text(output_path: Path) -> str:
 
-    yaml_text = _MINIMAL_ML_YAML.replace('n_permutations: 5', 'n_permutations: 1')
-    yaml_text = yaml_text.replace(
-        'use_calibration: [true, false]',
-        'use_calibration: [false]',
-    )
-    yaml_text = yaml_text.replace(
-        'use_threshold: [true, false]',
-        'use_threshold: [false]',
-    )
-
-    return yaml_text.replace(
+    return _COHORT_CONTRACT_YAML.replace(
         'output_format: csv',
         f'output_format: csv\n  output_path: "{output_path}"',
     )

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1,0 +1,379 @@
+from __future__ import annotations
+
+from datetime import date
+from typing import Any
+from unittest.mock import MagicMock
+
+import numpy as np
+import polars as pl
+import pytest
+
+from limen.experiment import MLManifest
+from limen.experiment.manifest_core import PCACompressionConfig
+from limen.experiment.manifest_core import _apply_sensor_pca
+from limen.experiment.manifest_core import _count_leading_nulls
+from limen.experiment.trainer.sensor import BarPrediction
+from limen.experiment.trainer.sensor import Sensor
+from limen.scalers.robust_scaler import RobustScaler
+
+
+def _make_klines(n: int = 20, start_year: int = 2026) -> pl.DataFrame:
+    idx = np.arange(n, dtype=float)
+    close = 100.0 + idx * 0.5
+    return pl.DataFrame({
+        'datetime': pl.datetime_range(
+            start=pl.datetime(start_year, 1, 1, 0, 0, 0),
+            end=pl.datetime(start_year, 1, n + 1, 0, 0, 0),
+            interval='1d',
+            eager=True,
+        )[:n],
+        'open': close - 0.2,
+        'high': close + 0.5,
+        'low': close - 0.5,
+        'close': close,
+        'volume': 1000.0 + idx * 5.0,
+    })
+
+
+def _make_basic_manifest() -> MLManifest:
+    return (
+        MLManifest()
+        .set_split_config(3, 1, 1)
+    )
+
+
+def _make_lag_manifest(lag: int = 3) -> tuple[MLManifest, int]:
+    manifest = (
+        MLManifest()
+        .set_split_config(3, 1, 1)
+        .add_indicator(
+            lambda df, n=lag: df.with_columns(pl.col('close').shift(n).alias(f'lag_{n}'))
+        )
+    )
+    return manifest, lag
+
+
+def _make_stub_model(pred: int = 1, prob: float = 0.7) -> MagicMock:
+    model = MagicMock()
+    def _predict(data_dict):
+        n = len(data_dict['x_test'])
+        return {'_preds': np.array([pred] * n), '_probs': np.array([prob] * n)}
+    model.predict.side_effect = _predict
+    model.deterministic = True
+    return model
+
+
+def _make_sensor(
+        manifest: Any,
+        model: Any = None,
+        fitted_params: dict | None = None,
+        round_params: dict | None = None,
+) -> Sensor:
+    sensor = object.__new__(Sensor)
+    sensor._yaml_reference = {}
+    sensor._model = model or _make_stub_model()
+    sensor._fitted_params = dict(fitted_params or {})
+    sensor._round_params = dict(round_params or {'bar_type': 'base'})
+    sensor._manifest = manifest
+    sensor.permutation_id = None
+    return sensor
+
+
+def _make_pca_manifest_stub(component_prefix: str = 'pc') -> Any:
+    manifest = object.__new__(MLManifest)
+    manifest.pca_compression_config = PCACompressionConfig(
+        enabled_param='use_pca',
+        n_components_param='n_pca',
+        scaler_param_name='_scaler',
+        component_prefix=component_prefix,
+    )
+    manifest.target_column = None
+    return manifest
+
+
+def test_count_leading_nulls_no_nulls() -> None:
+    data = pl.DataFrame({'datetime': [1, 2, 3], 'f': [1.0, 2.0, 3.0]})
+    assert _count_leading_nulls(data) == 0
+
+
+def test_count_leading_nulls_leading_nulls() -> None:
+    data = pl.DataFrame({'f': [None, None, 1.0, 2.0, 3.0]})
+    assert _count_leading_nulls(data) == 2
+
+
+def test_count_leading_nulls_all_null() -> None:
+    data = pl.DataFrame({'f': [None, None, None]})
+    assert _count_leading_nulls(data) == 3
+
+
+def test_count_leading_nulls_gap_in_middle() -> None:
+    data = pl.DataFrame({'f': [1.0, None, 3.0]})
+    assert _count_leading_nulls(data) == 0
+
+
+def test_count_leading_nulls_datetime_excluded() -> None:
+    data = pl.DataFrame({'datetime': [None, None], 'f': [1.0, 2.0]})
+    assert _count_leading_nulls(data) == 0
+
+
+def test_count_leading_nulls_any_null_col_triggers_row() -> None:
+    data = pl.DataFrame({'f1': [None, 1.0, 2.0], 'f2': [0.0, 2.0, 3.0]})
+    assert _count_leading_nulls(data) == 1
+
+
+def test_count_leading_nulls_empty_features() -> None:
+    data = pl.DataFrame({'datetime': [1, 2, 3]})
+    assert _count_leading_nulls(data) == 0
+
+
+def test_sensor_input_prep_preserves_row_count() -> None:
+    manifest = _make_basic_manifest()
+    raw = _make_klines(20)
+    data, _ = manifest.sensor_input_prep(raw, {}, {'bar_type': 'base'})
+    assert len(data) == len(raw)
+
+
+def test_sensor_input_prep_indicator_lookback_matches_leading_nulls() -> None:
+    manifest, lag = _make_lag_manifest(lag=4)
+    raw = _make_klines(20)
+    data, indicator_lookback = manifest.sensor_input_prep(raw, {}, {'bar_type': 'base'})
+    assert indicator_lookback == lag
+    assert len(data) == len(raw)
+
+
+def test_sensor_input_prep_no_leading_nulls_returns_zero_lookback() -> None:
+    manifest = _make_basic_manifest()
+    raw = _make_klines(10)
+    _, indicator_lookback = manifest.sensor_input_prep(raw, {}, {'bar_type': 'base'})
+    assert indicator_lookback == 0
+
+
+def test_sensor_input_prep_no_drop_nulls() -> None:
+    manifest, lag = _make_lag_manifest(lag=3)
+    raw = _make_klines(15)
+    data, lookback = manifest.sensor_input_prep(raw, {}, {'bar_type': 'base'})
+    assert len(data) == len(raw)
+    assert lookback == 3
+    assert data[f'lag_{lag}'][:lag].null_count() == lag
+
+
+def test_sensor_input_prep_drops_ablated_features() -> None:
+    manifest = (
+        MLManifest()
+        .set_split_config(3, 1, 1)
+        .add_indicator(lambda df: df.with_columns(pl.col('close').alias('feat_a')))
+        .add_indicator(lambda df: df.with_columns(pl.col('close').alias('feat_b')))
+        .set_feature_ablation()
+    )
+    raw = _make_klines(20)
+    round_params = {
+        'bar_type': 'base',
+        'feature_drop_count': 1,
+        'feature_drop_seed': 42,
+        '_dropped_features': ['feat_a'],
+    }
+    data, _ = manifest.sensor_input_prep(raw, {}, round_params)
+    assert 'feat_a' not in data.columns
+    assert 'feat_b' in data.columns
+
+
+def test_sensor_input_prep_applies_fitted_scaler() -> None:
+    manifest = (
+        MLManifest()
+        .set_split_config(3, 1, 1)
+        .set_scaler(RobustScaler)
+    )
+    raw = _make_klines(20)
+    train = raw.select([c for c in raw.columns if c != 'datetime'])
+    fitted_params = {'_scaler': RobustScaler(train)}
+
+    data, _ = manifest.sensor_input_prep(raw, fitted_params, {'bar_type': 'base'})
+
+    assert len(data) == len(raw)
+    assert data['close'].to_list() != raw['close'].to_list()
+
+
+def test_sensor_input_prep_scaler_leaves_null_rows_null() -> None:
+    manifest = (
+        MLManifest()
+        .set_split_config(3, 1, 1)
+        .add_indicator(lambda df: df.with_columns(pl.col('close').shift(2).alias('lag')))
+        .set_scaler(RobustScaler)
+    )
+    raw = _make_klines(20)
+    train = raw.drop_nulls().select([c for c in raw.columns if c != 'datetime'])
+    fitted_params = {'_scaler': RobustScaler(train)}
+
+    data, lookback = manifest.sensor_input_prep(raw, fitted_params, {'bar_type': 'base'})
+
+    assert lookback == 2
+    assert len(data) == len(raw)
+    assert data['lag'][:2].null_count() == 2
+
+
+def test_apply_sensor_pca_transforms_valid_rows() -> None:
+    from sklearn.decomposition import PCA
+
+    n = 10
+    data = pl.DataFrame({
+        'datetime': list(range(n)),
+        'f1': np.random.default_rng(0).standard_normal(n).tolist(),
+        'f2': np.random.default_rng(1).standard_normal(n).tolist(),
+    })
+    pca = PCA(n_components=1, svd_solver='full')
+    pca.fit(data.select(['f1', 'f2']).to_numpy())
+    manifest = _make_pca_manifest_stub()
+    all_fitted_params = {
+        '_pca': pca,
+        '_pca_input_feature_names': ['f1', 'f2'],
+        '_pca_feature_names': ['pc0'],
+    }
+
+    out = _apply_sensor_pca(manifest, data, {'use_pca': True, 'n_pca': 1}, all_fitted_params)
+
+    assert 'pc0' in out.columns
+    assert len(out) == n
+    assert out['pc0'].null_count() == 0
+
+
+def test_apply_sensor_pca_preserves_null_rows() -> None:
+    from sklearn.decomposition import PCA
+
+    n = 10
+    f1_vals = [None, None, *np.arange(8, dtype=float).tolist()]
+    f2_vals = [None, None, *np.arange(8, 16, dtype=float).tolist()]
+    data = pl.DataFrame({
+        'datetime': list(range(n)),
+        'f1': pl.Series(f1_vals, dtype=pl.Float64),
+        'f2': pl.Series(f2_vals, dtype=pl.Float64),
+    })
+    pca = PCA(n_components=1, svd_solver='full')
+    pca.fit(data.drop_nulls().select(['f1', 'f2']).to_numpy())
+    manifest = _make_pca_manifest_stub()
+    all_fitted_params = {
+        '_pca': pca,
+        '_pca_input_feature_names': ['f1', 'f2'],
+        '_pca_feature_names': ['pc0'],
+    }
+
+    out = _apply_sensor_pca(manifest, data, {'use_pca': True, 'n_pca': 1}, all_fitted_params)
+
+    assert len(out) == n
+    assert out['pc0'][:2].null_count() == 2
+    assert out['pc0'][2:].null_count() == 0
+
+
+def test_apply_sensor_pca_skipped_when_disabled() -> None:
+    manifest = _make_pca_manifest_stub()
+    data = pl.DataFrame({'datetime': [1, 2], 'f1': [1.0, 2.0]})
+    out = _apply_sensor_pca(manifest, data, {'use_pca': False}, {})
+    assert 'f1' in out.columns
+    assert 'pc0' not in out.columns
+
+
+def test_apply_sensor_pca_skipped_when_no_config() -> None:
+    manifest = object.__new__(MLManifest)
+    manifest.pca_compression_config = None
+    manifest.target_column = None
+    data = pl.DataFrame({'f1': [1.0, 2.0]})
+    out = _apply_sensor_pca(manifest, data, {}, {})
+    assert out is data
+
+
+def test_predict_raises_if_last_bar_is_warmup() -> None:
+    manifest, _lag = _make_lag_manifest(lag=5)
+    raw = _make_klines(5)
+    sensor = _make_sensor(manifest)
+    with pytest.raises(ValueError, match='warm-up'):
+        sensor.predict(raw)
+
+
+def test_predict_raises_if_insufficient_valid_rows() -> None:
+    manifest, _ = _make_lag_manifest(lag=3)
+    manifest.decoder_lookback = 5
+    # 3 warm-up + 1 valid < 5 decoder_lookback
+    raw = _make_klines(4)
+    sensor = _make_sensor(manifest)
+    with pytest.raises(ValueError, match='Insufficient data'):
+        sensor.predict(raw)
+
+
+def test_predict_raises_if_inside_training_window() -> None:
+    manifest = _make_basic_manifest()
+    manifest.split_dates = (
+        date(2026, 1, 1), date(2026, 1, 10),
+        date(2026, 1, 10), date(2026, 1, 15),
+        date(2026, 1, 15), date(2026, 1, 20),
+    )
+    raw = _make_klines(5, start_year=2026)
+    sensor = _make_sensor(manifest)
+    with pytest.raises(ValueError, match='training/test window'):
+        sensor.predict(raw)
+
+
+def test_predict_happy_path_returns_bar_prediction() -> None:
+    manifest, _lag = _make_lag_manifest(lag=2)
+    manifest.split_dates = None
+    raw = _make_klines(10)
+    sensor = _make_sensor(manifest, round_params={'bar_type': 'base'})
+    result = sensor.predict(raw)
+    assert isinstance(result, BarPrediction)
+    assert result.reason is None
+    assert result.prediction is not None
+
+
+def test_predict_all_output_length_equals_input() -> None:
+    manifest, _lag = _make_lag_manifest(lag=2)
+    manifest.split_dates = None
+    raw = _make_klines(10)
+    sensor = _make_sensor(manifest, round_params={'bar_type': 'base'})
+    results = sensor.predict_all(raw)
+    assert len(results) == len(raw)
+
+
+def test_predict_all_warmup_bars_have_reason_warmup() -> None:
+    manifest, lag = _make_lag_manifest(lag=3)
+    manifest.split_dates = None
+    raw = _make_klines(10)
+    sensor = _make_sensor(manifest, round_params={'bar_type': 'base'})
+    results = sensor.predict_all(raw)
+    for i in range(lag):
+        assert results[i].reason == 'warm-up'
+        assert results[i].prediction is None
+
+
+def test_predict_all_valid_bars_have_predictions() -> None:
+    manifest, lag = _make_lag_manifest(lag=2)
+    manifest.split_dates = None
+    raw = _make_klines(10)
+    sensor = _make_sensor(manifest, round_params={'bar_type': 'base'})
+    results = sensor.predict_all(raw)
+    for i in range(lag, len(results)):
+        assert results[i].reason is None
+        assert results[i].prediction is not None
+
+
+def test_predict_all_inside_window_bars_flagged() -> None:
+    manifest = _make_basic_manifest()
+    manifest.split_dates = (
+        date(2026, 1, 1), date(2026, 1, 5),
+        date(2026, 1, 5), date(2026, 1, 8),
+        date(2026, 1, 8), date(2026, 1, 12),
+    )
+    raw = _make_klines(20, start_year=2026)
+    sensor = _make_sensor(manifest, round_params={'bar_type': 'base'})
+    results = sensor.predict_all(raw)
+    inside = [r for r in results if r.reason == 'inside-training-window']
+    assert len(inside) > 0
+    for r in inside:
+        assert r.prediction is None
+
+
+def test_predict_all_decoder_lookback_gt1_raises() -> None:
+    manifest = _make_basic_manifest()
+    manifest.decoder_lookback = 2
+    manifest.split_dates = None
+    raw = _make_klines(10)
+    sensor = _make_sensor(manifest, round_params={'bar_type': 'base'})
+    with pytest.raises(NotImplementedError, match='decoder_lookback'):
+        sensor.predict_all(raw)

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -319,6 +319,20 @@ def test_predict_raises_if_inside_training_window() -> None:
         sensor.predict(raw)
 
 
+def test_predict_allows_context_bars_inside_window_when_last_bar_is_valid() -> None:
+    manifest, _lag = _make_lag_manifest(lag=2)
+    manifest.split_dates = (
+        date(2026, 1, 1), date(2026, 1, 10),
+        date(2026, 1, 10), date(2026, 1, 15),
+        date(2026, 1, 15), date(2026, 1, 20),
+    )
+    # 19 context bars (inside window) + 1 post-test_end bar as the last bar
+    raw = _make_klines(20, start_year=2026)
+    sensor = _make_sensor(manifest, round_params={'bar_type': 'base'})
+    result = sensor.predict(raw)
+    assert isinstance(result, BarPrediction)
+
+
 def test_predict_happy_path_returns_bar_prediction() -> None:
     manifest, _lag = _make_lag_manifest(lag=2)
     manifest.split_dates = None

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -14,6 +14,7 @@ from limen.experiment.manifest_core import _apply_sensor_pca
 from limen.experiment.manifest_core import _count_leading_nulls
 from limen.experiment.trainer.sensor import BarPrediction
 from limen.experiment.trainer.sensor import Sensor
+from limen.experiment.trainer.sensor import _extract_scalar
 from limen.scalers.robust_scaler import RobustScaler
 
 
@@ -399,3 +400,37 @@ def test_predict_all_decoder_lookback_gt1_raises() -> None:
     sensor = _make_sensor(manifest, round_params={'bar_type': 'base'})
     with pytest.raises(NotImplementedError, match='decoder_lookback'):
         sensor.predict_all(raw)
+
+
+def test_extract_scalar_returns_none_for_none() -> None:
+    assert _extract_scalar(None) is None
+
+
+def test_extract_scalar_returns_python_int() -> None:
+    assert _extract_scalar(1) == 1
+    assert isinstance(_extract_scalar(1), int)
+
+
+def test_extract_scalar_returns_python_float() -> None:
+    assert _extract_scalar(0.7) == 0.7
+    assert isinstance(_extract_scalar(0.7), float)
+
+
+def test_extract_scalar_rejects_bool() -> None:
+    assert _extract_scalar(True) is None
+
+
+def test_extract_scalar_from_numpy_array() -> None:
+    arr = np.array([0.5, 0.3])
+    result = _extract_scalar(arr)
+    assert result == 0.5
+
+
+def test_extract_scalar_from_zero_dim_numpy() -> None:
+    arr = np.float64(0.42)
+    result = _extract_scalar(arr)
+    assert result == 0.42
+
+
+def test_extract_scalar_from_empty_array_returns_none() -> None:
+    assert _extract_scalar(np.array([])) is None

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -290,11 +290,19 @@ def test_predict_raises_if_last_bar_is_warmup() -> None:
 
 def test_predict_raises_if_insufficient_valid_rows() -> None:
     manifest, _ = _make_lag_manifest(lag=3)
-    manifest.decoder_lookback = 5
-    # 3 warm-up + 1 valid < 5 decoder_lookback
-    raw = _make_klines(4)
+    # decoder_lookback=1, only 3 rows → valid_rows=0 < 1
+    raw = _make_klines(3)
     sensor = _make_sensor(manifest)
     with pytest.raises(ValueError, match='Insufficient data'):
+        sensor.predict(raw)
+
+
+def test_predict_raises_not_implemented_for_decoder_lookback_gt_1() -> None:
+    manifest, _ = _make_lag_manifest(lag=3)
+    manifest.decoder_lookback = 2
+    raw = _make_klines(10)
+    sensor = _make_sensor(manifest)
+    with pytest.raises(NotImplementedError, match='decoder_lookback > 1'):
         sensor.predict(raw)
 
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -392,6 +392,27 @@ def test_predict_all_inside_window_bars_flagged() -> None:
         assert r.prediction is None
 
 
+def test_predict_all_midstream_null_row_has_reason_null_features() -> None:
+    manifest, _lag = _make_lag_manifest(lag=2)
+    manifest.split_dates = None
+    raw = _make_klines(10)
+    # inject a null into a non-leading row (row 5, well past warm-up)
+    raw = raw.with_columns(
+        pl.when(pl.int_range(pl.len()) == 5)
+        .then(None)
+        .otherwise(pl.col('close'))
+        .alias('close')
+    )
+    sensor = _make_sensor(manifest, round_params={'bar_type': 'base'})
+    results = sensor.predict_all(raw)
+    assert results[5].reason == 'null-features'
+    assert results[5].prediction is None
+    assert results[5].probability is None
+    # other post-warmup bars still produce predictions
+    assert results[6].reason is None
+    assert results[6].prediction is not None
+
+
 def test_predict_all_decoder_lookback_gt1_raises() -> None:
     manifest = _make_basic_manifest()
     manifest.decoder_lookback = 2

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -7,7 +7,6 @@ from tempfile import TemporaryDirectory
 from textwrap import dedent
 from unittest.mock import patch
 
-import numpy as np
 import polars as pl
 import pytest
 

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -1,13 +1,220 @@
 import json
+import math
+from datetime import datetime
+from datetime import timedelta
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from types import SimpleNamespace
+from textwrap import dedent
+from unittest.mock import patch
 
+import numpy as np
 import polars as pl
 import pytest
 
-import limen.experiment.trainer.trainer as trainer_module
+from limen.cli.commands.run import run_experiment
+from limen.data import historical_data
+from limen.experiment.trainer import ReconstructionError
 from limen.experiment.trainer import Trainer
+from limen.experiment.trainer.sensor import BarPrediction
+
+
+_E2E_LOGREG_YAML = dedent('''\
+    schema_version: "1.0"
+    metadata:
+      name: test_logreg
+      mode: development
+    sfd:
+      manifest:
+        type: ml
+        data_source:
+          method: limen.data.HistoricalData.get_spot_klines
+          params:
+            kline_size: 3600
+        split_dates:
+          train_start: "2025-01-01"
+          train_end: "2025-01-15"
+          val_start: "2025-01-15"
+          val_end: "2025-01-18"
+          test_start: "2025-01-18"
+          test_end: "2025-01-22"
+        indicators:
+          - func: limen.indicators.roc
+            params:
+              period: 1
+              group: momentum
+        target:
+          name: quantile_flag
+          class: limen.targets.QuantileBinaryTarget
+          fit_params:
+            source_column: roc_1
+            quantile: 0.5
+          transform_params:
+            shift: -1
+        scaler:
+          from_params: scaler_type
+        reference_architecture: limen.sfd.reference_architecture.logreg_binary
+      params:
+        scaler_type: [logreg]
+        C: [1.0, 0.5]
+        random_state: [42]
+    uel:
+      n_permutations: 2
+      search_strategy:
+        type: grid
+      output_format: csv
+''')
+
+
+_E2E_RANDOM_YAML = dedent('''\
+    schema_version: "1.0"
+    metadata:
+      name: test_random
+      mode: development
+    sfd:
+      manifest:
+        type: ml
+        data_source:
+          method: limen.data.HistoricalData.get_spot_klines
+          params:
+            kline_size: 3600
+        split_dates:
+          train_start: "2025-01-01"
+          train_end: "2025-01-15"
+          val_start: "2025-01-15"
+          val_end: "2025-01-18"
+          test_start: "2025-01-18"
+          test_end: "2025-01-22"
+        indicators:
+          - func: limen.indicators.roc
+            params:
+              period: 1
+              group: momentum
+        target:
+          name: quantile_flag
+          class: limen.targets.QuantileBinaryTarget
+          fit_params:
+            source_column: roc_1
+            quantile: 0.5
+          transform_params:
+            shift: -1
+        reference_architecture: limen.sfd.reference_architecture.random_binary
+      params:
+        random_weights: [0.5]
+    uel:
+      n_permutations: 1
+      search_strategy:
+        type: grid
+      output_format: csv
+''')
+
+
+_E2E_ABLATION_YAML = dedent('''\
+    schema_version: "1.0"
+    metadata:
+      name: test_ablation
+      mode: development
+    sfd:
+      manifest:
+        type: ml
+        data_source:
+          method: limen.data.HistoricalData.get_spot_klines
+          params:
+            kline_size: 3600
+        split_dates:
+          train_start: "2025-01-01"
+          train_end: "2025-01-15"
+          val_start: "2025-01-15"
+          val_end: "2025-01-18"
+          test_start: "2025-01-18"
+          test_end: "2025-01-22"
+        indicators:
+          - func: limen.indicators.roc
+            params:
+              period: 1
+              group: momentum
+          - func: limen.indicators.roc
+            params:
+              period: 2
+              group: momentum
+        target:
+          name: quantile_flag
+          class: limen.targets.QuantileBinaryTarget
+          fit_params:
+            source_column: roc_1
+            quantile: 0.5
+          transform_params:
+            shift: -1
+        scaler:
+          from_params: scaler_type
+        feature_ablation:
+          drop_count_key: feature_drop_count
+          seed_key: feature_drop_seed
+        reference_architecture: limen.sfd.reference_architecture.logreg_binary
+      params:
+        scaler_type: [logreg]
+        C: [1.0]
+        random_state: [42]
+        feature_drop_count: [1]
+        feature_drop_seed: [42]
+    uel:
+      n_permutations: 1
+      search_strategy:
+        type: grid
+      output_format: csv
+''')
+
+
+def _make_e2e_data(kline_size: int = 3600,
+                   n_rows: int | None = None,
+                   start_date_limit: object = None,
+                   end_date_limit: object = None) -> pl.DataFrame:
+    _ = kline_size, start_date_limit, end_date_limit
+    n = int(n_rows or 500)
+    timestamps = [datetime(2025, 1, 1) + timedelta(hours=i) for i in range(n)]
+    close = [100.0 + 0.02 * i + math.sin(i / 7.0) for i in range(n)]
+    return pl.DataFrame({
+        'datetime': timestamps,
+        'open': [v - 0.1 for v in close],
+        'high': [v + 0.2 for v in close],
+        'low': [v - 0.2 for v in close],
+        'close': close,
+        'volume': [1000.0 + i for i in range(n)],
+    })
+
+
+def _run_e2e_experiment(experiment_dir: Path, yaml_text: str) -> list[int]:
+    experiment_dir = Path(experiment_dir).resolve()
+    original = historical_data.HistoricalData.get_spot_klines
+    historical_data.HistoricalData.get_spot_klines = staticmethod(_make_e2e_data)
+    try:
+        with TemporaryDirectory() as tmpdir, patch('click.echo'), patch('click.secho'):
+            yaml_path = Path(tmpdir) / 'exp.yaml'
+            yaml_path.write_text(yaml_text.replace(
+                'output_format: csv',
+                f'output_format: csv\n  output_path: "{experiment_dir}"',
+            ))
+            run_experiment(yaml_path)
+    finally:
+        historical_data.HistoricalData.get_spot_klines = original
+    round_ids: list[int] = []
+    with (experiment_dir / 'round_data.jsonl').open('r') as f:
+        for raw_line in f:
+            stripped = raw_line.strip()
+            if not stripped:
+                continue
+            round_ids.append(json.loads(stripped)['round_id'])
+    return sorted(round_ids)
+
+
+def _train_e2e(experiment_dir: Path, pids: list[int]) -> tuple[Trainer, list]:
+    original = historical_data.HistoricalData.get_spot_klines
+    historical_data.HistoricalData.get_spot_klines = staticmethod(_make_e2e_data)
+    try:
+        trainer = Trainer(experiment_dir)
+        sensors = trainer.train(pids)
+    finally:
+        historical_data.HistoricalData.get_spot_klines = original
+    return trainer, sensors
 
 
 def test_trainer_requires_yaml_reference() -> None:
@@ -23,102 +230,30 @@ def test_trainer_requires_yaml_reference() -> None:
             Trainer(experiment_dir, data=pl.DataFrame({'x': [1, 2, 3]}))
 
 
-def test_trainer_reconstructs_yaml_artifact_from_metadata_reference(monkeypatch) -> None:
-
-    seen = {}
-
-    class FakeCompiledSFD:
-
-        def __init__(self, yaml_reference):
-            seen['yaml_reference'] = yaml_reference
-
-        def params(self):
-            return {'alpha': [1]}
-
-        def manifest(self):
-            return SimpleNamespace(architecture_function=None)
-
-    monkeypatch.setattr(trainer_module, 'CompiledSFD', FakeCompiledSFD)
-
-    yaml_reference = {
-        'metadata': {'name': 'yaml_exp'},
-        'sfd': {'params': {'alpha': [1]}},
-    }
+def test_trainer_rejects_non_dict_yaml_reference() -> None:
 
     with TemporaryDirectory() as tmpdir:
         experiment_dir = Path(tmpdir)
         (experiment_dir / 'metadata.json').write_text(
-            json.dumps({'yaml_reference': yaml_reference}),
-        )
-        (experiment_dir / 'round_data.jsonl').write_text('')
-
-        trainer = Trainer(
-            experiment_dir,
-            data=pl.DataFrame({'x': [1, 2, 3]}),
-        )
-
-    assert seen['yaml_reference'] == yaml_reference
-    assert trainer._param_keys == frozenset({'alpha'})
-
-
-@pytest.mark.parametrize(
-    'yaml_reference',
-    [
-        [],
-        {'metadata': {'name': 'yaml_exp'}, 'sfd': {}},
-    ],
-)
-def test_trainer_rejects_malformed_yaml_reference(yaml_reference) -> None:
-
-    with TemporaryDirectory() as tmpdir:
-        experiment_dir = Path(tmpdir)
-        (experiment_dir / 'metadata.json').write_text(
-            json.dumps({'yaml_reference': yaml_reference}),
+            json.dumps({'yaml_reference': []}),
         )
         (experiment_dir / 'round_data.jsonl').write_text('')
 
         with pytest.raises(ValueError, match='yaml_reference'):
-            Trainer(
-                experiment_dir,
-                data=pl.DataFrame({'x': [1, 2, 3]}),
-            )
+            Trainer(experiment_dir, data=pl.DataFrame({'x': [1, 2, 3]}))
 
 
-def test_trainer_wraps_yaml_resolution_error(monkeypatch) -> None:
-
-    class FakeCompiledSFD:
-
-        def __init__(self, _yaml_reference):
-            pass
-
-        def params(self):
-            return {'alpha': [1]}
-
-        def manifest(self):
-            raise trainer_module.ResolutionError(
-                'bad.reference',
-                ['limen'],
-            )
-
-    monkeypatch.setattr(trainer_module, 'CompiledSFD', FakeCompiledSFD)
+def test_trainer_rejects_malformed_yaml_reference() -> None:
 
     with TemporaryDirectory() as tmpdir:
         experiment_dir = Path(tmpdir)
         (experiment_dir / 'metadata.json').write_text(
-            json.dumps({
-                'yaml_reference': {
-                    'metadata': {'name': 'yaml_exp'},
-                    'sfd': {'params': {'alpha': [1]}},
-                },
-            }),
+            json.dumps({'yaml_reference': {'metadata': {'name': 'yaml_exp'}, 'sfd': {}}}),
         )
         (experiment_dir / 'round_data.jsonl').write_text('')
 
         with pytest.raises(ValueError, match='yaml_reference'):
-            Trainer(
-                experiment_dir,
-                data=pl.DataFrame({'x': [1, 2, 3]}),
-            )
+            Trainer(experiment_dir, data=pl.DataFrame({'x': [1, 2, 3]}))
 
 
 def test_load_round_data_skips_blank_and_malformed_lines() -> None:
@@ -207,3 +342,116 @@ def test_validate_metrics_reports_missing_permutations_and_large_deterministic_m
     )
 
     assert mismatches == ['accuracy: original=0.8, new=0.81']
+
+
+def test_trainer_yaml_end_to_end() -> None:
+    with TemporaryDirectory() as tmpdir:
+        exp_dir = Path(tmpdir) / 'exp'
+        exp_dir.mkdir()
+        round_ids = _run_e2e_experiment(exp_dir, _E2E_LOGREG_YAML)
+        assert len(round_ids) == 2
+
+        metadata = json.loads((exp_dir / 'metadata.json').read_text())
+        assert 'yaml_reference' in metadata
+        assert 'limen_version' in metadata
+
+        trainer, sensors = _train_e2e(exp_dir, round_ids)
+        assert len(sensors) == 2
+
+        for i, sensor in enumerate(sensors):
+            assert sensor.permutation_id == round_ids[i]
+            assert isinstance(sensor.round_params, dict)
+
+        with pytest.raises(ValueError, match='not found in round_data'):
+            trainer.train([999])
+
+
+def test_trainer_yaml_reconstruction_error_stochastic() -> None:
+    with TemporaryDirectory() as tmpdir:
+        exp_dir = Path(tmpdir) / 'exp'
+        exp_dir.mkdir()
+        round_ids = _run_e2e_experiment(exp_dir, _E2E_RANDOM_YAML)
+        assert len(round_ids) == 1
+
+        original = historical_data.HistoricalData.get_spot_klines
+        historical_data.HistoricalData.get_spot_klines = staticmethod(_make_e2e_data)
+        try:
+            trainer = Trainer(exp_dir)
+            with pytest.raises(ReconstructionError, match='metric mismatch'):
+                trainer.train(round_ids)
+        finally:
+            historical_data.HistoricalData.get_spot_klines = original
+
+
+def test_trainer_yaml_reconstruction_error_tampered_log() -> None:
+    with TemporaryDirectory() as tmpdir:
+        exp_dir = Path(tmpdir) / 'exp'
+        exp_dir.mkdir()
+        round_ids = _run_e2e_experiment(exp_dir, _E2E_LOGREG_YAML)
+
+        df = pl.read_csv(exp_dir / 'results.csv')
+        df = df.with_columns((pl.col('accuracy') + 0.5).alias('accuracy'))
+        df.write_csv(exp_dir / 'results.csv')
+
+        with pytest.raises(ReconstructionError, match='metric mismatch'):
+            _train_e2e(exp_dir, [round_ids[0]])
+
+
+def test_trainer_yaml_deterministic_validation() -> None:
+    with TemporaryDirectory() as tmpdir:
+        exp_dir = Path(tmpdir) / 'exp'
+        exp_dir.mkdir()
+        round_ids = _run_e2e_experiment(exp_dir, _E2E_LOGREG_YAML)
+        _, sensors = _train_e2e(exp_dir, [round_ids[0]])
+        assert len(sensors) == 1
+        assert sensors[0]._model.deterministic is True
+
+
+def test_trainer_yaml_sensor_inference() -> None:
+    with TemporaryDirectory() as tmpdir:
+        exp_dir = Path(tmpdir) / 'exp'
+        exp_dir.mkdir()
+        round_ids = _run_e2e_experiment(exp_dir, _E2E_LOGREG_YAML)
+        trainer, sensors = _train_e2e(exp_dir, [round_ids[0]])
+        sensor = sensors[0]
+
+        # dict dispatch — delegates to underlying model, returns raw dict
+        data_dict = trainer._manifest.prepare_data(trainer._data, sensor.round_params)
+        x_batch = data_dict['x_test'].to_numpy()[:2]
+        dict_result = sensor.predict({'x_test': x_batch})
+        assert isinstance(dict_result, dict)
+        assert '_preds' in dict_result
+
+        # __call__ delegates to predict
+        call_result = sensor({'x_test': x_batch})
+        assert isinstance(call_result, dict)
+
+        # DataFrame path — returns BarPrediction for last bar
+        n = 100
+        post_ts = [datetime(2025, 1, 22) + timedelta(hours=i) for i in range(n)]
+        close = [110.0 + 0.02 * i + math.sin(i / 7.0) for i in range(n)]
+        post_data = pl.DataFrame({
+            'datetime': post_ts,
+            'open': [v - 0.1 for v in close],
+            'high': [v + 0.2 for v in close],
+            'low': [v - 0.2 for v in close],
+            'close': close,
+            'volume': [1000.0 + i for i in range(n)],
+        })
+        bar_pred = sensor.predict(post_data)
+        assert isinstance(bar_pred, BarPrediction)
+        assert bar_pred.reason is None
+        assert bar_pred.prediction is not None
+
+
+def test_trainer_yaml_feature_ablation() -> None:
+    with TemporaryDirectory() as tmpdir:
+        exp_dir = Path(tmpdir) / 'exp'
+        exp_dir.mkdir()
+        round_ids = _run_e2e_experiment(exp_dir, _E2E_ABLATION_YAML)
+        assert len(round_ids) == 1
+        _, sensors = _train_e2e(exp_dir, round_ids)
+        sensor = sensors[0]
+        dropped = sensor.round_params.get('_dropped_features')
+        assert isinstance(dropped, list)
+        assert len(dropped) == 1

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -1,360 +1,124 @@
-import importlib
 import json
-import sys
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from types import SimpleNamespace
-import types
 
 import polars as pl
 import pytest
 
 import limen.experiment.trainer.trainer as trainer_module
-from limen.experiment.experiment_core import UniversalExperimentLoop
-from limen.experiment.param_domain import ParamDomain
-from limen.experiment.trainer import ReconstructionError
 from limen.experiment.trainer import Trainer
-from limen.sfd.foundational_sfd import logreg_binary as logreg_sfd
-from limen.sfd.foundational_sfd import random_binary as random_sfd
-from limen.sfd.reference_architecture.base import ReferenceModel
-from limen.experiment.param_search import RandomStrategy
-from tests.utils.historical_data import get_cached_spot_klines_2h
 
 
-class _ReferenceModelA(ReferenceModel):
-    deterministic = True
-
-    def train(self, data, **kwargs):
-        return self
-
-    def predict(self, data, **kwargs):
-        return {'_preds': []}
-
-    def evaluate(self, data, **kwargs):
-        return {}
-
-
-class _ReferenceModelB(ReferenceModel):
-    deterministic = True
-
-    def train(self, data, **kwargs):
-        return self
-
-    def predict(self, data, **kwargs):
-        return {'_preds': []}
-
-    def evaluate(self, data, **kwargs):
-        return {}
-
-
-def test_trainer_end_to_end():
+def test_trainer_requires_yaml_reference() -> None:
 
     with TemporaryDirectory() as tmpdir:
-        experiment_dir = Path(tmpdir) / 'experiment'
-        params = logreg_sfd.params()
-        domain = ParamDomain(params)
-        strategy = RandomStrategy(domain, seed=42)
-
-        uel = UniversalExperimentLoop(
-            sfd=logreg_sfd,
-            search_strategy=strategy,
-            experiment_dir=experiment_dir,
-            test_mode=True,
+        experiment_dir = Path(tmpdir)
+        (experiment_dir / 'metadata.json').write_text(
+            json.dumps({'sfd_module': 'limen.sfd.foundational_sfd.logreg_binary'}),
         )
+        (experiment_dir / 'round_data.jsonl').write_text('')
 
-        uel.run(
-            experiment_name='test_trainer',
-            n_permutations=2,
-        )
-
-        # metadata.json written with correct fields
-        metadata_path = experiment_dir / 'metadata.json'
-        assert metadata_path.exists()
-        with metadata_path.open('r') as f:
-            metadata = json.load(f)
-        assert metadata['sfd_module'] == 'limen.sfd.foundational_sfd.logreg_binary'
-        assert 'limen_version' in metadata
-        assert 'created_at' in metadata
-
-        # Trainer loads manifest, params, round data, and original log
-        trainer = Trainer(experiment_dir, data=uel.data)
-        assert trainer._manifest is not None
-        assert len(trainer._param_keys) > 0
-        assert len(trainer._round_data) == 2
-        assert trainer._original_log is not None
-        assert len(trainer._original_log) == 2
-
-        # train returns Sensor instances with trained models
-        permutation_ids = list(trainer._round_data.keys())
-        sensors = trainer.train(permutation_ids)
-        assert len(sensors) == 2
-
-        for pid, sensor in zip(permutation_ids, sensors, strict=True):
-            assert sensor.permutation_id == pid
-            assert sensor.round_params is not None
-            assert sensor.metadata is not None
-            assert sensor.results is not None
-            assert sensor.model is not None
-            assert isinstance(sensor.model, ReferenceModel)
-
-        # Sensor is callable with trained model
-        data_dict = trainer._manifest.prepare_data(uel.data, sensors[0].round_params)
-        result = sensors[0](data_dict)
-        assert isinstance(result, dict)
-
-        # invalid permutation ID raises ValueError
-        try:
-            trainer.train([99999])
-            assert False, 'Expected ValueError'
-        except ValueError as e:
-            assert '99999' in str(e)
+        with pytest.raises(ValueError, match='yaml_reference'):
+            Trainer(experiment_dir, data=pl.DataFrame({'x': [1, 2, 3]}))
 
 
-def test_reconstruction_error_stochastic():
+def test_trainer_reconstructs_yaml_artifact_from_metadata_reference(monkeypatch) -> None:
+
+    seen = {}
+
+    class FakeCompiledSFD:
+
+        def __init__(self, yaml_reference):
+            seen['yaml_reference'] = yaml_reference
+
+        def params(self):
+            return {'alpha': [1]}
+
+        def manifest(self):
+            return SimpleNamespace(architecture_function=None)
+
+    monkeypatch.setattr(trainer_module, 'CompiledSFD', FakeCompiledSFD)
+
+    yaml_reference = {
+        'metadata': {'name': 'yaml_exp'},
+        'sfd': {'params': {'alpha': [1]}},
+    }
 
     with TemporaryDirectory() as tmpdir:
-        experiment_dir = Path(tmpdir) / 'experiment'
-        params = random_sfd.params()
-        domain = ParamDomain(params)
-        strategy = RandomStrategy(domain, seed=42)
+        experiment_dir = Path(tmpdir)
+        (experiment_dir / 'metadata.json').write_text(
+            json.dumps({'yaml_reference': yaml_reference}),
+        )
+        (experiment_dir / 'round_data.jsonl').write_text('')
 
-        uel = UniversalExperimentLoop(
-            sfd=random_sfd,
-            search_strategy=strategy,
-            experiment_dir=experiment_dir,
-            test_mode=True,
+        trainer = Trainer(
+            experiment_dir,
+            data=pl.DataFrame({'x': [1, 2, 3]}),
         )
 
-        uel.run(
-            experiment_name='test_stochastic',
-            n_permutations=2,
-        )
-
-        trainer = Trainer(experiment_dir, data=uel.data)
-        permutation_ids = list(trainer._round_data.keys())
-
-        try:
-            trainer.train(permutation_ids)
-            assert False, 'Expected ReconstructionError'
-        except ReconstructionError as e:
-            assert 'metric mismatch' in str(e).lower()
+    assert seen['yaml_reference'] == yaml_reference
+    assert trainer._param_keys == frozenset({'alpha'})
 
 
-def test_reconstruction_error_tampered_log():
+@pytest.mark.parametrize(
+    'yaml_reference',
+    [
+        [],
+        {'metadata': {'name': 'yaml_exp'}, 'sfd': {}},
+    ],
+)
+def test_trainer_rejects_malformed_yaml_reference(yaml_reference) -> None:
 
     with TemporaryDirectory() as tmpdir:
-        experiment_dir = Path(tmpdir) / 'experiment'
-        params = logreg_sfd.params()
-        domain = ParamDomain(params)
-        strategy = RandomStrategy(domain, seed=42)
-
-        uel = UniversalExperimentLoop(
-            sfd=logreg_sfd,
-            search_strategy=strategy,
-            experiment_dir=experiment_dir,
-            test_mode=True,
+        experiment_dir = Path(tmpdir)
+        (experiment_dir / 'metadata.json').write_text(
+            json.dumps({'yaml_reference': yaml_reference}),
         )
+        (experiment_dir / 'round_data.jsonl').write_text('')
 
-        uel.run(
-            experiment_name='test_tampered',
-            n_permutations=2,
-        )
-
-        trainer = Trainer(experiment_dir, data=uel.data)
-        permutation_ids = list(trainer._round_data.keys())
-
-        # Tamper with original log to force mismatch
-        pid = permutation_ids[0]
-        for key, value in trainer._original_log[pid].items():
-            if isinstance(value, float) and key not in ('id', '_id'):
-                trainer._original_log[pid][key] = value + 999.0
-                break
-
-        try:
-            trainer.train([pid])
-            assert False, 'Expected ReconstructionError'
-        except ReconstructionError as e:
-            assert str(pid) in str(e)
+        with pytest.raises(ValueError, match='yaml_reference'):
+            Trainer(
+                experiment_dir,
+                data=pl.DataFrame({'x': [1, 2, 3]}),
+            )
 
 
-def test_deterministic_validation():
+def test_trainer_wraps_yaml_resolution_error(monkeypatch) -> None:
+
+    class FakeCompiledSFD:
+
+        def __init__(self, _yaml_reference):
+            pass
+
+        def params(self):
+            return {'alpha': [1]}
+
+        def manifest(self):
+            raise trainer_module.ResolutionError(
+                'bad.reference',
+                ['limen'],
+            )
+
+    monkeypatch.setattr(trainer_module, 'CompiledSFD', FakeCompiledSFD)
 
     with TemporaryDirectory() as tmpdir:
-        experiment_dir = Path(tmpdir) / 'experiment'
-        params = logreg_sfd.params()
-        domain = ParamDomain(params)
-        strategy = RandomStrategy(domain, seed=42)
-
-        uel = UniversalExperimentLoop(
-            sfd=logreg_sfd,
-            search_strategy=strategy,
-            experiment_dir=experiment_dir,
-            test_mode=True,
+        experiment_dir = Path(tmpdir)
+        (experiment_dir / 'metadata.json').write_text(
+            json.dumps({
+                'yaml_reference': {
+                    'metadata': {'name': 'yaml_exp'},
+                    'sfd': {'params': {'alpha': [1]}},
+                },
+            }),
         )
+        (experiment_dir / 'round_data.jsonl').write_text('')
 
-        uel.run(
-            experiment_name='test_logreg',
-            n_permutations=2,
-        )
-
-        trainer = Trainer(experiment_dir, data=uel.data)
-        permutation_ids = list(trainer._round_data.keys())
-        sensors = trainer.train(permutation_ids)
-
-        # Deterministic model produces zero mismatches
-        for pid, sensor in zip(permutation_ids, sensors, strict=True):
-            mismatches = trainer._validate_metrics(pid, sensor.results, True)
-            assert mismatches == [], f"Permutation {pid} had mismatches: {mismatches}"
-
-
-def test_pass2_uses_full_data():
-
-    with TemporaryDirectory() as tmpdir:
-        experiment_dir = Path(tmpdir) / 'experiment'
-        params = logreg_sfd.params()
-        domain = ParamDomain(params)
-        strategy = RandomStrategy(domain, seed=42)
-
-        uel = UniversalExperimentLoop(
-            sfd=logreg_sfd,
-            search_strategy=strategy,
-            experiment_dir=experiment_dir,
-            test_mode=True,
-        )
-
-        uel.run(
-            experiment_name='test_full_data',
-            n_permutations=1,
-        )
-
-        trainer = Trainer(experiment_dir, data=uel.data)
-        pid = next(iter(trainer._round_data.keys()))
-        round_params = dict(trainer._round_data[pid]['round_params'])
-
-        # Pass 1 data has original split — val and test are non-empty
-        pass1_data = trainer._manifest.prepare_data(uel.data, round_params)
-        assert len(pass1_data['x_val']) > 0
-        assert len(pass1_data['x_test']) > 0
-        pass1_train_rows = len(pass1_data['x_train'])
-
-        # Pass 2 data uses split_config=(1,0,0) — all data in training
-        manifest_full = trainer._manifest.with_params_override(split_config=(1, 0, 0))
-        pass2_data = manifest_full.prepare_data(uel.data, round_params)
-        pass2_train_rows = len(pass2_data['x_train'])
-        assert len(pass2_data['x_val']) == 0
-        assert len(pass2_data['x_test']) == 0
-        assert pass2_train_rows > pass1_train_rows
-
-
-def test_sensor_inference():
-
-    with TemporaryDirectory() as tmpdir:
-        experiment_dir = Path(tmpdir) / 'experiment'
-        params = logreg_sfd.params()
-        domain = ParamDomain(params)
-        strategy = RandomStrategy(domain, seed=42)
-
-        uel = UniversalExperimentLoop(
-            sfd=logreg_sfd,
-            search_strategy=strategy,
-            experiment_dir=experiment_dir,
-            test_mode=True,
-        )
-
-        uel.run(
-            experiment_name='test_inference',
-            n_permutations=1,
-        )
-
-        trainer = Trainer(experiment_dir, data=uel.data)
-        pid = next(iter(trainer._round_data.keys()))
-        sensors = trainer.train([pid])
-        sensor = sensors[0]
-
-        # sensor.predict() works on feature-only data (no labels needed)
-        data_dict = trainer._manifest.prepare_data(uel.data, sensor.round_params)
-        live_data = {'x_test': data_dict['x_test']}
-        result = sensor.predict(live_data)
-        assert isinstance(result, dict)
-        assert '_preds' in result
-        assert '_probs' in result
-        assert len(result['_preds']) == len(data_dict['x_test'])
-
-        # __call__ delegates to predict()
-        result_via_call = sensor(live_data)
-        assert result_via_call.keys() == result.keys()
-
-
-def test_trainer_with_feature_ablation():
-
-    with TemporaryDirectory() as tmpdir:
-        experiment_dir = Path(tmpdir) / 'experiment'
-        params = logreg_sfd.params()
-        params['feature_drop_count'] = [1]
-        params['feature_drop_seed'] = [42]
-        domain = ParamDomain(params)
-        strategy = RandomStrategy(domain, seed=42)
-
-        uel = UniversalExperimentLoop(
-            sfd=logreg_sfd,
-            search_strategy=strategy,
-            experiment_dir=experiment_dir,
-            test_mode=True,
-        )
-
-        uel.run(
-            experiment_name='test_ablation',
-            n_permutations=1,
-        )
-
-        # _dropped_features stored in round_data.jsonl
-        trainer = Trainer(experiment_dir, data=uel.data)
-        pid = next(iter(trainer._round_data.keys()))
-        rp = trainer._round_data[pid]['round_params']
-        assert '_dropped_features' in rp
-        assert len(rp['_dropped_features']) == 1
-
-        # Trainer reproduces same drops
-        train_rp = dict(rp)
-        trainer._manifest.prepare_data(uel.data, train_rp)
-        assert train_rp['_dropped_features'] == rp['_dropped_features']
-
-        # Trainer Pass 1 validates with ablation active
-        sensors = trainer.train([pid])
-        assert len(sensors) == 1
-        assert sensors[0].model is not None
-
-
-def test_trainer_with_fractional_diff():
-
-    large_data = get_cached_spot_klines_2h(20000)
-
-    with TemporaryDirectory() as tmpdir:
-        experiment_dir = Path(tmpdir) / 'experiment'
-        params = logreg_sfd.params()
-        params['frac_diff_d'] = [0.4]
-        domain = ParamDomain(params)
-        strategy = RandomStrategy(domain, seed=42)
-
-        uel = UniversalExperimentLoop(
-            sfd=logreg_sfd,
-            search_strategy=strategy,
-            experiment_dir=experiment_dir,
-            data=large_data,
-        )
-
-        uel.run(
-            experiment_name='test_fracdiff',
-            n_permutations=1,
-        )
-
-        trainer = Trainer(experiment_dir, data=large_data)
-        pid = next(iter(trainer._round_data.keys()))
-
-        # Trainer Pass 1 validates with fracdiff active
-        sensors = trainer.train([pid])
-        assert len(sensors) == 1
-        assert sensors[0].model is not None
+        with pytest.raises(ValueError, match='yaml_reference'):
+            Trainer(
+                experiment_dir,
+                data=pl.DataFrame({'x': [1, 2, 3]}),
+            )
 
 
 def test_load_round_data_skips_blank_and_malformed_lines() -> None:
@@ -391,55 +155,6 @@ def test_load_original_log_returns_none_when_results_csv_is_missing() -> None:
         trainer._experiment_dir = Path(tmpdir)
 
         assert trainer._load_original_log() is None
-
-
-def test_resolve_model_class_requires_configured_architecture_function() -> None:
-    trainer = object.__new__(Trainer)
-    trainer._manifest = SimpleNamespace(architecture_function=None)
-
-    with pytest.raises(ValueError, match='Architecture function not configured'):
-        trainer._resolve_model_class()
-
-
-def test_resolve_model_class_rejects_modules_without_reference_model_subclasses() -> None:
-    def architecture_function():
-        return None
-
-    architecture_function.__module__ = 'dummy.no_model'
-    trainer = object.__new__(Trainer)
-    trainer._manifest = SimpleNamespace(architecture_function=architecture_function)
-
-    with pytest.MonkeyPatch.context() as monkeypatch:
-        monkeypatch.setattr(
-            trainer_module.importlib,
-            'import_module',
-            lambda module_name: types.SimpleNamespace(NotAReferenceModel=object),
-        )
-
-        with pytest.raises(ValueError, match='No ReferenceModel subclass found'):
-            trainer._resolve_model_class()
-
-
-def test_resolve_model_class_rejects_modules_with_multiple_reference_model_subclasses() -> None:
-    def architecture_function():
-        return None
-
-    architecture_function.__module__ = 'dummy.multi_model'
-    trainer = object.__new__(Trainer)
-    trainer._manifest = SimpleNamespace(architecture_function=architecture_function)
-
-    with pytest.MonkeyPatch.context() as monkeypatch:
-        monkeypatch.setattr(
-            trainer_module.importlib,
-            'import_module',
-            lambda module_name: types.SimpleNamespace(
-                ModelA=_ReferenceModelA,
-                ModelB=_ReferenceModelB,
-            ),
-        )
-
-        with pytest.raises(ValueError, match='Multiple ReferenceModel subclasses found'):
-            trainer._resolve_model_class()
 
 
 def test_validate_metrics_ignores_metadata_fields_and_accepts_small_stochastic_drift() -> None:
@@ -492,316 +207,3 @@ def test_validate_metrics_reports_missing_permutations_and_large_deterministic_m
     )
 
     assert mismatches == ['accuracy: original=0.8, new=0.81']
-
-
-_SELF_CONTAINED_SFD_SOURCE = '''
-from types import SimpleNamespace
-
-
-def manifest():
-    return SimpleNamespace(architecture_function=None)
-
-
-def params():
-    return {'alpha': 0.5}
-'''
-
-
-def test_trainer_loads_sfd_from_experiment_dir_without_sys_path_mutation() -> None:
-
-    '''
-    Pin the self-contained-experiment contract: Trainer(experiment_dir)
-    must succeed when the SFD .py lives inside experiment_dir and is
-    referenced by bare module name in metadata.json, even though that
-    name is not on sys.path. The loaded module must be registered in
-    sys.modules under the bare name so downstream
-    importlib.import_module(name) lookups (e.g. _resolve_model_class)
-    resolve to the same module instance.
-    '''
-
-    sys_path_before = list(sys.path)
-    sfd_module_name = 'isolated_sfd_for_trainer_test'
-    previous = sys.modules.pop(sfd_module_name, None)
-
-    try:
-        with TemporaryDirectory() as tmpdir:
-            experiment_dir = Path(tmpdir)
-
-            (experiment_dir / f'{sfd_module_name}.py').write_text(
-                _SELF_CONTAINED_SFD_SOURCE,
-            )
-            (experiment_dir / 'metadata.json').write_text(
-                json.dumps({'sfd_module': sfd_module_name}),
-            )
-            (experiment_dir / 'round_data.jsonl').write_text('')
-
-            trainer = Trainer(
-                experiment_dir,
-                data=pl.DataFrame({'x': [1, 2, 3]}),
-            )
-
-            assert trainer._param_keys == frozenset({'alpha'})
-            assert trainer._manifest.architecture_function is None
-
-            registered = sys.modules.get(sfd_module_name)
-            assert registered is not None
-            assert importlib.import_module(sfd_module_name) is registered
-    finally:
-        if previous is None:
-            sys.modules.pop(sfd_module_name, None)
-        else:
-            sys.modules[sfd_module_name] = previous
-
-    assert sys.path == sys_path_before
-
-
-def test_trainer_reconstructs_yaml_artifact_from_metadata_reference(monkeypatch) -> None:
-
-    '''
-    YAML CLI runs store the declarative SFD under metadata.json["yaml_reference"]
-    while metadata.json["sfd_module"] uses a non-importable yaml:<name> marker.
-    Trainer must use the YAML reference directly instead of treating that marker
-    as a Python module path.
-    '''
-
-    seen = {}
-
-    class FakeCompiledSFD:
-
-        def __init__(self, yaml_reference):
-            seen['yaml_reference'] = yaml_reference
-
-        def params(self):
-            return {'alpha': [1]}
-
-        def manifest(self):
-            return SimpleNamespace(architecture_function=None)
-
-    monkeypatch.setattr(trainer_module, 'CompiledSFD', FakeCompiledSFD)
-
-    yaml_reference = {
-        'metadata': {'name': 'yaml_exp'},
-        'sfd': {'params': {'alpha': [1]}},
-    }
-
-    with TemporaryDirectory() as tmpdir:
-        experiment_dir = Path(tmpdir)
-        (experiment_dir / 'metadata.json').write_text(
-            json.dumps({
-                'sfd_module': 'yaml:yaml_exp',
-                'yaml_reference': yaml_reference,
-            }),
-        )
-        (experiment_dir / 'round_data.jsonl').write_text('')
-
-        trainer = Trainer(
-            experiment_dir,
-            data=pl.DataFrame({'x': [1, 2, 3]}),
-        )
-
-    assert seen['yaml_reference'] == yaml_reference
-    assert trainer._param_keys == frozenset({'alpha'})
-
-
-@pytest.mark.parametrize(
-    'yaml_reference',
-    [
-        [],
-        {'metadata': {'name': 'yaml_exp'}, 'sfd': {}},
-    ],
-)
-def test_trainer_rejects_malformed_yaml_reference(yaml_reference) -> None:
-
-    with TemporaryDirectory() as tmpdir:
-        experiment_dir = Path(tmpdir)
-        (experiment_dir / 'metadata.json').write_text(
-            json.dumps({
-                'sfd_module': 'yaml:yaml_exp',
-                'yaml_reference': yaml_reference,
-            }),
-        )
-        (experiment_dir / 'round_data.jsonl').write_text('')
-
-        with pytest.raises(ValueError, match='yaml_reference'):
-            Trainer(
-                experiment_dir,
-                data=pl.DataFrame({'x': [1, 2, 3]}),
-            )
-
-
-def test_trainer_wraps_yaml_resolution_error(monkeypatch) -> None:
-
-    class FakeCompiledSFD:
-
-        def __init__(self, _yaml_reference):
-            pass
-
-        def params(self):
-            return {'alpha': [1]}
-
-        def manifest(self):
-            raise trainer_module.ResolutionError(
-                'bad.reference',
-                ['limen'],
-            )
-
-    monkeypatch.setattr(trainer_module, 'CompiledSFD', FakeCompiledSFD)
-
-    with TemporaryDirectory() as tmpdir:
-        experiment_dir = Path(tmpdir)
-        (experiment_dir / 'metadata.json').write_text(
-            json.dumps({
-                'sfd_module': 'yaml:yaml_exp',
-                'yaml_reference': {
-                    'metadata': {'name': 'yaml_exp'},
-                    'sfd': {'params': {'alpha': [1]}},
-                },
-            }),
-        )
-        (experiment_dir / 'round_data.jsonl').write_text('')
-
-        with pytest.raises(ValueError, match='yaml_reference'):
-            Trainer(
-                experiment_dir,
-                data=pl.DataFrame({'x': [1, 2, 3]}),
-            )
-
-
-def test_trainer_loads_sfd_rolls_back_sys_modules_on_exec_failure() -> None:
-
-    '''
-    If the SFD module raises during exec_module, the partially
-    initialised module must not remain in sys.modules and any
-    previous entry under the same name must be restored.
-    '''
-
-    sfd_module_name = 'broken_sfd_for_trainer_test'
-    previous = sys.modules.pop(sfd_module_name, None)
-
-    try:
-        with TemporaryDirectory() as tmpdir:
-            experiment_dir = Path(tmpdir)
-
-            (experiment_dir / f'{sfd_module_name}.py').write_text(
-                'raise RuntimeError("intentional sfd boom")\n',
-            )
-            (experiment_dir / 'metadata.json').write_text(
-                json.dumps({'sfd_module': sfd_module_name}),
-            )
-            (experiment_dir / 'round_data.jsonl').write_text('')
-
-            with pytest.raises(RuntimeError, match='intentional sfd boom'):
-                Trainer(
-                    experiment_dir,
-                    data=pl.DataFrame({'x': [1, 2, 3]}),
-                )
-
-            assert sfd_module_name not in sys.modules
-    finally:
-        if previous is None:
-            sys.modules.pop(sfd_module_name, None)
-        else:
-            sys.modules[sfd_module_name] = previous
-
-
-def test_trainer_loads_sfd_restores_previous_sys_modules_entry_on_exec_failure() -> None:
-
-    '''
-    If a different module was already registered under
-    `sfd_module_name`, an `exec_module` failure must restore that
-    prior entry instead of leaving the slot empty.
-    '''
-
-    sfd_module_name = 'preexisting_sfd_for_trainer_test'
-    sentinel = types.ModuleType(sfd_module_name)
-    sentinel.__limen_test_sentinel__ = True
-    saved = sys.modules.get(sfd_module_name)
-    sys.modules[sfd_module_name] = sentinel
-
-    try:
-        with TemporaryDirectory() as tmpdir:
-            experiment_dir = Path(tmpdir)
-
-            (experiment_dir / f'{sfd_module_name}.py').write_text(
-                'raise RuntimeError("intentional sfd boom")\n',
-            )
-            (experiment_dir / 'metadata.json').write_text(
-                json.dumps({'sfd_module': sfd_module_name}),
-            )
-            (experiment_dir / 'round_data.jsonl').write_text('')
-
-            with pytest.raises(RuntimeError, match='intentional sfd boom'):
-                Trainer(
-                    experiment_dir,
-                    data=pl.DataFrame({'x': [1, 2, 3]}),
-                )
-
-            assert sys.modules.get(sfd_module_name) is sentinel
-    finally:
-        if saved is None:
-            sys.modules.pop(sfd_module_name, None)
-        else:
-            sys.modules[sfd_module_name] = saved
-
-
-def test_trainer_falls_back_to_import_module_when_no_local_sfd_file() -> None:
-
-    '''
-    Built-in / packaged SFDs referenced by fully-qualified package
-    name must continue to work via importlib.import_module when no
-    `<sfd_module_name>.py` exists inside experiment_dir.
-    '''
-
-    with TemporaryDirectory() as tmpdir:
-        experiment_dir = Path(tmpdir)
-
-        (experiment_dir / 'metadata.json').write_text(
-            json.dumps({
-                'sfd_module': 'limen.sfd.foundational_sfd.logreg_binary',
-            }),
-        )
-        (experiment_dir / 'round_data.jsonl').write_text('')
-
-        trainer = Trainer(
-            experiment_dir,
-            data=pl.DataFrame({'x': [1, 2, 3]}),
-        )
-
-        assert trainer._param_keys == frozenset(logreg_sfd.params().keys())
-
-
-@pytest.mark.parametrize('bad_name', [
-    '../etc/passwd',
-    '..',
-    '/etc/passwd',
-    'foo/bar',
-    'foo\\bar',
-    'foo..bar',
-    '.leading_dot',
-    'trailing_dot.',
-    '',
-    '1starts_with_digit',
-    'has space',
-])
-def test_trainer_rejects_path_traversal_and_invalid_module_names(bad_name: str) -> None:
-
-    '''
-    Pin the path-traversal hardening: `_load_sfd_module` must reject
-    any `sfd_module` name that is not a dotted sequence of valid
-    Python identifiers, before either the local-file or import_module
-    branch runs.
-    '''
-
-    with TemporaryDirectory() as tmpdir:
-        experiment_dir = Path(tmpdir)
-
-        (experiment_dir / 'metadata.json').write_text(
-            json.dumps({'sfd_module': bad_name}),
-        )
-        (experiment_dir / 'round_data.jsonl').write_text('')
-
-        with pytest.raises(ValueError, match='not a dotted sequence'):
-            Trainer(
-                experiment_dir,
-                data=pl.DataFrame({'x': [1, 2, 3]}),
-            )

--- a/tests/test_yaml.py
+++ b/tests/test_yaml.py
@@ -672,6 +672,29 @@ def test_validate_error_for_required_columns_not_a_list() -> None:
     assert any('required_columns' in e.path for e in result.errors)
 
 
+def test_validate_error_for_decoder_lookback_greater_than_one() -> None:
+    yaml_dict, _ = parse(_MINIMAL_ML_YAML)
+    yaml_dict['sfd']['manifest']['decoder_lookback'] = 2
+    result = validate(yaml_dict)
+    assert not result.valid
+    assert any('decoder_lookback' in e.path for e in result.errors)
+
+
+def test_validate_error_for_decoder_lookback_zero() -> None:
+    yaml_dict, _ = parse(_MINIMAL_ML_YAML)
+    yaml_dict['sfd']['manifest']['decoder_lookback'] = 0
+    result = validate(yaml_dict)
+    assert not result.valid
+    assert any('decoder_lookback' in e.path for e in result.errors)
+
+
+def test_validate_accepts_decoder_lookback_one() -> None:
+    yaml_dict, _ = parse(_MINIMAL_ML_YAML)
+    yaml_dict['sfd']['manifest']['decoder_lookback'] = 1
+    result = validate(yaml_dict)
+    assert result.valid
+
+
 def test_validate_error_for_data_dict_extension_unknown_key() -> None:
     yaml_dict, _ = parse(_MINIMAL_ML_YAML)
     yaml_dict['sfd']['manifest']['data_dict_extension'] = {

--- a/tests/test_yaml.py
+++ b/tests/test_yaml.py
@@ -37,15 +37,13 @@ _MINIMAL_ML_YAML = dedent('''\
           method: limen.data.HistoricalData.get_spot_klines
           params:
             kline_size: 3600
-        test_data_source:
-          method: limen.data.HistoricalData.get_spot_klines
-          params:
-            kline_size: 7200
-            n_rows: 500
-        split_config:
-          train: 8
-          val: 1
-          test: 2
+        split_dates:
+          train_start: "2022-01-01"
+          train_end: "2022-07-01"
+          val_start: "2022-07-01"
+          val_end: "2022-10-01"
+          test_start: "2022-10-01"
+          test_end: "2023-01-01"
         indicators:
           - func: limen.indicators.roc
             params:
@@ -130,10 +128,13 @@ _MINIMAL_RULE_BASED_YAML = dedent('''\
           method: limen.data.HistoricalData.get_spot_klines
           params:
             kline_size: 3600
-        split_config:
-          train: 8
-          val: 1
-          test: 2
+        split_dates:
+          train_start: "2022-01-01"
+          train_end: "2022-07-01"
+          val_start: "2022-07-01"
+          val_end: "2022-10-01"
+          test_start: "2022-10-01"
+          test_end: "2023-01-01"
         strategy:
           conditions:
             - id: rsi_low
@@ -296,39 +297,28 @@ def test_validate_error_for_invalid_indicator_func_in_rule_based_manifest() -> N
 
 def test_validate_passes_valid_yaml_with_split_dates() -> None:
     yaml_dict, _ = parse(_MINIMAL_ML_YAML)
-    del yaml_dict['sfd']['manifest']['split_config']
-    yaml_dict['sfd']['manifest']['split_dates'] = {
-        'train_start': '2022-01-01', 'train_end': '2022-07-01',
-        'val_start': '2022-07-01', 'val_end': '2022-10-01',
-        'test_start': '2022-10-01', 'test_end': '2023-01-01',
-    }
     result = validate(yaml_dict)
     assert result.valid
 
 
 def test_validate_error_for_missing_required_field() -> None:
     yaml_dict, _ = parse(_MINIMAL_ML_YAML)
-    del yaml_dict['sfd']['manifest']['split_config']
+    del yaml_dict['sfd']['manifest']['split_dates']
     result = validate(yaml_dict)
     assert not result.valid
-    assert any('split_config' in e.message for e in result.errors)
+    assert any('split_dates' in e.message for e in result.errors)
 
 
-def test_validate_error_when_both_split_config_and_split_dates_present() -> None:
+def test_validate_error_when_split_config_present() -> None:
     yaml_dict, _ = parse(_MINIMAL_ML_YAML)
-    yaml_dict['sfd']['manifest']['split_dates'] = {
-        'train_start': '2022-01-01', 'train_end': '2022-07-01',
-        'val_start': '2022-07-01', 'val_end': '2022-10-01',
-        'test_start': '2022-10-01', 'test_end': '2023-01-01',
-    }
+    yaml_dict['sfd']['manifest']['split_config'] = {'train': 8, 'val': 1, 'test': 2}
     result = validate(yaml_dict)
     assert not result.valid
-    assert any('split_config' in e.message and 'split_dates' in e.message for e in result.errors)
+    assert any('split_config' in e.message and 'not supported' in e.message for e in result.errors)
 
 
 def test_validate_error_for_invalid_split_date_format() -> None:
     yaml_dict, _ = parse(_MINIMAL_ML_YAML)
-    del yaml_dict['sfd']['manifest']['split_config']
     yaml_dict['sfd']['manifest']['split_dates'] = {
         'train_start': '01/01/2022', 'train_end': '2022-07-01',
         'val_start': '2022-07-01', 'val_end': '2022-10-01',
@@ -341,7 +331,6 @@ def test_validate_error_for_invalid_split_date_format() -> None:
 
 def test_validate_error_for_split_dates_out_of_order() -> None:
     yaml_dict, _ = parse(_MINIMAL_ML_YAML)
-    del yaml_dict['sfd']['manifest']['split_config']
     yaml_dict['sfd']['manifest']['split_dates'] = {
         'train_start': '2022-07-01', 'train_end': '2022-01-01',
         'val_start': '2022-07-01', 'val_end': '2022-10-01',
@@ -352,13 +341,13 @@ def test_validate_error_for_split_dates_out_of_order() -> None:
     assert any('non-decreasing' in e.message for e in result.errors)
 
 
-def test_validate_error_for_split_config_invalid_value() -> None:
-    for key, value in [('train', 0), ('val', -1)]:
-        yaml_dict, _ = parse(_MINIMAL_ML_YAML)
-        yaml_dict['sfd']['manifest']['split_config'][key] = value
-        result = validate(yaml_dict)
-        assert not result.valid
-        assert any(key in e.message for e in result.errors)
+def test_validate_error_for_split_config_present() -> None:
+    yaml_dict, _ = parse(_MINIMAL_ML_YAML)
+    del yaml_dict['sfd']['manifest']['split_dates']
+    yaml_dict['sfd']['manifest']['split_config'] = {'train': 8, 'val': 1, 'test': 2}
+    result = validate(yaml_dict)
+    assert not result.valid
+    assert any('split_config' in e.message and 'not supported' in e.message for e in result.errors)
 
 
 def test_validate_error_for_missing_mode() -> None:
@@ -424,9 +413,9 @@ def test_validate_warning_for_unknown_key_in_data_source() -> None:
     assert any('typo_key' in w.message for w in result.warnings)
 
 
-def test_validate_warning_for_unknown_key_in_split_config() -> None:
+def test_validate_warning_for_unknown_key_in_split_dates() -> None:
     yaml_dict, _ = parse(_MINIMAL_ML_YAML)
-    yaml_dict['sfd']['manifest']['split_config']['typo_key'] = 1
+    yaml_dict['sfd']['manifest']['split_dates']['typo_key'] = '2022-01-01'
     result = validate(yaml_dict)
     assert any('typo_key' in w.message for w in result.warnings)
 
@@ -780,31 +769,69 @@ def test_build_manifest_data_source_method_is_callable_with_correct_params() -> 
     assert cfg.params['kline_size'] == 3600
 
 
-def test_build_manifest_test_data_source_method_is_callable() -> None:
+def test_build_manifest_data_source_date_limits_injected_from_split_dates() -> None:
     yaml_dict, _ = parse(_MINIMAL_ML_YAML)
     manifest = build_manifest(yaml_dict)
-    cfg = manifest.test_data_source_config
-    assert callable(cfg.method)
-    assert cfg.params['n_rows'] == 500
+    params = manifest.data_source_config.params
+    assert params['start_date_limit'] == '2022-01-01'
+    assert params['end_date_limit'] == '2023-01-01'
 
 
-def test_build_manifest_split_config_tuple_is_correct() -> None:
+def test_validate_error_for_test_data_source_in_yaml() -> None:
     yaml_dict, _ = parse(_MINIMAL_ML_YAML)
-    assert build_manifest(yaml_dict).split_config == (8, 1, 2)
-
-
-def test_build_manifest_split_dates_calls_set_split_dates() -> None:
-    yaml_dict, _ = parse(_MINIMAL_ML_YAML)
-    del yaml_dict['sfd']['manifest']['split_config']
-    yaml_dict['sfd']['manifest']['split_dates'] = {
-        'train_start': '2022-01-01', 'train_end': '2022-07-01',
-        'val_start': '2022-07-01', 'val_end': '2022-10-01',
-        'test_start': '2022-10-01', 'test_end': '2023-01-01',
+    yaml_dict['sfd']['manifest']['test_data_source'] = {
+        'method': 'limen.data.HistoricalData.get_spot_klines',
+        'params': {'kline_size': 7200},
     }
+    result = validate(yaml_dict)
+    assert not result.valid
+    assert any('test_data_source' in e.message for e in result.errors)
+
+
+def test_validate_error_for_start_date_limit_in_data_source_params() -> None:
+    yaml_dict, _ = parse(_MINIMAL_ML_YAML)
+    yaml_dict['sfd']['manifest']['data_source']['params']['start_date_limit'] = '2022-01-01'
+    result = validate(yaml_dict)
+    assert not result.valid
+    assert any('start_date_limit' in e.message for e in result.errors)
+
+
+def test_validate_error_for_end_date_limit_in_data_source_params() -> None:
+    yaml_dict, _ = parse(_MINIMAL_ML_YAML)
+    yaml_dict['sfd']['manifest']['data_source']['params']['end_date_limit'] = '2023-01-01'
+    result = validate(yaml_dict)
+    assert not result.valid
+    assert any('end_date_limit' in e.message for e in result.errors)
+
+
+def test_build_manifest_split_dates_is_correct() -> None:
+    yaml_dict, _ = parse(_MINIMAL_ML_YAML)
     manifest = build_manifest(yaml_dict)
     assert manifest.split_dates is not None
     assert manifest.split_dates[0] == date.fromisoformat('2022-01-01')
     assert manifest.split_dates[5] == date.fromisoformat('2023-01-01')
+
+
+def test_build_manifest_split_dates_all_six_dates_stored() -> None:
+    yaml_dict, _ = parse(_MINIMAL_ML_YAML)
+    yaml_dict['sfd']['manifest']['split_dates'] = {
+        'train_start': '2023-01-01', 'train_end': '2023-06-30',
+        'val_start': '2023-07-01', 'val_end': '2023-09-30',
+        'test_start': '2023-10-01', 'test_end': '2023-12-31',
+    }
+    manifest = build_manifest(yaml_dict)
+    assert manifest.split_dates is not None
+    assert manifest.split_dates[0] == date.fromisoformat('2023-01-01')
+    assert manifest.split_dates[3] == date.fromisoformat('2023-09-30')
+    assert manifest.split_dates[5] == date.fromisoformat('2023-12-31')
+
+
+def test_build_manifest_rule_based_data_source_date_limits_injected_from_split_dates() -> None:
+    yaml_dict, _ = parse(_MINIMAL_RULE_BASED_YAML)
+    manifest = build_manifest(yaml_dict)
+    params = manifest.data_source_config.params
+    assert params['start_date_limit'] == '2022-01-01'
+    assert params['end_date_limit'] == '2023-01-01'
 
 
 def test_build_manifest_indicator_include_if_stored_on_entry() -> None:
@@ -960,10 +987,13 @@ def test_build_manifest_rule_based_indicators_wired() -> None:
               method: limen.data.HistoricalData.get_spot_klines
               params:
                 kline_size: 3600
-            split_config:
-              train: 8
-              val: 1
-              test: 2
+            split_dates:
+              train_start: "2022-01-01"
+              train_end: "2022-07-01"
+              val_start: "2022-07-01"
+              val_end: "2022-10-01"
+              test_start: "2022-10-01"
+              test_end: "2023-01-01"
             indicators:
               - func: limen.indicators.wilder_rsi
                 params:


### PR DESCRIPTION
**NOTE:** The author must always **first review the PR themselves**, before requesting review from others, that means carefully having reviewed the full diff in GitHub.

## What does this PR change?

- Refactor `Trainer` to a single training pass: drop the second all-data retraining run; the validated training-run model is promoted directly to a `Sensor`; enforce YAML-only experiment input
- Add `sensor_input_prep` to `MLManifest` — the canonical preparation step for sensor inference: applies fitted scaler/PCA, guards against bars inside the training window, and enforces indicator and decoder lookback requirements
- Rewrite `Sensor` with a YAML-only constructor; `predict()` and `predict_all()` both wrap `sensor_input_prep` so feature preparation is never done outside the sensor
- Add `Sensor.predict_all(raw_klines)` — returns one `BarPrediction` per input bar with `reason` set for warm-up and inside-training-window bars; valid bars carry `prediction` and `probability`
- Add `decoder_lookback` to the YAML schema, validator, compiler, and `MLManifest` for architectures that require a multi-bar inference window
- Fix calibration at inference: `LogRegBinary` and `TabPFNBinary` fit the calibrator once during training evaluation and store it on the model; subsequent sensor inference calls reuse the stored calibrator without requiring validation data
- Add `fit_calibrator` to `limen.calibration` as a public API separating the calibrator fit step from the apply step
- Add `random_state` parameter to `RandomBinaryTarget` for reproducible label generation
- Remove split_config percentage-based splits from the YAML layer; all experiments use explicit `split_dates`

closes #555 

## Checklist

- [x] I have reviewed full diff in “Files changed”
- [x] I left no unnecessary files in the changes
- [x] I ran `python tests/run.py` locally without errors (where applicable)
- [x] I updated `/docs` (if behavior/API/config/user/etc changed)
- [x] I added and/or updated docstrings as per [Writing Docstrings](https://github.com/Vaquum/Limen/blob/main/docs/Developer/Writing-Docstrings.md) (for any changed public functions/classes)
- [x] I updated CHANGELOG.md (unless only docs or other non-code aspect was changed)
- [x] I updated pyproject.toml (unless only docs or other non-code aspect was changed)
- [x] I added and/or updated tests (if behavior changed or new code paths added)
- [x] I validated changes manually
- [x] I validated changes with LLM
- [x] I removed any extraneous examples/comments
- [x] I linked issue to auto-close on merge (e.g., “Fixes #123”) when applicable
