### PR TITLE
Add TripleBarrierTarget — Lopez de Prado's triple-barrier label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1052,3 +1052,7 @@ Note: add all new changelog entries to the bottom of this file.
 ## v3.15.4 on 6th of June, 2026
 
 - Make remote dataset fetches in `HistoricalData` resilient to transient HTTP failures: the HuggingFace `latest.json` lookup and the dataset download (`.parquet`, `.csv`, and `.zip`, including the default Parquet datasets) each run through a `requests` session with exponential backoff that retries on 429/5xx and honours `Retry-After`. Fixes intermittent CI failures when HuggingFace rate-limits the test-data fetch
+
+## v3.16.0 on 6th of June, 2026
+
+- Add `TripleBarrierTarget` to `limen.targets` — Lopez de Prado's triple-barrier label. Each bar is labelled by the first barrier its forward close path touches over the next `max_horizon` bars: `1` for the upper (profit-taking) barrier, `-1` for the lower (stop-loss) barrier, and `0` for the vertical (time) barrier when neither is touched. The horizontal barriers are volatility multiples — `upper_multiple`/`lower_multiple` times the EWMA standard deviation of close-to-close returns — so they adapt to the local regime rather than using a fixed percentage. Bars are null during the volatility warmup, on zero volatility, and when the vertical barrier extends past the available data with no touch

--- a/docs/Targets.md
+++ b/docs/Targets.md
@@ -44,6 +44,7 @@ manifest.with_target_label(
 | `NextReturnTarget` | continuous `Float64` | no | n/a | Percentage return over the next N bars. Use with regression architectures. |
 | `VolNormalizedReturnTarget` | continuous `Float64` | yes — train sanity gate | none | Canonical return decoder outcome: log return divided by prior Parkinson volatility. |
 | `ForwardVolNormalizedReturnTarget` | continuous `Float64` | yes — train sanity gate | none | Predictive label: forward log return divided by current Parkinson volatility. |
+| `TripleBarrierTarget` | ternary `Int8` | no | n/a | First barrier touched over the next `max_horizon` bars: `1` upper, `-1` lower, `0` vertical. Horizontal barriers are volatility multiples. |
 | `RiskRewardRatioTarget` | continuous `Float64` | no | n/a | Ratio of `capturable_breakout` to absolute `max_drawdown` per row. |
 | `ExitQualityTarget` | continuous `Float64` | no | n/a | Categorical score for closed trades based on `exit_reason` and `exit_net_return`. |
 | `RandomBinaryTarget` | binary `UInt8` | no | none | Uniformly random labels. Use as a noise benchmark. |
@@ -248,6 +249,35 @@ Produces a continuous predictive label as `log(close.shift(-periods) / close) / 
 | `close_col` | `str` | Close price column; default `'close'` |
 
 The class reuses the same dirty-bar filter and Parkinson-to-close volatility sanity gate as `VolNormalizedReturnTarget`.
+
+### `TripleBarrierTarget`
+
+```python
+TripleBarrierTarget(train_data, target_name, upper_multiple=1.0, lower_multiple=1.0, max_horizon=10, span=100, min_periods=100, close_col='close')
+```
+
+Produces a ternary label from Lopez de Prado's triple-barrier method. For each bar, the forward close path is followed for up to `max_horizon` bars and labelled by the first barrier it touches: `1` if the upper (profit-taking) barrier is touched first, `-1` if the lower (stop-loss) barrier is touched first, and `0` if neither is touched within `max_horizon` bars (the vertical barrier). No fitting step.
+
+The horizontal barriers are volatility multiples — `+upper_multiple * sigma` and `-lower_multiple * sigma`, where `sigma` is the EWMA standard deviation of close-to-close returns with the given `span`. The barrier width is taken from the entry-bar volatility, so it adapts to the local regime instead of using a fixed percentage.
+
+A bar is null during the volatility warmup (`min_periods`), when its volatility is zero, and when the vertical barrier would extend past the available data and no barrier is touched within the truncated window. Manifest preparation drops null target rows.
+
+```python
+.with_target_label(
+    'triple_barrier',
+    TripleBarrierTarget,
+    fit_params={'upper_multiple': 2.0, 'lower_multiple': 2.0, 'max_horizon': 24, 'span': 100, 'min_periods': 100},
+)
+```
+
+| Parameter | Type | Description |
+|---|---|---|
+| `upper_multiple` | `float` | Profit-taking barrier width in volatility units; default `1.0` |
+| `lower_multiple` | `float` | Stop-loss barrier width in volatility units; default `1.0` |
+| `max_horizon` | `int` | Vertical barrier as a forward window in bars; default `10` |
+| `span` | `int` | EWMA span for the close-to-close return volatility; default `100` |
+| `min_periods` | `int` | Warmup before volatility is emitted; default `100` |
+| `close_col` | `str` | Close price column used for the barrier path; default `'close'` |
 
 ### `RiskRewardRatioTarget`
 

--- a/docs/Targets.md
+++ b/docs/Targets.md
@@ -260,7 +260,7 @@ Produces a ternary label from Lopez de Prado's triple-barrier method. For each b
 
 The horizontal barriers are volatility multiples — `+upper_multiple * sigma` and `-lower_multiple * sigma`, where `sigma` is the EWMA standard deviation of close-to-close returns with the given `span`. The barrier width is taken from the entry-bar volatility, so it adapts to the local regime instead of using a fixed percentage.
 
-A bar is null during the volatility warmup (`min_periods`), when its volatility is zero, and when the vertical barrier would extend past the available data and no barrier is touched within the truncated window. Manifest preparation drops null target rows.
+A bar is null during the volatility warmup (`min_periods`), when its volatility is zero, and when the vertical barrier would extend past the available data and no barrier is touched within the truncated window. Manifest preparation drops null target rows. Size `min_periods` (and `span`) against the smallest split: a split shorter than the volatility warmup is entirely null and is dropped, leaving no labelled rows for that split.
 
 ```python
 .with_target_label(

--- a/limen/targets/__init__.py
+++ b/limen/targets/__init__.py
@@ -10,6 +10,7 @@ from limen.targets.quantile_binary import QuantileBinaryTarget
 from limen.targets.random_binary import RandomBinaryTarget
 from limen.targets.risk_reward_ratio import RiskRewardRatioTarget
 from limen.targets.threshold_binary import ThresholdBinaryTarget
+from limen.targets.triple_barrier import TripleBarrierTarget
 from limen.targets.vol_normalized_return import VolNormalizedReturnTarget
 
 __all__ = [
@@ -25,5 +26,6 @@ __all__ = [
     'RandomBinaryTarget',
     'RiskRewardRatioTarget',
     'ThresholdBinaryTarget',
+    'TripleBarrierTarget',
     'VolNormalizedReturnTarget',
 ]

--- a/limen/targets/triple_barrier.py
+++ b/limen/targets/triple_barrier.py
@@ -112,13 +112,14 @@ class TripleBarrierTarget:
         for k in range(1, self.max_horizon + 1):
             if k >= n:
                 break
-            forward_return = np.full(n, np.nan)
-            forward_return[:n - k] = close[k:] / close[:n - k] - 1.0
-            hit_upper = (~touched) & (forward_return >= upper)
-            hit_lower = (~touched) & (forward_return <= -lower)
-            label[hit_upper] = 1
-            label[hit_lower] = -1
-            touched = touched | hit_upper | hit_lower
+            prefix = n - k
+            forward_return = close[k:] / close[:prefix] - 1.0
+            open_bars = ~touched[:prefix]
+            hit_upper = open_bars & (forward_return >= upper[:prefix])
+            hit_lower = open_bars & (forward_return <= -lower[:prefix])
+            label[:prefix][hit_upper] = 1
+            label[:prefix][hit_lower] = -1
+            touched[:prefix] |= hit_upper | hit_lower
 
         horizon_available = np.arange(n) <= (n - 1 - self.max_horizon)
         valid = (volatility > 0.0) & (touched | horizon_available)

--- a/limen/targets/triple_barrier.py
+++ b/limen/targets/triple_barrier.py
@@ -1,0 +1,125 @@
+import numpy as np
+import polars as pl
+
+
+class TripleBarrierTarget:
+
+    '''Ternary label from Lopez de Prado's triple-barrier method.'''
+
+    def __init__(self,
+                 train_data: pl.DataFrame,
+                 target_name: str,
+                 upper_multiple: float = 1.0,
+                 lower_multiple: float = 1.0,
+                 max_horizon: int = 10,
+                 span: int = 100,
+                 min_periods: int = 100,
+                 close_col: str = 'close') -> None:
+
+        '''
+        Store barrier settings and validate them; no fitting is performed.
+
+        Args:
+            train_data (pl.DataFrame): Training split (not used; kept for interface consistency)
+            target_name (str): Name of the target column to create
+            upper_multiple (float): Profit-taking barrier width in volatility units
+            lower_multiple (float): Stop-loss barrier width in volatility units
+            max_horizon (int): Vertical barrier as a forward window in bars
+            span (int): EWMA span for the close-to-close return volatility estimate
+            min_periods (int): Warmup before a volatility value is emitted
+            close_col (str): Close price column used for the barrier path
+        '''
+
+        if upper_multiple <= 0:
+            raise ValueError('TripleBarrierTarget upper_multiple must be positive')
+        if lower_multiple <= 0:
+            raise ValueError('TripleBarrierTarget lower_multiple must be positive')
+        if max_horizon <= 0:
+            raise ValueError('TripleBarrierTarget max_horizon must be positive')
+        if span <= 0:
+            raise ValueError('TripleBarrierTarget span must be positive')
+        if min_periods <= 0:
+            raise ValueError('TripleBarrierTarget min_periods must be positive')
+
+        self.target_name = target_name
+        self.upper_multiple = upper_multiple
+        self.lower_multiple = lower_multiple
+        self.max_horizon = max_horizon
+        self.span = span
+        self.min_periods = min_periods
+        self.close_col = close_col
+
+    def transform(self, data: pl.DataFrame) -> pl.DataFrame:
+
+        '''
+        Label each bar by the first barrier its forward close path touches.
+
+        Args:
+            data (pl.DataFrame): Split to transform; must have the close column
+
+        Returns:
+            pl.DataFrame: Data with a ternary target column added (1 upper, -1 lower,
+                0 vertical; null during volatility warmup and when the vertical barrier
+                extends past the available data)
+        '''
+
+        self._validate_columns(data)
+        close = data[self.close_col].to_numpy().astype(float, copy=False)
+        label, valid = self._first_touch(close, self._volatility(data))
+
+        return (
+            data
+            .with_columns(
+                [
+                    pl.Series('_limen_tbl_label', label, dtype=pl.Int8),
+                    pl.Series('_limen_tbl_valid', valid, dtype=pl.Boolean),
+                ]
+            )
+            .with_columns(
+                pl.when(pl.col('_limen_tbl_valid'))
+                .then(pl.col('_limen_tbl_label'))
+                .otherwise(None)
+                .alias(self.target_name)
+            )
+            .drop(['_limen_tbl_label', '_limen_tbl_valid'])
+        )
+
+    def _validate_columns(self, data: pl.DataFrame) -> None:
+        if self.close_col not in data.columns:
+            raise ValueError(f"TripleBarrierTarget missing column: {self.close_col}")
+
+    def _volatility(self, data: pl.DataFrame) -> np.ndarray:
+        return (
+            data
+            .select(
+                (pl.col(self.close_col) / pl.col(self.close_col).shift(1) - 1.0)
+                .ewm_std(span=self.span, min_samples=self.min_periods)
+                .alias('_limen_tbl_vol')
+            )
+            .get_column('_limen_tbl_vol')
+            .to_numpy()
+        )
+
+    def _first_touch(self,
+                     close: np.ndarray,
+                     volatility: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+        n = close.shape[0]
+        upper = self.upper_multiple * volatility
+        lower = self.lower_multiple * volatility
+        label = np.zeros(n, dtype=np.int8)
+        touched = np.zeros(n, dtype=bool)
+
+        for k in range(1, self.max_horizon + 1):
+            if k >= n:
+                break
+            forward_return = np.full(n, np.nan)
+            forward_return[:n - k] = close[k:] / close[:n - k] - 1.0
+            hit_upper = (~touched) & (forward_return >= upper)
+            hit_lower = (~touched) & (forward_return <= -lower)
+            label[hit_upper] = 1
+            label[hit_lower] = -1
+            touched = touched | hit_upper | hit_lower
+
+        horizon_available = np.arange(n) <= (n - 1 - self.max_horizon)
+        valid = (volatility > 0.0) & (touched | horizon_available)
+        return label, valid

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaquum_limen"
-version = "3.15.4"
+version = "3.16.0"
 description = "Limen unifies parameter search across machine learning and rule-based strategies, with built-in analytics that show not just what works, but why it works."
 readme = "README.md"
 authors = [

--- a/tests/run.py
+++ b/tests/run.py
@@ -708,6 +708,12 @@ from tests.test_targets import test_identity_target_raises_when_column_missing_o
 from tests.test_targets import test_ema_breakout_target_labels_future_moves_above_ema_threshold
 from tests.test_targets import test_exit_quality_target_distinguishes_good_bad_and_neutral_exits
 from tests.test_targets import test_risk_reward_ratio_target_uses_absolute_drawdown_with_epsilon_guard
+from tests.test_targets import test_triple_barrier_labels_upper_touch_first
+from tests.test_targets import test_triple_barrier_labels_lower_touch_first
+from tests.test_targets import test_triple_barrier_vertical_barrier_labels_zero
+from tests.test_targets import test_triple_barrier_nulls_warmup_and_truncated_horizon
+from tests.test_targets import test_triple_barrier_lower_multiple_widens_stop
+from tests.test_targets import test_triple_barrier_rejects_nonpositive_params
 from tests.test_feature_perturbation import test_ablation_drop_count_exceeds_eligible_raises
 from tests.test_reducer_factory import test_reducer_registry_has_all_types
 from tests.test_reducer_factory import test_reducer_registry_maps_to_correct_classes
@@ -1600,6 +1606,12 @@ tests = [
     test_ema_breakout_target_labels_future_moves_above_ema_threshold,
     test_exit_quality_target_distinguishes_good_bad_and_neutral_exits,
     test_risk_reward_ratio_target_uses_absolute_drawdown_with_epsilon_guard,
+    test_triple_barrier_labels_upper_touch_first,
+    test_triple_barrier_labels_lower_touch_first,
+    test_triple_barrier_vertical_barrier_labels_zero,
+    test_triple_barrier_nulls_warmup_and_truncated_horizon,
+    test_triple_barrier_lower_multiple_widens_stop,
+    test_triple_barrier_rejects_nonpositive_params,
     test_ablation_drop_count_exceeds_eligible_raises,
     test_reducer_registry_has_all_types,
     test_reducer_registry_maps_to_correct_classes,

--- a/tests/test_targets.py
+++ b/tests/test_targets.py
@@ -17,6 +17,7 @@ from limen.targets import QuantileBinaryTarget
 from limen.targets import RandomBinaryTarget
 from limen.targets import RiskRewardRatioTarget
 from limen.targets import ThresholdBinaryTarget
+from limen.targets import TripleBarrierTarget
 from limen.targets import VolNormalizedReturnTarget
 
 
@@ -383,3 +384,57 @@ def test_risk_reward_ratio_target_uses_absolute_drawdown_with_epsilon_guard() ->
     assert result['risk_reward_ratio'].to_list() == pytest.approx([0.5 / 0.101, 1000.0])
     assert 'capturable_breakout' not in result.columns
     assert 'max_drawdown' not in result.columns
+
+
+def _triple_barrier_close() -> list[float]:
+    return [100.0, 101.0, 100.0, 101.0, 100.0]
+
+
+def test_triple_barrier_labels_upper_touch_first() -> None:
+    data = _close_series([*_triple_barrier_close(), 200.0, 200.0, 200.0])
+    t = TripleBarrierTarget(data, 'tb', span=2, min_periods=2, max_horizon=3)
+    result = t.transform(data)['tb'].to_list()
+    assert result[4] == 1
+
+
+def test_triple_barrier_labels_lower_touch_first() -> None:
+    data = _close_series([*_triple_barrier_close(), 50.0, 50.0, 50.0])
+    t = TripleBarrierTarget(data, 'tb', span=2, min_periods=2, max_horizon=3)
+    result = t.transform(data)['tb'].to_list()
+    assert result[4] == -1
+
+
+def test_triple_barrier_vertical_barrier_labels_zero() -> None:
+    data = _close_series([*_triple_barrier_close(), 100.0, 100.0, 100.0])
+    t = TripleBarrierTarget(data, 'tb', span=2, min_periods=2, max_horizon=3)
+    result = t.transform(data)['tb'].to_list()
+    assert result[4] == 0
+
+
+def test_triple_barrier_nulls_warmup_and_truncated_horizon() -> None:
+    data = _close_series([*_triple_barrier_close(), 100.0, 100.0, 100.0])
+    t = TripleBarrierTarget(data, 'tb', span=2, min_periods=2, max_horizon=3)
+    result = t.transform(data)['tb'].to_list()
+    assert result[0] is None
+    assert result[1] is None
+    assert result[5] is None
+    assert result[6] is None
+    assert result[7] is None
+
+
+def test_triple_barrier_lower_multiple_widens_stop() -> None:
+    data = _close_series([*_triple_barrier_close(), 97.0, 110.0, 110.0])
+    narrow = TripleBarrierTarget(data, 'tb', span=2, min_periods=2, max_horizon=3,
+                                 lower_multiple=1.0).transform(data)['tb'].to_list()
+    wide = TripleBarrierTarget(data, 'tb', span=2, min_periods=2, max_horizon=3,
+                               lower_multiple=100.0).transform(data)['tb'].to_list()
+    assert narrow[4] == -1
+    assert wide[4] == 1
+
+
+def test_triple_barrier_rejects_nonpositive_params() -> None:
+    data = _close_series(_triple_barrier_close())
+    with pytest.raises(ValueError, match='upper_multiple'):
+        TripleBarrierTarget(data, 'tb', upper_multiple=0.0)
+    with pytest.raises(ValueError, match='max_horizon'):
+        TripleBarrierTarget(data, 'tb', max_horizon=0)


### PR DESCRIPTION
> Implements slice #572 · PRD #571

Closes #572

## What

Adds `TripleBarrierTarget` to `limen.targets` — Lopez de Prado's triple-barrier label, the canonical path-dependent labelling method from *Advances in Financial Machine Learning*. Limen had no triple-barrier label; this implements it in the existing target-class style.

For each bar, the forward **close** path is followed for up to `max_horizon` bars and labelled by the first barrier it touches:

- `1` — upper (profit-taking) barrier touched first
- `-1` — lower (stop-loss) barrier touched first
- `0` — neither touched within `max_horizon` bars (vertical / time barrier)

The horizontal barriers are **volatility multiples**: `+upper_multiple · σ` and `-lower_multiple · σ`, where `σ` is the EWMA standard deviation of close-to-close returns (de Prado's `getDailyVol`, bar-indexed). The width is set from the entry-bar volatility, so it adapts to the local regime instead of using a fixed percentage.

A bar is **null** during the volatility warmup (`min_periods`), on zero volatility, and when the vertical barrier would extend past the available data with no touch (no look-ahead). Manifest preparation drops null target rows.

### Design note — vertical barrier

The book's `getBins` labels a vertical-barrier touch with `sign(ret)`; this implementation uses the clean 3-class form (`0` for the timeout) so the three barriers map to three classes — the most common meaning of "triple-barrier **label**". Happy to add the sign-of-return variant behind a flag if preferred.

## Interface

```python
TripleBarrierTarget(train_data, target_name,
                    upper_multiple=1.0, lower_multiple=1.0,
                    max_horizon=10, span=100, min_periods=100, close_col='close')
```

No fitting step (like `ForwardBreakoutTarget`); the volatility is a causal EWMA computed within each split's `transform`. Usable from YAML via `class: limen.targets.TripleBarrierTarget`.

## Changes

- `limen/targets/triple_barrier.py` — new target class
- `limen/targets/__init__.py` — export + `__all__`
- `tests/test_targets.py` — 6 tests (upper / lower / vertical / null warmup+truncation / asymmetric stop / param validation), registered in `tests/run.py`
- `docs/Targets.md` — table row + reference section
- `CHANGELOG.md` + `pyproject.toml` — v3.16.0

## Validation

- `ruff check .` clean
- `pytest tests/test_targets.py` — 36 passed (30 existing + 6 new)
- Full `tests.run` suite run locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)