### PR TITLE
Retry transient HTTP errors when fetching remote datasets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1051,4 +1051,4 @@ Note: add all new changelog entries to the bottom of this file.
 
 ## v3.15.4 on 6th of June, 2026
 
-- Make remote dataset fetches in `HistoricalData` resilient to transient HTTP failures: route the HuggingFace `latest.json` lookup and the file download through a shared `requests` session with exponential backoff that retries on 429/5xx and honours `Retry-After`. Fixes intermittent CI failures when HuggingFace rate-limits the test-data fetch
+- Make remote dataset fetches in `HistoricalData` resilient to transient HTTP failures: the HuggingFace `latest.json` lookup and the file download each run through a `requests` session with exponential backoff that retries on 429/5xx and honours `Retry-After`. Fixes intermittent CI failures when HuggingFace rate-limits the test-data fetch

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1051,4 +1051,4 @@ Note: add all new changelog entries to the bottom of this file.
 
 ## v3.15.4 on 6th of June, 2026
 
-- Make remote dataset fetches in `HistoricalData` resilient to transient HTTP failures: the HuggingFace `latest.json` lookup and the file download each run through a `requests` session with exponential backoff that retries on 429/5xx and honours `Retry-After`. Fixes intermittent CI failures when HuggingFace rate-limits the test-data fetch
+- Make remote dataset fetches in `HistoricalData` resilient to transient HTTP failures: the HuggingFace `latest.json` lookup and the dataset download (`.parquet`, `.csv`, and `.zip`, including the default Parquet datasets) each run through a `requests` session with exponential backoff that retries on 429/5xx and honours `Retry-After`. Fixes intermittent CI failures when HuggingFace rate-limits the test-data fetch

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1048,3 +1048,7 @@ Note: add all new changelog entries to the bottom of this file.
 ## v3.15.3 on 6th of June, 2026
 
 - Fix macOS-only failures in `test_yaml_config` and `test_yaml_store`: resolve the temporary directory before comparing it against the canonicalised output of `find_project_root`/`get_store_path`/`resolve_manifest_uri`, so the `/tmp` vs `/private/tmp` symlink no longer causes a spurious path mismatch. Test-only change; no library behaviour affected
+
+## v3.15.4 on 6th of June, 2026
+
+- Make remote dataset fetches in `HistoricalData` resilient to transient HTTP failures: route the HuggingFace `latest.json` lookup and the file download through a shared `requests` session with exponential backoff that retries on 429/5xx and honours `Retry-After`. Fixes intermittent CI failures when HuggingFace rate-limits the test-data fetch

--- a/limen/data/historical_data.py
+++ b/limen/data/historical_data.py
@@ -12,6 +12,8 @@ import polars as pl
 import pyarrow as pa
 import pyarrow.ipc as pa_ipc
 import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
 
 from limen.data._internal.binance_file_to_polars import binance_file_to_polars
 
@@ -22,6 +24,9 @@ _SUPPORTED_DATETIME_FORMATS: Final[tuple[str, ...]] = (
     '%Y-%m-%dT%H:%M:%S',
 )
 _REMOTE_TIMEOUT_SECONDS: Final[int] = 60
+_REMOTE_MAX_RETRIES: Final[int] = 5
+_REMOTE_BACKOFF_FACTOR: Final[float] = 1.0
+_REMOTE_RETRY_STATUSES: Final[tuple[int, ...]] = (429, 500, 502, 503, 504)
 _DEFAULT_SPOT_DATASET_REPO: Final[str] = 'vaquum/binance_btcusdt_1m_klines'
 _DEFAULT_SPOT_DOLLAR_DATASET_REPO: Final[str] = (
     'vaquum/binance_btcusdt_1M_dollar_klines'
@@ -210,10 +215,27 @@ def _validate_columns(df: pl.DataFrame, columns: list[str] | None) -> pl.DataFra
     return df
 
 
+def _remote_session() -> requests.Session:
+    retry = Retry(
+        total=_REMOTE_MAX_RETRIES,
+        backoff_factor=_REMOTE_BACKOFF_FACTOR,
+        status_forcelist=_REMOTE_RETRY_STATUSES,
+        allowed_methods=frozenset({'GET'}),
+        respect_retry_after_header=True,
+        raise_on_status=False,
+    )
+    adapter = HTTPAdapter(max_retries=retry)
+    session = requests.Session()
+    session.mount('https://', adapter)
+    session.mount('http://', adapter)
+    return session
+
+
 def _read_remote_bytes(url: str) -> bytes:
-    response = requests.get(url, timeout=_REMOTE_TIMEOUT_SECONDS)
-    response.raise_for_status()
-    return response.content
+    with _remote_session() as session:
+        response = session.get(url, timeout=_REMOTE_TIMEOUT_SECONDS)
+        response.raise_for_status()
+        return response.content
 
 
 def _read_csv_source(
@@ -260,9 +282,10 @@ def _read_zip_source(
 
 def _resolve_huggingface_latest_file(repo_id: str) -> str:
     metadata_url = f"https://huggingface.co/datasets/{repo_id}/resolve/main/latest.json"
-    response = requests.get(metadata_url, timeout=_REMOTE_TIMEOUT_SECONDS)
-    response.raise_for_status()
-    metadata = response.json()
+    with _remote_session() as session:
+        response = session.get(metadata_url, timeout=_REMOTE_TIMEOUT_SECONDS)
+        response.raise_for_status()
+        metadata = response.json()
     file_name = metadata['file_name']
     return f"https://huggingface.co/datasets/{repo_id}/resolve/main/{file_name}"
 

--- a/limen/data/historical_data.py
+++ b/limen/data/historical_data.py
@@ -361,7 +361,10 @@ def _read_any_file(
     suffix = Path(source_path).suffix.lower()
 
     if suffix == '.parquet':
-        df = pl.read_parquet(resolved_source)
+        if _is_url(resolved_source):
+            df = pl.read_parquet(BytesIO(_read_remote_bytes(resolved_source)))
+        else:
+            df = pl.read_parquet(resolved_source)
     elif suffix == '.csv':
         df = _read_csv_source(resolved_source, has_header=has_header)
     elif suffix == '.zip':

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaquum_limen"
-version = "3.15.3"
+version = "3.15.4"
 description = "Limen unifies parameter search across machine learning and rule-based strategies, with built-in analytics that show not just what works, but why it works."
 readme = "README.md"
 authors = [

--- a/tests/run.py
+++ b/tests/run.py
@@ -224,6 +224,7 @@ from tests.test_historical_data import test_get_any_file_validates_requested_row
 from tests.test_historical_data import test_get_any_file_rejects_unsupported_extensions
 from tests.test_historical_data import test_get_spot_klines_accepts_iso_date_limits_and_rejects_invalid_literals
 from tests.test_historical_data import test_get_spot_klines_rejects_row_limit_with_closed_date_window
+from tests.test_remote_fetch_retry import test_remote_session_is_configured_to_retry_transient_errors
 from tests.test_param_domain import test_param_domain_init
 from tests.test_param_domain import test_param_domain_init_validation
 from tests.test_param_domain import test_param_domain_defensive_copy
@@ -1361,6 +1362,7 @@ tests = [
     test_get_any_file_rejects_unsupported_extensions,
     test_get_spot_klines_accepts_iso_date_limits_and_rejects_invalid_literals,
     test_get_spot_klines_rejects_row_limit_with_closed_date_window,
+    test_remote_session_is_configured_to_retry_transient_errors,
     test_indicators_vs_talib,
     test_xgboost_train_returns_fitted_model,
     test_xgboost_evaluate_returns_all_metric_types,

--- a/tests/run.py
+++ b/tests/run.py
@@ -225,6 +225,7 @@ from tests.test_historical_data import test_get_any_file_rejects_unsupported_ext
 from tests.test_historical_data import test_get_spot_klines_accepts_iso_date_limits_and_rejects_invalid_literals
 from tests.test_historical_data import test_get_spot_klines_rejects_row_limit_with_closed_date_window
 from tests.test_remote_fetch_retry import test_remote_session_is_configured_to_retry_transient_errors
+from tests.test_remote_fetch_retry import test_read_any_file_routes_remote_parquet_through_retrying_reader
 from tests.test_param_domain import test_param_domain_init
 from tests.test_param_domain import test_param_domain_init_validation
 from tests.test_param_domain import test_param_domain_defensive_copy
@@ -1363,6 +1364,7 @@ tests = [
     test_get_spot_klines_accepts_iso_date_limits_and_rejects_invalid_literals,
     test_get_spot_klines_rejects_row_limit_with_closed_date_window,
     test_remote_session_is_configured_to_retry_transient_errors,
+    test_read_any_file_routes_remote_parquet_through_retrying_reader,
     test_indicators_vs_talib,
     test_xgboost_train_returns_fitted_model,
     test_xgboost_evaluate_returns_all_metric_types,

--- a/tests/test_remote_fetch_retry.py
+++ b/tests/test_remote_fetch_retry.py
@@ -1,3 +1,10 @@
+from io import BytesIO
+
+import polars as pl
+import pytest
+
+from limen.data import historical_data
+from limen.data.historical_data import _read_any_file
 from limen.data.historical_data import _REMOTE_BACKOFF_FACTOR
 from limen.data.historical_data import _REMOTE_MAX_RETRIES
 from limen.data.historical_data import _REMOTE_RETRY_STATUSES
@@ -14,3 +21,22 @@ def test_remote_session_is_configured_to_retry_transient_errors() -> None:
             assert 429 in retry.status_forcelist
             assert retry.respect_retry_after_header is True
             assert 'GET' in retry.allowed_methods
+
+
+def test_read_any_file_routes_remote_parquet_through_retrying_reader() -> None:
+    frame = pl.DataFrame({'a': [1, 2, 3]})
+    buffer = BytesIO()
+    frame.write_parquet(buffer)
+    parquet_bytes = buffer.getvalue()
+    seen: list[str] = []
+
+    def fake_read_remote_bytes(url: str) -> bytes:
+        seen.append(url)
+        return parquet_bytes
+
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setattr(historical_data, '_read_remote_bytes', fake_read_remote_bytes)
+        result = _read_any_file('https://example.com/data.parquet')
+
+    assert seen == ['https://example.com/data.parquet']
+    assert result.equals(frame)

--- a/tests/test_remote_fetch_retry.py
+++ b/tests/test_remote_fetch_retry.py
@@ -1,0 +1,17 @@
+from limen.data.historical_data import _REMOTE_BACKOFF_FACTOR
+from limen.data.historical_data import _REMOTE_MAX_RETRIES
+from limen.data.historical_data import _REMOTE_RETRY_STATUSES
+from limen.data.historical_data import _remote_session
+
+
+def test_remote_session_is_configured_to_retry_transient_errors() -> None:
+    session = _remote_session()
+
+    for scheme in ('https://', 'http://'):
+        retry = session.get_adapter(f'{scheme}example').max_retries
+        assert retry.total == _REMOTE_MAX_RETRIES
+        assert retry.backoff_factor == _REMOTE_BACKOFF_FACTOR
+        assert set(_REMOTE_RETRY_STATUSES) <= set(retry.status_forcelist)
+        assert 429 in retry.status_forcelist
+        assert retry.respect_retry_after_header is True
+        assert 'GET' in retry.allowed_methods

--- a/tests/test_remote_fetch_retry.py
+++ b/tests/test_remote_fetch_retry.py
@@ -5,13 +5,12 @@ from limen.data.historical_data import _remote_session
 
 
 def test_remote_session_is_configured_to_retry_transient_errors() -> None:
-    session = _remote_session()
-
-    for scheme in ('https://', 'http://'):
-        retry = session.get_adapter(f'{scheme}example').max_retries
-        assert retry.total == _REMOTE_MAX_RETRIES
-        assert retry.backoff_factor == _REMOTE_BACKOFF_FACTOR
-        assert set(_REMOTE_RETRY_STATUSES) <= set(retry.status_forcelist)
-        assert 429 in retry.status_forcelist
-        assert retry.respect_retry_after_header is True
-        assert 'GET' in retry.allowed_methods
+    with _remote_session() as session:
+        for scheme in ('https://', 'http://'):
+            retry = session.get_adapter(f'{scheme}example').max_retries
+            assert retry.total == _REMOTE_MAX_RETRIES
+            assert retry.backoff_factor == _REMOTE_BACKOFF_FACTOR
+            assert set(_REMOTE_RETRY_STATUSES) <= set(retry.status_forcelist)
+            assert 429 in retry.status_forcelist
+            assert retry.respect_retry_after_header is True
+            assert 'GET' in retry.allowed_methods


### PR DESCRIPTION
## What

Fixes the recurring CI flake where `PR Checks Tests` fails fast with `429 Client Error: Too Many Requests` from HuggingFace (`_resolve_huggingface_latest_file` / the dataset download). Both fetches in `HistoricalData` were bare `requests.get` with **no resilience**, so a single transient `429` failed the whole suite and required a manual `gh run rerun`.

## Fix

Route both network calls through a shared session with retry/backoff (uses `urllib3`'s `Retry` — already a `requests` dependency, no new package):

```python
def _remote_session() -> requests.Session:
    retry = Retry(
        total=_REMOTE_MAX_RETRIES,            # 5
        backoff_factor=_REMOTE_BACKOFF_FACTOR, # 1.0
        status_forcelist=_REMOTE_RETRY_STATUSES, # (429, 500, 502, 503, 504)
        allowed_methods=frozenset({'GET'}),
        respect_retry_after_header=True,
        raise_on_status=False,
    )
    ...
```

- Retries `429`/`5xx` with exponential backoff, **honouring the `Retry-After`** header HF sends on a `429`.
- Success behaviour is unchanged; a genuinely persistent failure still surfaces via `raise_for_status()` after retries are exhausted.
- `GET`-only (idempotent).
- Scope kept to `HistoricalData` (the actual flake source); the unrelated `requests.get` in `_internal/binance_file_to_polars.py` is left to avoid a cross-module private import.

## Test

`tests/test_remote_fetch_retry.py` asserts the session's retry policy deterministically (no sockets/threads). I first wrote a live localhost-server behaviour test; it passed 30× standalone but flaked once under a heavily-loaded full-suite run, so I replaced it with the deterministic config-assertion test rather than ship a load-sensitive test to *fix* a flaky test. End-to-end retry behaviour is delegated to urllib3's well-tested `Retry`. Registered in `tests/run.py` (the manual CI registry).

## Validation
- `ruff check` — clean
- Full local `tests.run`: **840 passed, 1 failed** — the one failure is the pre-existing macOS-only `test_find_project_root` symlink artifact (fixed in #568, passes on Linux CI); my new test and all `HistoricalData` fetch tests pass.

## ⚠️ Merge order
Bumps **3.15.3 → 3.15.4**, so please merge #568 (which is 3.15.3) **first**. This branch is cut from main (3.15.2); after #568 lands, the CHANGELOG/version reconcile to 3.15.2 → 3.15.3 → 3.15.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)