### PR TITLE
Make backtest fee_bps/slip_bps configurable on the reference architectures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1064,3 +1064,7 @@ Note: add all new changelog entries to the bottom of this file.
 - Add `vpin` to `limen.features` — Volume-synchronized Probability of Informed Trading (Easley, Lopez de Prado, and O'Hara): the rolling absolute BVC buy/sell imbalance over total volume, a flow-toxicity gauge in `[0, 1]`. Composes `bulk_volume_classification`; feed volume bars for canonical equal-volume buckets
 - Add `cusum_filter` to `limen.features` — Lopez de Prado's symmetric CUSUM event gate on the close log-return path, emitting an Int8 `cusum_event` flag (`1` up, `-1` down, `0` none) that samples only moves whose cumulative magnitude breaches `threshold`
 - Add `time_to_funding` to `limen.features` — continuous hours until the next funding settlement (default cadence every `8` hours from `0` UTC), complementing the existing `is_funding_hour` flag
+
+## v3.18.0 on 6th of June, 2026
+
+- Make the backtest cost model configurable on the reference architectures: `fee_bps` and `slip_bps` are now parameters on `logreg_binary`, `random_binary`, `xgboost_regressor`, `tabpfn_binary`, and `rule_based`, carried on `ReferenceModel` and forwarded to `backtest_snapshot`, defaulting to the existing `5.0`/`5.0`. Because model parameters resolve by signature inspection, `fee_bps`/`slip_bps` in `params()` now sweep cost as a search dimension — to match a venue's costs, make cost a first-class axis of the results, or stress-test how sensitive an edge is to the cost assumption. Omitting them is byte-for-byte unchanged. Resolves #534

--- a/docs/Backtest.md
+++ b/docs/Backtest.md
@@ -49,6 +49,8 @@ The current snapshot backtest is intentionally simple and opinionated:
 - output metrics are quantiles over their declared substrate
 - return and ratio outputs are basis-point scaled
 
+The fee and slippage rates default to `5.0` bps each per fill (a ~20 bps round trip). On the reference architectures they are configurable: pass `fee_bps` / `slip_bps` to a reference-architecture SFD, or sweep them in `params()` (for example `'fee_bps': [2.0, 5.0, 10.0]`), to match a venue's costs, make cost a search dimension, or stress-test how sensitive an edge is to the cost assumption. Omitting them keeps the 5 + 5 default, so existing experiments are unchanged.
+
 This makes snapshot backtests fast and comparable across rounds, but it also means they are not trying to be a full execution simulator.
 
 ### Output columns

--- a/limen/sfd/reference_architecture/base.py
+++ b/limen/sfd/reference_architecture/base.py
@@ -9,6 +9,10 @@ from limen.backtest.backtest_snapshot import backtest_snapshot
 from limen.log._permutation_confusion_metrics import _confusion_mean_return_pct
 
 
+DEFAULT_FEE_BPS = 5.0
+DEFAULT_SLIP_BPS = 5.0
+
+
 class ReferenceModel(ABC):
 
     '''Base class for class-based reference architecture models.'''
@@ -18,6 +22,8 @@ class ReferenceModel(ABC):
     def __init__(self) -> None:
 
         self.model = None
+        self.fee_bps = DEFAULT_FEE_BPS
+        self.slip_bps = DEFAULT_SLIP_BPS
 
     @abstractmethod
     def train(self, data: dict, **params: Any) -> 'ReferenceModel':
@@ -151,7 +157,12 @@ class ReferenceModel(ABC):
 
         bt_input = pd.DataFrame(bt_input_data)
 
-        bt_result = backtest_snapshot(bt_input, execution_lag_bars=1)
+        bt_result = backtest_snapshot(
+            bt_input,
+            execution_lag_bars=1,
+            fee_bps=self.fee_bps,
+            slip_bps=self.slip_bps,
+        )
 
         if bt_result.empty:
             return {}

--- a/limen/sfd/reference_architecture/base.py
+++ b/limen/sfd/reference_architecture/base.py
@@ -25,6 +25,26 @@ class ReferenceModel(ABC):
         self.fee_bps = DEFAULT_FEE_BPS
         self.slip_bps = DEFAULT_SLIP_BPS
 
+    @property
+    def fee_bps(self) -> float:
+        return self._fee_bps
+
+    @fee_bps.setter
+    def fee_bps(self, value: float) -> None:
+        if value < 0:
+            raise ValueError('ReferenceModel fee_bps must be non-negative')
+        self._fee_bps = value
+
+    @property
+    def slip_bps(self) -> float:
+        return self._slip_bps
+
+    @slip_bps.setter
+    def slip_bps(self, value: float) -> None:
+        if value < 0:
+            raise ValueError('ReferenceModel slip_bps must be non-negative')
+        self._slip_bps = value
+
     @abstractmethod
     def train(self, data: dict, **params: Any) -> 'ReferenceModel':
 

--- a/limen/sfd/reference_architecture/base.py
+++ b/limen/sfd/reference_architecture/base.py
@@ -1,5 +1,6 @@
 from abc import ABC
 from abc import abstractmethod
+import math
 from typing import Any
 
 import numpy as np
@@ -31,8 +32,8 @@ class ReferenceModel(ABC):
 
     @fee_bps.setter
     def fee_bps(self, value: float) -> None:
-        if value < 0:
-            raise ValueError('ReferenceModel fee_bps must be non-negative')
+        if not math.isfinite(value) or value < 0:
+            raise ValueError('ReferenceModel fee_bps must be a non-negative finite number')
         self._fee_bps = value
 
     @property
@@ -41,8 +42,8 @@ class ReferenceModel(ABC):
 
     @slip_bps.setter
     def slip_bps(self, value: float) -> None:
-        if value < 0:
-            raise ValueError('ReferenceModel slip_bps must be non-negative')
+        if not math.isfinite(value) or value < 0:
+            raise ValueError('ReferenceModel slip_bps must be a non-negative finite number')
         self._slip_bps = value
 
     @abstractmethod

--- a/limen/sfd/reference_architecture/logreg_binary.py
+++ b/limen/sfd/reference_architecture/logreg_binary.py
@@ -6,6 +6,8 @@ from sklearn.linear_model import LogisticRegression
 
 from limen.calibration import fit_calibrator
 from limen.metrics.binary_metrics import binary_metrics
+from limen.sfd.reference_architecture.base import DEFAULT_FEE_BPS
+from limen.sfd.reference_architecture.base import DEFAULT_SLIP_BPS
 from limen.sfd.reference_architecture.base import ReferenceModel
 
 if TYPE_CHECKING:
@@ -159,8 +161,8 @@ def logreg_binary(data: dict,
                   warm_start: bool = False,
                   n_jobs: int = -1,
                   l1_ratio: float | None = None,
-                  fee_bps: float = 5.0,
-                  slip_bps: float = 5.0,
+                  fee_bps: float = DEFAULT_FEE_BPS,
+                  slip_bps: float = DEFAULT_SLIP_BPS,
                   prediction_calibration_config: 'CalibrationConfig | None' = None) -> dict:
 
     '''

--- a/limen/sfd/reference_architecture/logreg_binary.py
+++ b/limen/sfd/reference_architecture/logreg_binary.py
@@ -159,6 +159,8 @@ def logreg_binary(data: dict,
                   warm_start: bool = False,
                   n_jobs: int = -1,
                   l1_ratio: float | None = None,
+                  fee_bps: float = 5.0,
+                  slip_bps: float = 5.0,
                   prediction_calibration_config: 'CalibrationConfig | None' = None) -> dict:
 
     '''
@@ -182,6 +184,8 @@ def logreg_binary(data: dict,
         warm_start (bool): Whether to reuse previous solution
         n_jobs (int): Number of parallel jobs
         l1_ratio (float | None): Elastic-net mixing parameter
+        fee_bps (float): Per-fill fee in basis points applied in the backtest
+        slip_bps (float): Per-fill slippage in basis points applied in the backtest
         prediction_calibration_config (CalibrationConfig | None): Optional calibration config
 
     Returns:
@@ -208,6 +212,8 @@ def logreg_binary(data: dict,
         l1_ratio=l1_ratio,
     )
 
+    model.fee_bps = fee_bps
+    model.slip_bps = slip_bps
     result = model.evaluate(data, inline_metrics=True)
     result['_model'] = model
     return result

--- a/limen/sfd/reference_architecture/random_binary.py
+++ b/limen/sfd/reference_architecture/random_binary.py
@@ -83,7 +83,9 @@ class RandomBinary(ReferenceModel):
 
 
 def random_binary(data: dict,
-                  random_weights: float = 0.5) -> dict:
+                  random_weights: float = 0.5,
+                  fee_bps: float = 5.0,
+                  slip_bps: float = 5.0) -> dict:
 
     '''
     Random binary classifier for testing and demonstration purposes.
@@ -91,6 +93,8 @@ def random_binary(data: dict,
     Args:
         data (dict): Data dictionary with x_test, y_test
         random_weights (float): Probability weight for class 1 (0.0 to 1.0)
+        fee_bps (float): Per-fill fee in basis points applied in the backtest
+        slip_bps (float): Per-fill slippage in basis points applied in the backtest
 
     Returns:
         dict: Results with binary metrics, predictions, inline confusion metrics,
@@ -98,6 +102,8 @@ def random_binary(data: dict,
     '''
 
     model = RandomBinary().train(data, random_weights=random_weights)
+    model.fee_bps = fee_bps
+    model.slip_bps = slip_bps
     result = model.evaluate(data, inline_metrics=True)
     result['_model'] = model
     return result

--- a/limen/sfd/reference_architecture/random_binary.py
+++ b/limen/sfd/reference_architecture/random_binary.py
@@ -3,6 +3,8 @@ from typing import Any
 import numpy as np
 
 from limen.metrics.binary_metrics import binary_metrics
+from limen.sfd.reference_architecture.base import DEFAULT_FEE_BPS
+from limen.sfd.reference_architecture.base import DEFAULT_SLIP_BPS
 from limen.sfd.reference_architecture.base import ReferenceModel
 
 
@@ -84,8 +86,8 @@ class RandomBinary(ReferenceModel):
 
 def random_binary(data: dict,
                   random_weights: float = 0.5,
-                  fee_bps: float = 5.0,
-                  slip_bps: float = 5.0) -> dict:
+                  fee_bps: float = DEFAULT_FEE_BPS,
+                  slip_bps: float = DEFAULT_SLIP_BPS) -> dict:
 
     '''
     Random binary classifier for testing and demonstration purposes.

--- a/limen/sfd/reference_architecture/rule_based.py
+++ b/limen/sfd/reference_architecture/rule_based.py
@@ -6,6 +6,8 @@ import polars as pl
 
 from limen.backtest.backtest_snapshot import backtest_snapshot
 from limen.metrics.rule_based_metrics import rule_based_metrics
+from limen.sfd.reference_architecture.base import DEFAULT_FEE_BPS
+from limen.sfd.reference_architecture.base import DEFAULT_SLIP_BPS
 from limen.sfd.reference_architecture.base import ReferenceModel
 
 
@@ -137,8 +139,8 @@ class RuleBasedStrategy(ReferenceModel):
 def rule_based(data: dict,
                sharpe_std_threshold: float = 0.5,
                sharpe_degradation_threshold: float = 0.3,
-               fee_bps: float = 5.0,
-               slip_bps: float = 5.0) -> dict:
+               fee_bps: float = DEFAULT_FEE_BPS,
+               slip_bps: float = DEFAULT_SLIP_BPS) -> dict:
 
     '''
     Apply a rule-based strategy to the given data and return evaluation metrics.

--- a/limen/sfd/reference_architecture/rule_based.py
+++ b/limen/sfd/reference_architecture/rule_based.py
@@ -123,7 +123,12 @@ class RuleBasedStrategy(ReferenceModel):
             bt_input_data['datetime'] = df['datetime'].to_numpy()
 
         bt_input = pd.DataFrame(bt_input_data)
-        bt_result = backtest_snapshot(bt_input, execution_lag_bars=1)
+        bt_result = backtest_snapshot(
+            bt_input,
+            execution_lag_bars=1,
+            fee_bps=self.fee_bps,
+            slip_bps=self.slip_bps,
+        )
         if bt_result.empty:
             return {}
         return bt_result.iloc[0].to_dict()
@@ -131,7 +136,9 @@ class RuleBasedStrategy(ReferenceModel):
 
 def rule_based(data: dict,
                sharpe_std_threshold: float = 0.5,
-               sharpe_degradation_threshold: float = 0.3) -> dict:
+               sharpe_degradation_threshold: float = 0.3,
+               fee_bps: float = 5.0,
+               slip_bps: float = 5.0) -> dict:
 
     '''
     Apply a rule-based strategy to the given data and return evaluation metrics.
@@ -140,6 +147,8 @@ def rule_based(data: dict,
         data (dict): Data dict with 'train', 'val', 'test' DataFrames and 'strategy' config
         sharpe_std_threshold (float): Max sharpe_std for is_stable to be True
         sharpe_degradation_threshold (float): Max sharpe_degradation for is_stable to be True
+        fee_bps (float): Per-fill fee in basis points applied in the backtest
+        slip_bps (float): Per-fill slippage in basis points applied in the backtest
 
     Returns:
         dict: Rule-based metrics with Tier 1, Tier 2, Tier 3 keys and '_preds'
@@ -150,4 +159,6 @@ def rule_based(data: dict,
         sharpe_degradation_threshold=sharpe_degradation_threshold,
     )
     model.train(data)
+    model.fee_bps = fee_bps
+    model.slip_bps = slip_bps
     return model.evaluate(data)

--- a/limen/sfd/reference_architecture/tabpfn_binary.py
+++ b/limen/sfd/reference_architecture/tabpfn_binary.py
@@ -142,6 +142,8 @@ class TabPFNBinary(ReferenceModel):
 def tabpfn_binary(data: dict,
                   n_ensemble_configurations: int = 4,
                   device: str = 'cpu',
+                  fee_bps: float = 5.0,
+                  slip_bps: float = 5.0,
                   prediction_calibration_config: 'CalibrationConfig | None' = None) -> dict:
 
     '''
@@ -151,6 +153,8 @@ def tabpfn_binary(data: dict,
         data (dict): Data dictionary with x_train, y_train, x_val, y_val, x_test, y_test
         n_ensemble_configurations (int): Number of ensemble configurations for TabPFN
         device (str): Device to run on ('cpu' or 'cuda')
+        fee_bps (float): Per-fill fee in basis points applied in the backtest
+        slip_bps (float): Per-fill slippage in basis points applied in the backtest
         prediction_calibration_config (CalibrationConfig | None): Optional calibration config
 
     Returns:
@@ -165,6 +169,8 @@ def tabpfn_binary(data: dict,
         device=device,
     )
 
+    model.fee_bps = fee_bps
+    model.slip_bps = slip_bps
     result = model.evaluate(data, inline_metrics=True)
     result['_model'] = model
     return result

--- a/limen/sfd/reference_architecture/tabpfn_binary.py
+++ b/limen/sfd/reference_architecture/tabpfn_binary.py
@@ -6,6 +6,8 @@ from tabpfn import TabPFNClassifier
 
 from limen.calibration import fit_calibrator
 from limen.metrics.binary_metrics import binary_metrics
+from limen.sfd.reference_architecture.base import DEFAULT_FEE_BPS
+from limen.sfd.reference_architecture.base import DEFAULT_SLIP_BPS
 from limen.sfd.reference_architecture.base import ReferenceModel
 from limen.utils.data_dict_to_numpy import data_dict_to_numpy
 
@@ -142,8 +144,8 @@ class TabPFNBinary(ReferenceModel):
 def tabpfn_binary(data: dict,
                   n_ensemble_configurations: int = 4,
                   device: str = 'cpu',
-                  fee_bps: float = 5.0,
-                  slip_bps: float = 5.0,
+                  fee_bps: float = DEFAULT_FEE_BPS,
+                  slip_bps: float = DEFAULT_SLIP_BPS,
                   prediction_calibration_config: 'CalibrationConfig | None' = None) -> dict:
 
     '''

--- a/limen/sfd/reference_architecture/xgboost_regressor.py
+++ b/limen/sfd/reference_architecture/xgboost_regressor.py
@@ -104,7 +104,9 @@ def xgboost_regressor(data: dict,
                   objective: str = 'reg:squarederror',
                   booster: str = 'gbtree',
                   early_stopping_rounds: int | None = 50,
-                  random_state: int = 42) -> dict:
+                  random_state: int = 42,
+                  fee_bps: float = 5.0,
+                  slip_bps: float = 5.0) -> dict:
 
     '''
     Compute XGBoost regression predictions and evaluation metrics.
@@ -124,6 +126,8 @@ def xgboost_regressor(data: dict,
         booster (str): Which booster to use
         early_stopping_rounds (int): Early stopping rounds
         random_state (int): Random seed
+        fee_bps (float): Per-fill fee in basis points applied in the backtest
+        slip_bps (float): Per-fill slippage in basis points applied in the backtest
 
     Returns:
         dict: Results with continuous metrics, predictions, inline confusion metrics,
@@ -147,6 +151,8 @@ def xgboost_regressor(data: dict,
         random_state=random_state,
     )
 
+    model.fee_bps = fee_bps
+    model.slip_bps = slip_bps
     result = model.evaluate(data, inline_metrics=True)
     result['_model'] = model
     return result

--- a/limen/sfd/reference_architecture/xgboost_regressor.py
+++ b/limen/sfd/reference_architecture/xgboost_regressor.py
@@ -4,6 +4,8 @@ import numpy as np
 import xgboost as xgb
 
 from limen.metrics.continuous_metrics import continuous_metrics
+from limen.sfd.reference_architecture.base import DEFAULT_FEE_BPS
+from limen.sfd.reference_architecture.base import DEFAULT_SLIP_BPS
 from limen.sfd.reference_architecture.base import ReferenceModel
 
 
@@ -105,8 +107,8 @@ def xgboost_regressor(data: dict,
                   booster: str = 'gbtree',
                   early_stopping_rounds: int | None = 50,
                   random_state: int = 42,
-                  fee_bps: float = 5.0,
-                  slip_bps: float = 5.0) -> dict:
+                  fee_bps: float = DEFAULT_FEE_BPS,
+                  slip_bps: float = DEFAULT_SLIP_BPS) -> dict:
 
     '''
     Compute XGBoost regression predictions and evaluation metrics.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaquum_limen"
-version = "3.17.0"
+version = "3.18.0"
 description = "Limen unifies parameter search across machine learning and rule-based strategies, with built-in analytics that show not just what works, but why it works."
 readme = "README.md"
 authors = [

--- a/tests/run.py
+++ b/tests/run.py
@@ -480,6 +480,9 @@ from tests.test_reference_architecture import test_rule_based_or_compound_condit
 from tests.test_reference_architecture import test_rule_based_not_operator
 from tests.test_reference_architecture import test_rule_based_empty_operands_raises
 from tests.test_reference_architecture import test_rule_based_unknown_operator_raises
+from tests.test_reference_architecture import test_reference_architectures_expose_cost_parameters
+from tests.test_reference_architecture import test_higher_cost_raises_drag_and_lowers_net_pnl
+from tests.test_reference_architecture import test_omitting_cost_matches_explicit_default
 from tests.test_manifest_prepare_data import test_price_data_for_backtest_has_ohlc_columns
 from tests.test_manifest_prepare_data import test_price_data_for_backtest_row_count_matches_test
 from tests.test_manifest_prepare_data import test_price_data_for_backtest_datetime_alignment
@@ -1395,6 +1398,9 @@ tests = [
     test_rule_based_not_operator,
     test_rule_based_empty_operands_raises,
     test_rule_based_unknown_operator_raises,
+    test_reference_architectures_expose_cost_parameters,
+    test_higher_cost_raises_drag_and_lowers_net_pnl,
+    test_omitting_cost_matches_explicit_default,
     test_price_data_for_backtest_has_ohlc_columns,
     test_price_data_for_backtest_row_count_matches_test,
     test_price_data_for_backtest_datetime_alignment,

--- a/tests/run.py
+++ b/tests/run.py
@@ -483,7 +483,7 @@ from tests.test_reference_architecture import test_rule_based_unknown_operator_r
 from tests.test_reference_architecture import test_reference_architectures_expose_cost_parameters
 from tests.test_reference_architecture import test_higher_cost_raises_drag_and_lowers_net_pnl
 from tests.test_reference_architecture import test_omitting_cost_matches_explicit_default
-from tests.test_reference_architecture import test_negative_cost_is_rejected
+from tests.test_reference_architecture import test_invalid_cost_is_rejected
 from tests.test_manifest_prepare_data import test_price_data_for_backtest_has_ohlc_columns
 from tests.test_manifest_prepare_data import test_price_data_for_backtest_row_count_matches_test
 from tests.test_manifest_prepare_data import test_price_data_for_backtest_datetime_alignment
@@ -1402,7 +1402,7 @@ tests = [
     test_reference_architectures_expose_cost_parameters,
     test_higher_cost_raises_drag_and_lowers_net_pnl,
     test_omitting_cost_matches_explicit_default,
-    test_negative_cost_is_rejected,
+    test_invalid_cost_is_rejected,
     test_price_data_for_backtest_has_ohlc_columns,
     test_price_data_for_backtest_row_count_matches_test,
     test_price_data_for_backtest_datetime_alignment,

--- a/tests/run.py
+++ b/tests/run.py
@@ -483,6 +483,7 @@ from tests.test_reference_architecture import test_rule_based_unknown_operator_r
 from tests.test_reference_architecture import test_reference_architectures_expose_cost_parameters
 from tests.test_reference_architecture import test_higher_cost_raises_drag_and_lowers_net_pnl
 from tests.test_reference_architecture import test_omitting_cost_matches_explicit_default
+from tests.test_reference_architecture import test_negative_cost_is_rejected
 from tests.test_manifest_prepare_data import test_price_data_for_backtest_has_ohlc_columns
 from tests.test_manifest_prepare_data import test_price_data_for_backtest_row_count_matches_test
 from tests.test_manifest_prepare_data import test_price_data_for_backtest_datetime_alignment
@@ -1401,6 +1402,7 @@ tests = [
     test_reference_architectures_expose_cost_parameters,
     test_higher_cost_raises_drag_and_lowers_net_pnl,
     test_omitting_cost_matches_explicit_default,
+    test_negative_cost_is_rejected,
     test_price_data_for_backtest_has_ohlc_columns,
     test_price_data_for_backtest_row_count_matches_test,
     test_price_data_for_backtest_datetime_alignment,

--- a/tests/test_reference_architecture.py
+++ b/tests/test_reference_architecture.py
@@ -16,6 +16,9 @@ from limen.sfd.reference_architecture import RuleBasedStrategy
 from limen.sfd.reference_architecture import TabPFNBinary
 from limen.sfd.reference_architecture import XGBoostRegressor
 from limen.sfd.reference_architecture import logreg_binary
+from limen.sfd.reference_architecture import random_binary
+from limen.sfd.reference_architecture import tabpfn_binary
+from limen.sfd.reference_architecture import xgboost_regressor
 from limen.sfd.reference_architecture.rule_based import rule_based
 
 
@@ -123,6 +126,8 @@ def test_logreg_foundational_params_cover_wrapper_model_surface():
     model_params = set(inspect.signature(logreg_binary).parameters) - {
         'data',
         'prediction_calibration_config',
+        'fee_bps',
+        'slip_bps',
     }
 
     assert model_params <= set(foundational_logreg_binary.params())
@@ -332,3 +337,36 @@ def test_rule_based_unknown_operator_raises():
         assert False, 'Expected ValueError'
     except ValueError as e:
         assert 'Unknown logical operator' in str(e)
+
+
+def test_reference_architectures_expose_cost_parameters():
+
+    architectures = [logreg_binary, random_binary, xgboost_regressor, rule_based]
+    if tabpfn_binary is not None:
+        architectures.append(tabpfn_binary)
+
+    for architecture in architectures:
+        params = inspect.signature(architecture).parameters
+        assert 'fee_bps' in params, f"{architecture.__name__} missing fee_bps"
+        assert 'slip_bps' in params, f"{architecture.__name__} missing slip_bps"
+
+
+def test_higher_cost_raises_drag_and_lowers_net_pnl():
+
+    zero = logreg_binary(_make_data(binary=True, with_price=True), fee_bps=0.0, slip_bps=0.0)
+    high = logreg_binary(_make_data(binary=True, with_price=True), fee_bps=20.0, slip_bps=20.0)
+
+    assert zero['backtest_cost_drag_bps_p50'] == 0.0
+    assert high['backtest_cost_drag_bps_p50'] > zero['backtest_cost_drag_bps_p50']
+    assert zero['backtest_trade_pnl_net_bps_p50'] > high['backtest_trade_pnl_net_bps_p50']
+
+
+def test_omitting_cost_matches_explicit_default():
+
+    omitted = logreg_binary(_make_data(binary=True, with_price=True))
+    explicit = logreg_binary(_make_data(binary=True, with_price=True), fee_bps=5.0, slip_bps=5.0)
+
+    backtest_keys = [key for key in omitted if key.startswith('backtest_')]
+    assert backtest_keys
+    for key in backtest_keys:
+        assert omitted[key] == explicit[key] or (np.isnan(omitted[key]) and np.isnan(explicit[key]))

--- a/tests/test_reference_architecture.py
+++ b/tests/test_reference_architecture.py
@@ -374,12 +374,18 @@ def test_omitting_cost_matches_explicit_default():
         assert omitted[key] == explicit[key] or (np.isnan(omitted[key]) and np.isnan(explicit[key]))
 
 
-def test_negative_cost_is_rejected():
+def test_invalid_cost_is_rejected():
 
     data = _make_data(binary=True, with_price=True)
-    for bad_cost in ({'fee_bps': -1.0}, {'slip_bps': -1.0}):
+    bad_costs = (
+        {'fee_bps': -1.0},
+        {'slip_bps': -1.0},
+        {'fee_bps': float('inf')},
+        {'slip_bps': float('nan')},
+    )
+    for bad_cost in bad_costs:
         try:
             logreg_binary(data, **bad_cost)
-            assert False, 'Expected ValueError for negative cost'
+            assert False, 'Expected ValueError for invalid cost'
         except ValueError as e:
             assert 'bps' in str(e)

--- a/tests/test_reference_architecture.py
+++ b/tests/test_reference_architecture.py
@@ -19,6 +19,8 @@ from limen.sfd.reference_architecture import logreg_binary
 from limen.sfd.reference_architecture import random_binary
 from limen.sfd.reference_architecture import tabpfn_binary
 from limen.sfd.reference_architecture import xgboost_regressor
+from limen.sfd.reference_architecture.base import DEFAULT_FEE_BPS
+from limen.sfd.reference_architecture.base import DEFAULT_SLIP_BPS
 from limen.sfd.reference_architecture.rule_based import rule_based
 
 
@@ -364,9 +366,20 @@ def test_higher_cost_raises_drag_and_lowers_net_pnl():
 def test_omitting_cost_matches_explicit_default():
 
     omitted = logreg_binary(_make_data(binary=True, with_price=True))
-    explicit = logreg_binary(_make_data(binary=True, with_price=True), fee_bps=5.0, slip_bps=5.0)
+    explicit = logreg_binary(_make_data(binary=True, with_price=True), fee_bps=DEFAULT_FEE_BPS, slip_bps=DEFAULT_SLIP_BPS)
 
     backtest_keys = [key for key in omitted if key.startswith('backtest_')]
     assert backtest_keys
     for key in backtest_keys:
         assert omitted[key] == explicit[key] or (np.isnan(omitted[key]) and np.isnan(explicit[key]))
+
+
+def test_negative_cost_is_rejected():
+
+    data = _make_data(binary=True, with_price=True)
+    for bad_cost in ({'fee_bps': -1.0}, {'slip_bps': -1.0}):
+        try:
+            logreg_binary(data, **bad_cost)
+            assert False, 'Expected ValueError for negative cost'
+        except ValueError as e:
+            assert 'bps' in str(e)

--- a/tests/test_yaml.py
+++ b/tests/test_yaml.py
@@ -273,6 +273,8 @@ def test_logreg_yaml_template_exposes_full_architecture_surface() -> None:
     model_params = set(inspect.signature(arch).parameters) - {
         'data',
         'prediction_calibration_config',
+        'fee_bps',
+        'slip_bps',
     }
 
     assert model_params <= set(yaml_dict['sfd']['params'])
@@ -1116,7 +1118,7 @@ def test_tabpfn_binary_template_is_valid_and_arch_surface_complete() -> None:
     assert isinstance(sfd.manifest(), MLManifest)
 
     arch = resolve(yaml_dict['sfd']['manifest']['reference_architecture'])
-    model_params = set(inspect.signature(arch).parameters) - {'data', 'prediction_calibration_config'}
+    model_params = set(inspect.signature(arch).parameters) - {'data', 'prediction_calibration_config', 'fee_bps', 'slip_bps'}
     assert model_params <= set(yaml_dict['sfd']['params'])
 
 
@@ -1134,7 +1136,7 @@ def test_xgboost_regressor_template_is_valid_and_arch_surface_complete() -> None
     assert isinstance(sfd.manifest(), MLManifest)
 
     arch = resolve(yaml_dict['sfd']['manifest']['reference_architecture'])
-    model_params = set(inspect.signature(arch).parameters) - {'data', 'prediction_calibration_config'}
+    model_params = set(inspect.signature(arch).parameters) - {'data', 'prediction_calibration_config', 'fee_bps', 'slip_bps'}
     assert model_params <= set(yaml_dict['sfd']['params'])
 
 


### PR DESCRIPTION
Implements slice [#577](https://github.com/Vaquum/Limen/issues/577) (PRD [#575](https://github.com/Vaquum/Limen/issues/575)).

Closes #577
Closes #534

## What

The backtest cost model (`fee_bps`/`slip_bps`, ~20 bps round-trip) was hardcoded — `backtest_snapshot` accepts the knobs but `_compute_backtest` never forwarded them, so every reference-architecture experiment was locked to 5 + 5 bps. This threads them through so cost is **settable per round and sweepable in `params()`**, defaulting to `5.0`/`5.0` (omit-cost path byte-for-byte unchanged).

## The dead-simplest mechanism

`Manifest.resolve_model_kwargs` already resolves model params by **signature inspection**, so once `fee_bps`/`slip_bps` are signature parameters they sweep from `params()` with **no YAML/schema/compiler change**:

- `ReferenceModel` carries `fee_bps`/`slip_bps` (`DEFAULT_FEE_BPS`/`DEFAULT_SLIP_BPS`); the shared `_compute_backtest` forwards them to `backtest_snapshot`.
- `logreg_binary`, `random_binary`, `xgboost_regressor`, `tabpfn_binary`, `rule_based` gain `fee_bps`/`slip_bps` and set them on the model; `RuleBasedStrategy` forwards them in its own backtest call.

```python
def params():
    return {'C': [0.1, 1.0], 'fee_bps': [2.0, 5.0, 10.0], 'slip_bps': [3.0, 5.0]}
```

## Tests (in `tests/test_reference_architecture.py`)

- `test_reference_architectures_expose_cost_parameters` — all five entry functions expose `fee_bps`/`slip_bps` (tabpfn guarded by its optional-dep pattern).
- `test_higher_cost_raises_drag_and_lowers_net_pnl` — `fee_bps=0,slip_bps=0` → `cost_drag_bps_p50 == 0`; high cost raises drag and lowers `trade_pnl_net_bps_p50`.
- `test_omitting_cost_matches_explicit_default` — omitting cost reproduces explicit `5.0`/`5.0` backtest metrics.

Also narrowed `test_logreg_foundational_params_cover_wrapper_model_surface` to exclude the two backtest params (they're execution costs, not model hyperparameters).

## Scope

Exactly the slice's Surfaces (6 reference-architecture files + tests + `tests/run.py` + `docs/Backtest.md` + CHANGELOG + version → v3.18.0). `backtest_snapshot.py`, `limen/yaml/`, and `manifest_core.py` are untouched (slice Out of Scope).

## Validation

- `ruff check .` clean; `tests/test_reference_architecture.py` 22 passed; full `tests.run` run locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)