### PR TITLE
Add CODEOWNERS requesting @zero-bang on all PRs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Request @zero-bang to review every pull request.
+* @zero-bang


### PR DESCRIPTION
## What

Adds `.github/CODEOWNERS` with a catch-all rule so **@zero-bang is automatically requested as a reviewer on every pull request**:

```
* @zero-bang
```

@zero-bang is a repo collaborator with write access, so GitHub will auto-request them on all PRs.

## Scope

Config/governance only — no library code, tests, docs, or version touched. Per the PR template, CHANGELOG/`pyproject.toml` updates are not required for a non-code change. Kept separate from the TripleBarrierTarget feature ([#570](https://github.com/Vaquum/Limen/pull/570)) to respect that slice's declared surfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)