### PR TITLE
Fix macOS-only path-equality failures in yaml config/store tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1044,3 +1044,7 @@ Note: add all new changelog entries to the bottom of this file.
 - Disambiguate previously-identical messages duplicated across files (e.g. selector errors shared by `top_n`, `diverse_metrics`, `backtest_pareto`; `min_observations must be > 0` shared by three reducers)
 - Replace the `ERROR:` prefix anti-pattern in `Account` and `BacktestSequential` with the component name
 - Leave messages that already name their source untouched (e.g. `CheckpointManager` checkpoint errors, `manifest` store/URI errors, `round_params[...]` and `Condition {id}` validations)
+
+## v3.15.3 on 6th of June, 2026
+
+- Fix macOS-only failures in `test_yaml_config` and `test_yaml_store`: resolve the temporary directory before comparing it against the canonicalised output of `find_project_root`/`get_store_path`/`resolve_manifest_uri`, so the `/tmp` vs `/private/tmp` symlink no longer causes a spurious path mismatch. Test-only change; no library behaviour affected

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaquum_limen"
-version = "3.15.2"
+version = "3.15.3"
 description = "Limen unifies parameter search across machine learning and rule-based strategies, with built-in analytics that show not just what works, but why it works."
 readme = "README.md"
 authors = [

--- a/tests/test_yaml_config.py
+++ b/tests/test_yaml_config.py
@@ -9,7 +9,7 @@ from limen.yaml.config import _STORE_RELATIVE
 
 def test_find_project_root_walks_up_from_subdirectory() -> None:
     with tempfile.TemporaryDirectory() as d:
-        root = Path(d)
+        root = Path(d).resolve()
         (root / 'limen.toml').write_text('')
         subdir = root / 'manifests' / 'examples'
         subdir.mkdir(parents=True)
@@ -32,7 +32,7 @@ def test_get_store_path_raises_when_no_project_root() -> None:
 
 def test_get_store_path_returns_committed_dir() -> None:
     with tempfile.TemporaryDirectory() as d:
-        root = Path(d)
+        root = Path(d).resolve()
         (root / 'limen.toml').write_text('')
         assert get_store_path(root) == root / _STORE_RELATIVE
 

--- a/tests/test_yaml_store.py
+++ b/tests/test_yaml_store.py
@@ -31,6 +31,7 @@ uel:
 
 
 def _make_project(tmp: Path) -> tuple[Path, Path]:
+    tmp = tmp.resolve()
     (tmp / 'limen.toml').write_text('[store]\nbackup_remote = ""\n')
     (tmp / 'manifests' / 'committed').mkdir(parents=True)
     yaml_path = tmp / 'manifests' / 'examples' / 'test.yaml'


### PR DESCRIPTION
## What

Three tests failed **only on macOS** (they pass on Linux CI, which is why all checks were green): `test_yaml_config.py::test_find_project_root_walks_up_from_subdirectory`, `test_yaml_config.py::test_get_store_path_returns_committed_dir`, and `test_yaml_store.py::test_resolve_manifest_uri_returns_path_and_project_root`.

### Cause
The tests build a project under a `tempfile.TemporaryDirectory()` and compare that path against the output of `find_project_root` / `get_store_path` / `resolve_manifest_uri`. Those functions canonicalise via `Path.resolve()` ([`limen/yaml/config.py:30`](limen/yaml/config.py)). On macOS `/tmp` is a symlink to `/private/tmp`, so e.g.:

```
find_project_root(...) -> /private/tmp/claude-501/tmpXXXX   (resolved)
Path(d)                -> /tmp/claude-501/tmpXXXX           (unresolved)
```

The library behaviour (returning a canonical path) is correct; the **tests** were comparing against an unresolved temp dir.

### Fix
Resolve the temp dir at the point of creation so the comparison is symlink-stable (a no-op on Linux):
- `test_yaml_config.py`: `Path(d)` → `Path(d).resolve()` in the two path-comparing tests
- `test_yaml_store.py`: `tmp = tmp.resolve()` once at the top of the `_make_project` helper (covers all its tests)

`test_cli_ls.py` (asserts booleans) and `test_proto_cohort.py` (already resolves) were checked and are unaffected.

## Validation
- `tests/test_yaml_config.py`, `tests/test_yaml_store.py`, `tests/test_cli_ls.py` — pass under pytest
- Full local suite (`python -m tests.run`): **897 passed, 0 failed** (previously 1 failure surfaced at a time due to the runner's ordering)
- `ruff check` — clean

## Bookkeeping
- Version `3.15.2` → `3.15.3`
- CHANGELOG entry added

🤖 Generated with [Claude Code](https://claude.com/claude-code)