### PR TITLE
Add indicator/feature name context to validation error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1033,3 +1033,7 @@ Note: add all new changelog entries to the bottom of this file.
 - Add `sensor-error` graceful degradation to `Cohort._aggregate_bar_predictions`: sensor-error members are excluded before aggregation; only when all members error does the cohort return `reason='sensor-error'`
 - Fix flaky `test_e2e_label_control_trainer_sensor` by adding `seed: 42` to YAML search strategy; fix `build_search_strategy` compiler to pass `seed` through to `RandomStrategy`
 - Extend `test_e2e_label_control_trainer_sensor` to cover full cohort prediction path: `Cohort` construction, `set_members`, `predict_all`, `predict`, and probability mean verification
+
+## v3.15.1 on 6th of June, 2026
+
+- Prefix every parameter-validation error message in `limen/indicators` and `limen/features` with the indicator/feature name, so each message names its own context (e.g. `period must be between 2 and 100000` becomes `ema period must be between 2 and 100000`) — 107 messages across 54 files

--- a/Claude.md
+++ b/Claude.md
@@ -57,6 +57,7 @@ Every declaration is type-hinted; magic numbers become named constants. When int
 - You always add empty line when in doubt between adding or not
 - You make functions over 50 lines its own file, except when there is good reason for not to
 - Make the filename and the function name identical
+- Prefix validation error messages in `indicators`/`features` with the feature/function name (e.g. `ema period must be between 2 and 100000`); skip only when the message already names the feature
 - Make magic numbers constants
 - Make constants uppercase
 - Make variables lowercase

--- a/limen/features/close_position.py
+++ b/limen/features/close_position.py
@@ -37,5 +37,5 @@ def close_position(
     if window == 1:
         return data.with_columns(position.alias(output_col))
     if window <= 0:
-        raise ValueError('window must be positive')
+        raise ValueError('close_position window must be positive')
     return data.with_columns(position.rolling_mean(window_size=window).alias(output_col))

--- a/limen/features/fractional_diff.py
+++ b/limen/features/fractional_diff.py
@@ -26,7 +26,7 @@ def _get_weights_ffd(d: float, threshold: float = 1e-5) -> np.ndarray:
     '''
 
     if threshold <= 0:
-        raise ValueError(f"threshold must be positive, got {threshold}")
+        raise ValueError(f"fractional_diff threshold must be positive, got {threshold}")
 
     weights = [1.0]
     k = 1
@@ -70,13 +70,13 @@ def fractional_diff(data: pl.DataFrame,
     '''
 
     if not cols:
-        raise ValueError('cols must be a non-empty list of column names')
+        raise ValueError('fractional_diff cols must be a non-empty list of column names')
 
     if d < 0:
-        raise ValueError(f"d must be non-negative, got {d}")
+        raise ValueError(f"fractional_diff d must be non-negative, got {d}")
 
     if threshold <= 0:
-        raise ValueError(f"threshold must be positive, got {threshold}")
+        raise ValueError(f"fractional_diff threshold must be positive, got {threshold}")
 
     schema_names = data.collect_schema().names()
 
@@ -169,7 +169,7 @@ def find_min_d(data: pl.DataFrame,
     from limen.utils.adf_test import adf_test
 
     if step <= 0:
-        raise ValueError(f"step must be positive, got {step}")
+        raise ValueError(f"fractional_diff step must be positive, got {step}")
 
     fracdiff_col = f"{col}{FRACDIFF_SUFFIX}"
 

--- a/limen/features/lagged_features.py
+++ b/limen/features/lagged_features.py
@@ -20,16 +20,16 @@ def lag_range_cols(data: pl.DataFrame,
     '''
 
     if not cols:
-        raise ValueError('cols cannot be empty')
+        raise ValueError('lagged_features cols cannot be empty')
 
     if not isinstance(start, int) or not isinstance(end, int):
-        raise TypeError('start and end must be integers')
+        raise TypeError('lagged_features start and end must be integers')
 
     if start < 0 or end < 0:
-        raise ValueError('start and end must be non-negative')
+        raise ValueError('lagged_features start and end must be non-negative')
 
     if start > end:
-        raise ValueError('start must be less than or equal to end')
+        raise ValueError('lagged_features start must be less than or equal to end')
 
     lag_expressions = [
         pl.col(col).shift(lag).alias(f'{col}_lag_{lag}')
@@ -100,7 +100,7 @@ def lag_column(data: pl.DataFrame,
     '''
 
     if alias is not None and not isinstance(alias, str):
-        raise TypeError('alias must be a string or None')
+        raise TypeError('lagged_features alias must be a string or None')
 
     result = lag_range_cols(data, [col], lag, lag)
 

--- a/limen/features/momentum_confirmation.py
+++ b/limen/features/momentum_confirmation.py
@@ -20,7 +20,7 @@ def momentum_confirmation(df: pl.DataFrame,
     '''
 
     if short_period >= long_period:
-        raise ValueError(f"short_period ({short_period}) must be less than long_period ({long_period})")
+        raise ValueError(f"momentum_confirmation short_period ({short_period}) must be less than long_period ({long_period})")
 
     long_weight = 1.0 - short_weight
 

--- a/limen/features/rolling_zscore.py
+++ b/limen/features/rolling_zscore.py
@@ -30,7 +30,7 @@ def rolling_zscore(
     '''
 
     if window <= 0:
-        raise ValueError('window must be positive')
+        raise ValueError('rolling_zscore window must be positive')
 
     x = pl.col(column)
     if transform == 'log1p':
@@ -38,7 +38,7 @@ def rolling_zscore(
     elif transform == 'abs':
         x = x.abs()
     elif transform != 'identity':
-        raise ValueError("transform must be one of 'identity', 'log1p', or 'abs'")
+        raise ValueError("rolling_zscore transform must be one of 'identity', 'log1p', or 'abs'")
 
     mean = x.rolling_mean(window_size=window)
     std = x.rolling_std(window_size=window)

--- a/limen/indicators/adosc.py
+++ b/limen/indicators/adosc.py
@@ -31,9 +31,9 @@ def adosc(
     '''
 
     if fast_period < CMP_N_2 or fast_period > CMP_N_100000:
-        raise ValueError('fast_period must be between 2 and 100000')
+        raise ValueError('adosc fast_period must be between 2 and 100000')
     if slow_period < CMP_N_2 or slow_period > CMP_N_100000:
-        raise ValueError('slow_period must be between 2 and 100000')
+        raise ValueError('adosc slow_period must be between 2 and 100000')
 
     out_col = f"adosc_{fast_period}_{slow_period}"
     lookback = max(fast_period, slow_period) - 1

--- a/limen/indicators/apo.py
+++ b/limen/indicators/apo.py
@@ -30,13 +30,13 @@ def apo(
     '''
 
     if fast_period < CMP_N_2 or fast_period > CMP_N_100000:
-        raise ValueError('fast_period must be between 2 and 100000')
+        raise ValueError('apo fast_period must be between 2 and 100000')
     if slow_period < CMP_N_2 or slow_period > CMP_N_100000:
-        raise ValueError('slow_period must be between 2 and 100000')
+        raise ValueError('apo slow_period must be between 2 and 100000')
     if ma_type < 0 or ma_type > CMP_N_8:
-        raise ValueError('ma_type must be between 0 and 8')
+        raise ValueError('apo ma_type must be between 0 and 8')
     if slow_period <= fast_period:
-        raise ValueError('slow_period must be greater than fast_period')
+        raise ValueError('apo slow_period must be greater than fast_period')
 
     out_col = f"apo_{fast_period}_{slow_period}_{ma_type}"
     frame = data

--- a/limen/indicators/atr.py
+++ b/limen/indicators/atr.py
@@ -31,7 +31,7 @@ def atr(
     '''
 
     if period < ATR_PERIOD_MIN or period > ATR_PERIOD_MAX:
-        raise ValueError(f"period must be between {ATR_PERIOD_MIN} and {ATR_PERIOD_MAX}")
+        raise ValueError(f"atr period must be between {ATR_PERIOD_MIN} and {ATR_PERIOD_MAX}")
 
     out_col = f"{ATR_OUT_COL_PREFIX}{period}"
     prev_close = pl.col(close_col).shift(1)

--- a/limen/indicators/bbands.py
+++ b/limen/indicators/bbands.py
@@ -58,13 +58,13 @@ def bbands(
     '''
 
     if period < BBANDS_PERIOD_MIN or period > BBANDS_PERIOD_MAX:
-        raise ValueError(f"period must be between {BBANDS_PERIOD_MIN} and {BBANDS_PERIOD_MAX}")
+        raise ValueError(f"bbands period must be between {BBANDS_PERIOD_MIN} and {BBANDS_PERIOD_MAX}")
     if nb_dev_up < BBANDS_NBDEV_MIN or nb_dev_up > BBANDS_NBDEV_MAX:
-        raise ValueError(f"nb_dev_up must be between {BBANDS_NBDEV_MIN} and {BBANDS_NBDEV_MAX}")
+        raise ValueError(f"bbands nb_dev_up must be between {BBANDS_NBDEV_MIN} and {BBANDS_NBDEV_MAX}")
     if nb_dev_dn < BBANDS_NBDEV_MIN or nb_dev_dn > BBANDS_NBDEV_MAX:
-        raise ValueError(f"nb_dev_dn must be between {BBANDS_NBDEV_MIN} and {BBANDS_NBDEV_MAX}")
+        raise ValueError(f"bbands nb_dev_dn must be between {BBANDS_NBDEV_MIN} and {BBANDS_NBDEV_MAX}")
     if ma_type < BBANDS_MATYPE_MIN or ma_type > BBANDS_MATYPE_MAX:
-        raise ValueError(f"ma_type must be between {BBANDS_MATYPE_MIN} and {BBANDS_MATYPE_MAX}")
+        raise ValueError(f"bbands ma_type must be between {BBANDS_MATYPE_MIN} and {BBANDS_MATYPE_MAX}")
 
     middle_col = f"ma_{period}_{ma_type}"
     frame = ma(

--- a/limen/indicators/cci.py
+++ b/limen/indicators/cci.py
@@ -63,7 +63,7 @@ def cci(
     '''
 
     if period < CMP_N_2 or period > CMP_N_100000:
-        raise ValueError('period must be between 2 and 100000')
+        raise ValueError('cci period must be between 2 and 100000')
 
     out_col = f"cci_{period}"
     frame = data

--- a/limen/indicators/cdlabandonedbaby.py
+++ b/limen/indicators/cdlabandonedbaby.py
@@ -37,7 +37,7 @@ def _cdlabandonedbaby_impl(
     '''
 
     if penetration < 0.0 or penetration > CMP_N_3E37:
-        raise ValueError('penetration must be between 0 and 3e37')
+        raise ValueError('cdlabandonedbaby penetration must be between 0 and 3e37')
 
     open_values = data[open_col].to_numpy().astype(float, copy=False)
     high_values = data[high_col].to_numpy().astype(float, copy=False)

--- a/limen/indicators/cdldarkcloudcover.py
+++ b/limen/indicators/cdldarkcloudcover.py
@@ -33,7 +33,7 @@ def _cdldarkcloudcover_impl(
     _ = low_col
 
     if penetration < 0.0 or penetration > CMP_N_3E37:
-        raise ValueError('penetration must be between 0 and 3e37')
+        raise ValueError('cdldarkcloudcover penetration must be between 0 and 3e37')
 
     open_values = data[open_col].to_numpy().astype(float, copy=False)
     high_values = data[high_col].to_numpy().astype(float, copy=False)

--- a/limen/indicators/cdlmathold.py
+++ b/limen/indicators/cdlmathold.py
@@ -33,7 +33,7 @@ def _cdlmathold_impl(
     _ = low_col
 
     if penetration < 0.0 or penetration > CMP_N_3E37:
-        raise ValueError('penetration must be between 0 and 3e37')
+        raise ValueError('cdlmathold penetration must be between 0 and 3e37')
 
     open_values = data[open_col].to_numpy().astype(float, copy=False)
     high_values = data[high_col].to_numpy().astype(float, copy=False)

--- a/limen/indicators/cmo.py
+++ b/limen/indicators/cmo.py
@@ -92,7 +92,7 @@ def cmo(
     '''
 
     if period < CMP_N_2 or period > CMP_N_100000:
-        raise ValueError('period must be between 2 and 100000')
+        raise ValueError('cmo period must be between 2 and 100000')
 
     out_col = f"cmo_{period}"
     frame = data

--- a/limen/indicators/dema.py
+++ b/limen/indicators/dema.py
@@ -52,7 +52,7 @@ def dema(
     '''
 
     if period < CMP_N_2 or period > CMP_N_100000:
-        raise ValueError('period must be between 2 and 100000')
+        raise ValueError('dema period must be between 2 and 100000')
 
     out_col = f"dema_{period}"
     frame = data

--- a/limen/indicators/ema.py
+++ b/limen/indicators/ema.py
@@ -40,7 +40,7 @@ def ema(
     '''
 
     if period < CMP_N_2 or period > CMP_N_100000:
-        raise ValueError('period must be between 2 and 100000')
+        raise ValueError('ema period must be between 2 and 100000')
 
     out_col = f"ema_{period}"
     frame = data

--- a/limen/indicators/kama.py
+++ b/limen/indicators/kama.py
@@ -117,7 +117,7 @@ def kama(
     '''
 
     if period < CMP_N_2 or period > CMP_N_100000:
-        raise ValueError('period must be between 2 and 100000')
+        raise ValueError('kama period must be between 2 and 100000')
 
     out_col = f"kama_{period}"
     frame = data

--- a/limen/indicators/linearreg.py
+++ b/limen/indicators/linearreg.py
@@ -59,7 +59,7 @@ def linearreg(
     '''
 
     if period < CMP_N_2 or period > CMP_N_100000:
-        raise ValueError('period must be between 2 and 100000')
+        raise ValueError('linearreg period must be between 2 and 100000')
 
     out_col = f"linearreg_{period}"
     return data.with_columns(

--- a/limen/indicators/linearreg_angle.py
+++ b/limen/indicators/linearreg_angle.py
@@ -60,7 +60,7 @@ def linearreg_angle(
     '''
 
     if period < CMP_N_2 or period > CMP_N_100000:
-        raise ValueError('period must be between 2 and 100000')
+        raise ValueError('linearreg_angle period must be between 2 and 100000')
 
     out_col = f"linearreg_angle_{period}"
     return data.with_columns(

--- a/limen/indicators/linearreg_intercept.py
+++ b/limen/indicators/linearreg_intercept.py
@@ -58,7 +58,7 @@ def linearreg_intercept(
     '''
 
     if period < CMP_N_2 or period > CMP_N_100000:
-        raise ValueError('period must be between 2 and 100000')
+        raise ValueError('linearreg_intercept period must be between 2 and 100000')
 
     out_col = f"linearreg_intercept_{period}"
     return data.with_columns(

--- a/limen/indicators/linearreg_slope.py
+++ b/limen/indicators/linearreg_slope.py
@@ -57,7 +57,7 @@ def linearreg_slope(
     '''
 
     if period < CMP_N_2 or period > CMP_N_100000:
-        raise ValueError('period must be between 2 and 100000')
+        raise ValueError('linearreg_slope period must be between 2 and 100000')
 
     out_col = f"linearreg_slope_{period}"
     return data.with_columns(

--- a/limen/indicators/ma.py
+++ b/limen/indicators/ma.py
@@ -41,9 +41,9 @@ def ma(
     '''
 
     if period < 1 or period > CMP_N_100000:
-        raise ValueError('period must be between 1 and 100000')
+        raise ValueError('ma period must be between 1 and 100000')
     if ma_type < 0 or ma_type > CMP_N_8:
-        raise ValueError('ma_type must be between 0 and 8')
+        raise ValueError('ma ma_type must be between 0 and 8')
 
     out_col = f"ma_{period}_{ma_type}"
     frame = data

--- a/limen/indicators/macd.py
+++ b/limen/indicators/macd.py
@@ -74,11 +74,11 @@ def macd(
     '''
 
     if fast_period < CMP_N_2 or fast_period > CMP_N_100000:
-        raise ValueError('fast_period must be between 2 and 100000')
+        raise ValueError('macd fast_period must be between 2 and 100000')
     if slow_period < CMP_N_2 or slow_period > CMP_N_100000:
-        raise ValueError('slow_period must be between 2 and 100000')
+        raise ValueError('macd slow_period must be between 2 and 100000')
     if signal_period < 1 or signal_period > CMP_N_100000:
-        raise ValueError('signal_period must be between 1 and 100000')
+        raise ValueError('macd signal_period must be between 1 and 100000')
 
     values = data[price_col].to_numpy().astype(float, copy=False)
     macd_values, signal_values, hist_values = _macd_from_values(

--- a/limen/indicators/macdext.py
+++ b/limen/indicators/macdext.py
@@ -28,7 +28,7 @@ def _ma_lookback(period: int, ma_type: int) -> int:
     }
     if ma_type in lookback_by_type:
         return lookback_by_type[ma_type]
-    raise ValueError('ma_type must be between 0 and 8')
+    raise ValueError('macdext ma_type must be between 0 and 8')
 
 
 def _ma_talib_segment(
@@ -153,17 +153,17 @@ def macdext(
     '''
 
     if fast_period < CMP_N_2 or fast_period > CMP_N_100000:
-        raise ValueError('fast_period must be between 2 and 100000')
+        raise ValueError('macdext fast_period must be between 2 and 100000')
     if slow_period < CMP_N_2 or slow_period > CMP_N_100000:
-        raise ValueError('slow_period must be between 2 and 100000')
+        raise ValueError('macdext slow_period must be between 2 and 100000')
     if signal_period < 1 or signal_period > CMP_N_100000:
-        raise ValueError('signal_period must be between 1 and 100000')
+        raise ValueError('macdext signal_period must be between 1 and 100000')
     if fast_ma_type < 0 or fast_ma_type > CMP_N_8:
-        raise ValueError('fast_ma_type must be between 0 and 8')
+        raise ValueError('macdext fast_ma_type must be between 0 and 8')
     if slow_ma_type < 0 or slow_ma_type > CMP_N_8:
-        raise ValueError('slow_ma_type must be between 0 and 8')
+        raise ValueError('macdext slow_ma_type must be between 0 and 8')
     if signal_ma_type < 0 or signal_ma_type > CMP_N_8:
-        raise ValueError('signal_ma_type must be between 0 and 8')
+        raise ValueError('macdext signal_ma_type must be between 0 and 8')
 
     values = data[price_col].to_numpy().astype(float, copy=False)
     macd_values, signal_values, hist_values = _macdext_from_values(

--- a/limen/indicators/macdfix.py
+++ b/limen/indicators/macdfix.py
@@ -81,7 +81,7 @@ def macdfix(
     '''
 
     if signal_period < 1 or signal_period > CMP_N_100000:
-        raise ValueError('signal_period must be between 1 and 100000')
+        raise ValueError('macdfix signal_period must be between 1 and 100000')
 
     values = data[price_col].to_numpy().astype(float, copy=False)
     macd_values, signal_values, hist_values = _macdfix_from_values(values, signal_period)

--- a/limen/indicators/mama.py
+++ b/limen/indicators/mama.py
@@ -245,9 +245,9 @@ def mama(
     '''
 
     if fast_limit < CMP_N_0_01 or fast_limit > CMP_N_0_99:
-        raise ValueError('fast_limit must be between 0.01 and 0.99')
+        raise ValueError('mama fast_limit must be between 0.01 and 0.99')
     if slow_limit < CMP_N_0_01 or slow_limit > CMP_N_0_99:
-        raise ValueError('slow_limit must be between 0.01 and 0.99')
+        raise ValueError('mama slow_limit must be between 0.01 and 0.99')
 
     frame = data
     return frame.with_columns([

--- a/limen/indicators/mfi.py
+++ b/limen/indicators/mfi.py
@@ -29,7 +29,7 @@ def mfi(
     '''
 
     if period < CMP_N_2 or period > CMP_N_100000:
-        raise ValueError('period must be between 2 and 100000')
+        raise ValueError('mfi period must be between 2 and 100000')
 
     out_col = f"mfi_{period}"
 

--- a/limen/indicators/midpoint.py
+++ b/limen/indicators/midpoint.py
@@ -53,7 +53,7 @@ def midpoint(
     '''
 
     if period < CMP_N_2 or period > CMP_N_100000:
-        raise ValueError('period must be between 2 and 100000')
+        raise ValueError('midpoint period must be between 2 and 100000')
 
     out_col = f"midpoint_{period}"
     return data.with_columns(

--- a/limen/indicators/midprice.py
+++ b/limen/indicators/midprice.py
@@ -54,7 +54,7 @@ def midprice(
     '''
 
     if period < CMP_N_2 or period > CMP_N_100000:
-        raise ValueError('period must be between 2 and 100000')
+        raise ValueError('midprice period must be between 2 and 100000')
 
     out_col = f"midprice_{period}"
     return data.with_columns(

--- a/limen/indicators/mom.py
+++ b/limen/indicators/mom.py
@@ -22,7 +22,7 @@ def mom(
     '''
 
     if period < 1 or period > CMP_N_100000:
-        raise ValueError('period must be between 1 and 100000')
+        raise ValueError('mom period must be between 1 and 100000')
 
     out_col = f"mom_{period}"
     mom_expr = (

--- a/limen/indicators/natr.py
+++ b/limen/indicators/natr.py
@@ -33,7 +33,7 @@ def natr(
     '''
 
     if period < NATR_PERIOD_MIN or period > NATR_PERIOD_MAX:
-        raise ValueError(f"period must be between {NATR_PERIOD_MIN} and {NATR_PERIOD_MAX}")
+        raise ValueError(f"natr period must be between {NATR_PERIOD_MIN} and {NATR_PERIOD_MAX}")
 
     out_col = f"{NATR_OUT_COL_PREFIX}{period}"
     prev_close = pl.col(close_col).shift(1)

--- a/limen/indicators/ppo.py
+++ b/limen/indicators/ppo.py
@@ -31,13 +31,13 @@ def ppo(
     '''
 
     if fast_period < CMP_N_2 or fast_period > CMP_N_100000:
-        raise ValueError('fast_period must be between 2 and 100000')
+        raise ValueError('ppo fast_period must be between 2 and 100000')
     if slow_period < CMP_N_2 or slow_period > CMP_N_100000:
-        raise ValueError('slow_period must be between 2 and 100000')
+        raise ValueError('ppo slow_period must be between 2 and 100000')
     if ma_type < 0 or ma_type > CMP_N_8:
-        raise ValueError('ma_type must be between 0 and 8')
+        raise ValueError('ppo ma_type must be between 0 and 8')
     if slow_period <= fast_period:
-        raise ValueError('slow_period must be greater than fast_period')
+        raise ValueError('ppo slow_period must be greater than fast_period')
 
     out_col = f"ppo_{fast_period}_{slow_period}_{ma_type}"
     frame = data

--- a/limen/indicators/roc.py
+++ b/limen/indicators/roc.py
@@ -22,7 +22,7 @@ def roc(
     '''
 
     if period < 1 or period > CMP_N_100000:
-        raise ValueError('period must be between 1 and 100000')
+        raise ValueError('roc period must be between 1 and 100000')
 
     out_col = f"roc_{period}"
     trailing = pl.col(price_col).shift(period)

--- a/limen/indicators/rocp.py
+++ b/limen/indicators/rocp.py
@@ -22,7 +22,7 @@ def rocp(
     '''
 
     if period < 1 or period > CMP_N_100000:
-        raise ValueError('period must be between 1 and 100000')
+        raise ValueError('rocp period must be between 1 and 100000')
 
     out_col = f"rocp_{period}"
     trailing = pl.col(price_col).shift(period)

--- a/limen/indicators/rocr.py
+++ b/limen/indicators/rocr.py
@@ -22,7 +22,7 @@ def rocr(
     '''
 
     if period < 1 or period > CMP_N_100000:
-        raise ValueError('period must be between 1 and 100000')
+        raise ValueError('rocr period must be between 1 and 100000')
 
     out_col = f"rocr_{period}"
     trailing = pl.col(price_col).shift(period)

--- a/limen/indicators/rocr100.py
+++ b/limen/indicators/rocr100.py
@@ -22,7 +22,7 @@ def rocr100(
     '''
 
     if period < 1 or period > CMP_N_100000:
-        raise ValueError('period must be between 1 and 100000')
+        raise ValueError('rocr100 period must be between 1 and 100000')
 
     out_col = f"rocr100_{period}"
     trailing = pl.col(price_col).shift(period)

--- a/limen/indicators/rsi.py
+++ b/limen/indicators/rsi.py
@@ -72,7 +72,7 @@ def rsi(
     '''
 
     if period < CMP_N_2 or period > CMP_N_100000:
-        raise ValueError('period must be between 2 and 100000')
+        raise ValueError('rsi period must be between 2 and 100000')
 
     out_col = f"rsi_{period}"
     frame = data

--- a/limen/indicators/sar.py
+++ b/limen/indicators/sar.py
@@ -137,9 +137,9 @@ def sar(
     '''
 
     if acceleration < 0.0 or acceleration > CMP_N_3E37:
-        raise ValueError('acceleration must be between 0 and 3e37')
+        raise ValueError('sar acceleration must be between 0 and 3e37')
     if maximum < 0.0 or maximum > CMP_N_3E37:
-        raise ValueError('maximum must be between 0 and 3e37')
+        raise ValueError('sar maximum must be between 0 and 3e37')
 
     frame = data
     sar_expr = pl.struct([high_col, low_col]).map_batches(

--- a/limen/indicators/sarext.py
+++ b/limen/indicators/sarext.py
@@ -181,21 +181,21 @@ def sarext(
     '''
 
     if start_value < CMP_NEG_3E37 or start_value > CMP_N_3E37:
-        raise ValueError('start_value must be between -3e37 and 3e37')
+        raise ValueError('sarext start_value must be between -3e37 and 3e37')
     if offset_on_reverse < 0.0 or offset_on_reverse > CMP_N_3E37:
-        raise ValueError('offset_on_reverse must be between 0 and 3e37')
+        raise ValueError('sarext offset_on_reverse must be between 0 and 3e37')
     if acceleration_init_long < 0.0 or acceleration_init_long > CMP_N_3E37:
-        raise ValueError('acceleration_init_long must be between 0 and 3e37')
+        raise ValueError('sarext acceleration_init_long must be between 0 and 3e37')
     if acceleration_long < 0.0 or acceleration_long > CMP_N_3E37:
-        raise ValueError('acceleration_long must be between 0 and 3e37')
+        raise ValueError('sarext acceleration_long must be between 0 and 3e37')
     if acceleration_max_long < 0.0 or acceleration_max_long > CMP_N_3E37:
-        raise ValueError('acceleration_max_long must be between 0 and 3e37')
+        raise ValueError('sarext acceleration_max_long must be between 0 and 3e37')
     if acceleration_init_short < 0.0 or acceleration_init_short > CMP_N_3E37:
-        raise ValueError('acceleration_init_short must be between 0 and 3e37')
+        raise ValueError('sarext acceleration_init_short must be between 0 and 3e37')
     if acceleration_short < 0.0 or acceleration_short > CMP_N_3E37:
-        raise ValueError('acceleration_short must be between 0 and 3e37')
+        raise ValueError('sarext acceleration_short must be between 0 and 3e37')
     if acceleration_max_short < 0.0 or acceleration_max_short > CMP_N_3E37:
-        raise ValueError('acceleration_max_short must be between 0 and 3e37')
+        raise ValueError('sarext acceleration_max_short must be between 0 and 3e37')
 
     frame = data
     sarext_expr = pl.struct([high_col, low_col]).map_batches(

--- a/limen/indicators/sma.py
+++ b/limen/indicators/sma.py
@@ -56,7 +56,7 @@ def sma(
         price_col = column
 
     if period < CMP_N_2 or period > CMP_N_100000:
-        raise ValueError('period must be between 2 and 100000')
+        raise ValueError('sma period must be between 2 and 100000')
 
     out_col = f"sma_{period}"
     compat_col = f"{price_col}_sma_{period}"

--- a/limen/indicators/stddev.py
+++ b/limen/indicators/stddev.py
@@ -82,9 +82,9 @@ def stddev(
     '''
 
     if period < CMP_N_2 or period > CMP_N_100000:
-        raise ValueError('period must be between 2 and 100000')
+        raise ValueError('stddev period must be between 2 and 100000')
     if nb_dev < CMP_NEG_3E37 or nb_dev > CMP_N_3E37:
-        raise ValueError('nb_dev must be between -3e37 and 3e37')
+        raise ValueError('stddev nb_dev must be between -3e37 and 3e37')
 
     out_col = f"stddev_{period}_{nb_dev:g}"
     return data.with_columns(

--- a/limen/indicators/stoch.py
+++ b/limen/indicators/stoch.py
@@ -27,7 +27,7 @@ def _ma_lookback(period: int, ma_type: int) -> int:
     }
     if ma_type in lookback_by_type:
         return lookback_by_type[ma_type]
-    raise ValueError('ma_type must be between 0 and 8')
+    raise ValueError('stoch ma_type must be between 0 and 8')
 
 
 def _stoch_from_arrays(
@@ -171,15 +171,15 @@ def stoch(
     '''
 
     if fastk_period < 1 or fastk_period > CMP_N_100000:
-        raise ValueError('fastk_period must be between 1 and 100000')
+        raise ValueError('stoch fastk_period must be between 1 and 100000')
     if slowk_period < 1 or slowk_period > CMP_N_100000:
-        raise ValueError('slowk_period must be between 1 and 100000')
+        raise ValueError('stoch slowk_period must be between 1 and 100000')
     if slowd_period < 1 or slowd_period > CMP_N_100000:
-        raise ValueError('slowd_period must be between 1 and 100000')
+        raise ValueError('stoch slowd_period must be between 1 and 100000')
     if slowk_ma_type < 0 or slowk_ma_type > CMP_N_8:
-        raise ValueError('slowk_ma_type must be between 0 and 8')
+        raise ValueError('stoch slowk_ma_type must be between 0 and 8')
     if slowd_ma_type < 0 or slowd_ma_type > CMP_N_8:
-        raise ValueError('slowd_ma_type must be between 0 and 8')
+        raise ValueError('stoch slowd_ma_type must be between 0 and 8')
 
     high_values = data[high_col].to_numpy().astype(float, copy=False)
     low_values = data[low_col].to_numpy().astype(float, copy=False)

--- a/limen/indicators/stochf.py
+++ b/limen/indicators/stochf.py
@@ -27,7 +27,7 @@ def _ma_lookback(period: int, ma_type: int) -> int:
     }
     if ma_type in lookback_by_type:
         return lookback_by_type[ma_type]
-    raise ValueError('ma_type must be between 0 and 8')
+    raise ValueError('stochf ma_type must be between 0 and 8')
 
 
 def _stochf_from_arrays(
@@ -153,11 +153,11 @@ def stochf(
     '''
 
     if fastk_period < 1 or fastk_period > CMP_N_100000:
-        raise ValueError('fastk_period must be between 1 and 100000')
+        raise ValueError('stochf fastk_period must be between 1 and 100000')
     if fastd_period < 1 or fastd_period > CMP_N_100000:
-        raise ValueError('fastd_period must be between 1 and 100000')
+        raise ValueError('stochf fastd_period must be between 1 and 100000')
     if fastd_ma_type < 0 or fastd_ma_type > CMP_N_8:
-        raise ValueError('fastd_ma_type must be between 0 and 8')
+        raise ValueError('stochf fastd_ma_type must be between 0 and 8')
 
     high_values = data[high_col].to_numpy().astype(float, copy=False)
     low_values = data[low_col].to_numpy().astype(float, copy=False)

--- a/limen/indicators/stochrsi.py
+++ b/limen/indicators/stochrsi.py
@@ -66,13 +66,13 @@ def stochrsi(
     '''
 
     if period < CMP_N_2 or period > CMP_N_100000:
-        raise ValueError('period must be between 2 and 100000')
+        raise ValueError('stochrsi period must be between 2 and 100000')
     if fastk_period < 1 or fastk_period > CMP_N_100000:
-        raise ValueError('fastk_period must be between 1 and 100000')
+        raise ValueError('stochrsi fastk_period must be between 1 and 100000')
     if fastd_period < 1 or fastd_period > CMP_N_100000:
-        raise ValueError('fastd_period must be between 1 and 100000')
+        raise ValueError('stochrsi fastd_period must be between 1 and 100000')
     if fastd_ma_type < 0 or fastd_ma_type > CMP_N_8:
-        raise ValueError('fastd_ma_type must be between 0 and 8')
+        raise ValueError('stochrsi fastd_ma_type must be between 0 and 8')
 
     values = data[price_col].to_numpy().astype(float, copy=False)
     fastk_values, fastd_values = _stochrsi_from_values(

--- a/limen/indicators/t3.py
+++ b/limen/indicators/t3.py
@@ -138,9 +138,9 @@ def t3(
     '''
 
     if period < CMP_N_2 or period > CMP_N_100000:
-        raise ValueError('period must be between 2 and 100000')
+        raise ValueError('t3 period must be between 2 and 100000')
     if vfactor < 0.0 or vfactor > 1.0:
-        raise ValueError('vfactor must be between 0 and 1')
+        raise ValueError('t3 vfactor must be between 0 and 1')
 
     out_col = f"t3_{period}_{vfactor:g}"
     frame = data

--- a/limen/indicators/tema.py
+++ b/limen/indicators/tema.py
@@ -52,7 +52,7 @@ def tema(
     '''
 
     if period < CMP_N_2 or period > CMP_N_100000:
-        raise ValueError('period must be between 2 and 100000')
+        raise ValueError('tema period must be between 2 and 100000')
 
     out_col = f"tema_{period}"
     frame = data

--- a/limen/indicators/trima.py
+++ b/limen/indicators/trima.py
@@ -143,7 +143,7 @@ def trima(
     '''
 
     if period < CMP_N_2 or period > CMP_N_100000:
-        raise ValueError('period must be between 2 and 100000')
+        raise ValueError('trima period must be between 2 and 100000')
 
     out_col = f"trima_{period}"
     frame = data

--- a/limen/indicators/trix.py
+++ b/limen/indicators/trix.py
@@ -59,7 +59,7 @@ def trix(
     '''
 
     if period < 1 or period > CMP_N_100000:
-        raise ValueError('period must be between 1 and 100000')
+        raise ValueError('trix period must be between 1 and 100000')
 
     out_col = f"trix_{period}"
     frame = data

--- a/limen/indicators/tsf.py
+++ b/limen/indicators/tsf.py
@@ -59,7 +59,7 @@ def tsf(
     '''
 
     if period < CMP_N_2 or period > CMP_N_100000:
-        raise ValueError('period must be between 2 and 100000')
+        raise ValueError('tsf period must be between 2 and 100000')
 
     out_col = f"tsf_{period}"
     frame = data

--- a/limen/indicators/ultosc.py
+++ b/limen/indicators/ultosc.py
@@ -139,11 +139,11 @@ def ultosc(
     '''
 
     if period1 < 1 or period1 > CMP_N_100000:
-        raise ValueError('period1 must be between 1 and 100000')
+        raise ValueError('ultosc period1 must be between 1 and 100000')
     if period2 < 1 or period2 > CMP_N_100000:
-        raise ValueError('period2 must be between 1 and 100000')
+        raise ValueError('ultosc period2 must be between 1 and 100000')
     if period3 < 1 or period3 > CMP_N_100000:
-        raise ValueError('period3 must be between 1 and 100000')
+        raise ValueError('ultosc period3 must be between 1 and 100000')
 
     out_col = f"ultosc_{period1}_{period2}_{period3}"
     frame = data

--- a/limen/indicators/var.py
+++ b/limen/indicators/var.py
@@ -74,9 +74,9 @@ def var(
     '''
 
     if period < 1 or period > CMP_N_100000:
-        raise ValueError('period must be between 1 and 100000')
+        raise ValueError('var period must be between 1 and 100000')
     if nb_dev < CMP_NEG_3E37 or nb_dev > CMP_N_3E37:
-        raise ValueError('nb_dev must be between -3e37 and 3e37')
+        raise ValueError('var nb_dev must be between -3e37 and 3e37')
 
     out_col = f"var_{period}_{nb_dev:g}"
     return data.with_columns(

--- a/limen/indicators/wilder_rsi.py
+++ b/limen/indicators/wilder_rsi.py
@@ -22,7 +22,7 @@ def wilder_rsi(data: pl.DataFrame,
     '''
 
     if period < CMP_N_2 or period > CMP_N_100000:
-        raise ValueError('period must be between 2 and 100000')
+        raise ValueError('wilder_rsi period must be between 2 and 100000')
 
     out_col = f'wilder_rsi_{period}'
     return data.with_columns(

--- a/limen/indicators/willr.py
+++ b/limen/indicators/willr.py
@@ -29,7 +29,7 @@ def willr(
     '''
 
     if period < CMP_N_2 or period > CMP_N_100000:
-        raise ValueError('period must be between 2 and 100000')
+        raise ValueError('willr period must be between 2 and 100000')
 
     out_col = f"willr_{period}"
     highest = pl.col(high_col).rolling_max(window_size=period)

--- a/limen/indicators/wma.py
+++ b/limen/indicators/wma.py
@@ -75,7 +75,7 @@ def wma(
     '''
 
     if period < CMP_N_2 or period > CMP_N_100000:
-        raise ValueError('period must be between 2 and 100000')
+        raise ValueError('wma period must be between 2 and 100000')
 
     out_col = f"wma_{period}"
     frame = data

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaquum_limen"
-version = "3.15.0"
+version = "3.15.1"
 description = "Limen unifies parameter search across machine learning and rule-based strategies, with built-in analytics that show not just what works, but why it works."
 readme = "README.md"
 authors = [


### PR DESCRIPTION
## What

Parameter-validation error messages in `limen/indicators` and `limen/features` named the parameter generically without saying which indicator/feature raised them, e.g. `period must be between 2 and 100000`. This prefixes each message with the function name (= filename) so it names its own context:

```
'period must be between 2 and 100000'      ->  'ema period must be between 2 and 100000'
'fast_period must be between 2 and 100000' ->  'adosc fast_period must be between 2 and 100000'
f"d must be non-negative, got {d}"         ->  f"fractional_diff d must be non-negative, got {d}"
```

**107 messages across 54 files** (53 indicators + 5 features... `fractional_diff` carries several). Each edit is an in-place string change only (107 insertions / 107 deletions); quote style is preserved (single, double, and f-strings).

## Scope decisions

- `_hilbert.py` (private helper) left untouched — its `TypeError` is an internal type-narrowing guard that already names the exact `state[...]` key, not user-facing parameter validation.
- `yang_zhang_volatility.py` left untouched — its message already ends with `...for yang_zhang_volatility`.
- `fractional_diff` `logger.warning` lines left untouched — already say "fractional diff" and are warnings, not raised errors.

## Validation

- `ruff check .` — clean
- All indicator/feature tests pass (221 passed). The three tests that assert on these messages use pytest's substring `match=`, so the preserved substrings keep them green.

## Bookkeeping

- Version bump `3.15.0` -> `3.15.1`
- CHANGELOG entry added

🤖 Generated with [Claude Code](https://claude.com/claude-code)