### PR TITLE
Add a manifest-level backtest cost config (set_backtest_config)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1064,3 +1064,7 @@ Note: add all new changelog entries to the bottom of this file.
 - Add `vpin` to `limen.features` — Volume-synchronized Probability of Informed Trading (Easley, Lopez de Prado, and O'Hara): the rolling absolute BVC buy/sell imbalance over total volume, a flow-toxicity gauge in `[0, 1]`. Composes `bulk_volume_classification`; feed volume bars for canonical equal-volume buckets
 - Add `cusum_filter` to `limen.features` — Lopez de Prado's symmetric CUSUM event gate on the close log-return path, emitting an Int8 `cusum_event` flag (`1` up, `-1` down, `0` none) that samples only moves whose cumulative magnitude breaches `threshold`
 - Add `time_to_funding` to `limen.features` — continuous hours until the next funding settlement (default cadence every `8` hours from `0` UTC), complementing the existing `is_funding_hour` flag
+
+## v3.18.0 on 6th of June, 2026
+
+- Add a manifest-level backtest cost config: `Manifest.set_backtest_config(fee_bps, slip_bps)` stores a `BacktestConfig` that `run_model` resolves against the round's params (a number is fixed; a string is a search-param reference, so `set_backtest_config(fee_bps='fee')` sweeps cost via `params()`), validates non-negative and finite, and injects into the prepared `data` dict. `ReferenceModel._compute_backtest` and the rule-based backtest forward the resolved cost to `backtest_snapshot`, defaulting to the existing `5.0`/`5.0` when no config is set. The model architectures are untouched — cost stays off the model surface. Towards #534

--- a/docs/Backtest.md
+++ b/docs/Backtest.md
@@ -49,6 +49,8 @@ The current snapshot backtest is intentionally simple and opinionated:
 - output metrics are quantiles over their declared substrate
 - return and ratio outputs are basis-point scaled
 
+The fee and slippage rates default to `5.0` bps each per fill (a ~20 bps round trip) and are configured on the manifest, not on the model: `manifest.set_backtest_config(fee_bps=..., slip_bps=...)`. Each value is a fixed number or a search-param name — pass a param name to sweep cost across the search (for example `set_backtest_config(fee_bps='fee')` with `fee` in `params()`), to match a venue's costs, make cost a search dimension, or stress-test how sensitive an edge is to the cost assumption. Omitting the config keeps the 5 + 5 default, so existing experiments are unchanged.
+
 This makes snapshot backtests fast and comparable across rounds, but it also means they are not trying to be a full execution simulator.
 
 ### Output columns

--- a/limen/experiment/manifest_core.py
+++ b/limen/experiment/manifest_core.py
@@ -2,6 +2,8 @@ import copy
 import inspect
 import importlib
 import logging
+import math
+import numbers
 import random
 import re
 from datetime import date
@@ -237,6 +239,15 @@ class DataSourceResolver:
 
 
 @dataclass
+class BacktestConfig:
+
+    '''Backtest cost configuration: per-fill fee and slippage in basis points.'''
+
+    fee_bps: float | str = 5.0
+    slip_bps: float | str = 5.0
+
+
+@dataclass
 class Manifest:
 
     '''Base manifest with shared data pipeline configuration for Loop experiments.'''
@@ -255,6 +266,7 @@ class Manifest:
     architecture_function: Callable = None
     architecture_params: dict[str, ParamValue] = field(default_factory=dict)
     metrics_params: dict[str, ParamValue] = field(default_factory=dict)
+    backtest_config: BacktestConfig | None = None
 
     def _add_transform(self,
                        func: Callable,
@@ -742,6 +754,44 @@ class Manifest:
         return model_kwargs
 
 
+    def set_backtest_config(self,
+                            fee_bps: float | str = 5.0,
+                            slip_bps: float | str = 5.0) -> 'Manifest':
+
+        '''
+        Configure the backtest cost model for this manifest.
+
+        Args:
+            fee_bps (float | str): Per-fill fee in basis points, or a round-param name to sweep
+            slip_bps (float | str): Per-fill slippage in basis points, or a round-param name to sweep
+
+        Returns:
+            Manifest: Self for method chaining
+        '''
+
+        self.backtest_config = BacktestConfig(fee_bps=fee_bps, slip_bps=slip_bps)
+
+        return self
+
+    def _apply_backtest_cost(self, data: dict, round_params: dict[str, Any]) -> None:
+        if self.backtest_config is None:
+            return
+
+        resolved = _resolve_params(
+            {'fee_bps': self.backtest_config.fee_bps, 'slip_bps': self.backtest_config.slip_bps},
+            round_params,
+        )
+        for key in ('fee_bps', 'slip_bps'):
+            value = resolved[key]
+            if (
+                isinstance(value, bool)
+                or not isinstance(value, numbers.Real)
+                or not math.isfinite(value)
+                or value < 0
+            ):
+                raise ValueError(f"Manifest backtest {key} must be a non-negative finite number")
+            data[f"backtest_{key}"] = float(value)
+
     def run_model(self, data: dict, round_params: dict[str, Any]) -> dict:
 
         '''
@@ -764,6 +814,7 @@ class Manifest:
         '''
 
         model_kwargs = self.resolve_model_kwargs(round_params)
+        self._apply_backtest_cost(data, round_params)
         return self.architecture_function(data, **model_kwargs)
 
 
@@ -1030,6 +1081,7 @@ class MLManifest(Manifest):
                     threshold_params=resolved.threshold_params,
                 )
                 model_kwargs['prediction_calibration_config'] = config
+        self._apply_backtest_cost(data, round_params)
         return self.architecture_function(data, **model_kwargs)
 
     def sensor_input_prep(

--- a/limen/experiment/manifest_core.py
+++ b/limen/experiment/manifest_core.py
@@ -777,15 +777,19 @@ class Manifest:
         if self.backtest_config is None:
             return
 
-        resolved = _resolve_params(
-            {'fee_bps': self.backtest_config.fee_bps, 'slip_bps': self.backtest_config.slip_bps},
-            round_params,
-        )
+        raw = {'fee_bps': self.backtest_config.fee_bps, 'slip_bps': self.backtest_config.slip_bps}
+        resolved = _resolve_params(raw, round_params)
         for key in ('fee_bps', 'slip_bps'):
+            original = raw[key]
             value = resolved[key]
-            if isinstance(value, str):
+            if (
+                isinstance(original, str)
+                and isinstance(value, str)
+                and value == original
+                and original not in round_params
+            ):
                 raise ValueError(
-                    f"Manifest backtest {key} references unknown search-param '{value}'; "
+                    f"Manifest backtest {key} references unknown search-param '{original}'; "
                     "add it to params() or pass a number"
                 )
             if (

--- a/limen/experiment/manifest_core.py
+++ b/limen/experiment/manifest_core.py
@@ -794,7 +794,9 @@ class Manifest:
                 or not math.isfinite(value)
                 or value < 0
             ):
-                raise ValueError(f"Manifest backtest {key} must be a non-negative finite number")
+                raise ValueError(
+                    f"Manifest backtest {key} must be a non-negative finite number, got {value!r}"
+                )
             data[f"backtest_{key}"] = float(value)
 
     def run_model(self, data: dict, round_params: dict[str, Any]) -> dict:

--- a/limen/experiment/manifest_core.py
+++ b/limen/experiment/manifest_core.py
@@ -783,6 +783,11 @@ class Manifest:
         )
         for key in ('fee_bps', 'slip_bps'):
             value = resolved[key]
+            if isinstance(value, str):
+                raise ValueError(
+                    f"Manifest backtest {key} references unknown search-param '{value}'; "
+                    "add it to params() or pass a number"
+                )
             if (
                 isinstance(value, bool)
                 or not isinstance(value, numbers.Real)

--- a/limen/sfd/reference_architecture/base.py
+++ b/limen/sfd/reference_architecture/base.py
@@ -122,6 +122,13 @@ class ReferenceModel(ABC):
 
         return results
 
+    def _cost_kwargs(self, data: dict) -> dict:
+        return {
+            key: data[f"backtest_{key}"]
+            for key in ('fee_bps', 'slip_bps')
+            if f"backtest_{key}" in data
+        }
+
     def _compute_backtest(self, preds: np.ndarray, data: dict) -> dict:
 
         '''
@@ -151,7 +158,7 @@ class ReferenceModel(ABC):
 
         bt_input = pd.DataFrame(bt_input_data)
 
-        bt_result = backtest_snapshot(bt_input, execution_lag_bars=1)
+        bt_result = backtest_snapshot(bt_input, execution_lag_bars=1, **self._cost_kwargs(data))
 
         if bt_result.empty:
             return {}

--- a/limen/sfd/reference_architecture/rule_based.py
+++ b/limen/sfd/reference_architecture/rule_based.py
@@ -72,10 +72,11 @@ class RuleBasedStrategy(ReferenceModel):
         strategy = data['strategy']
         cond_index = {c['id']: c for c in strategy['conditions']}
 
+        cost_kwargs = self._cost_kwargs(data)
         for split in ('train', 'val', 'test'):
             pos = self._resolve(cond_index[strategy['entry']], cond_index, data[split]).fill_null(False).to_numpy().astype(int)
             positions[split] = pos
-            backtest_results[split] = self._backtest_split(data[split], pos)
+            backtest_results[split] = self._backtest_split(data[split], pos, cost_kwargs)
 
         results = rule_based_metrics(
             positions,
@@ -108,7 +109,7 @@ class RuleBasedStrategy(ReferenceModel):
             result = result & s if operator == 'and' else result | s
         return result
 
-    def _backtest_split(self, df: pl.DataFrame, positions: np.ndarray) -> dict:
+    def _backtest_split(self, df: pl.DataFrame, positions: np.ndarray, cost_kwargs: dict) -> dict:
         if 'open' not in df.columns or 'close' not in df.columns:
             return {}
         open_arr = df['open'].to_numpy().astype(float)
@@ -123,7 +124,7 @@ class RuleBasedStrategy(ReferenceModel):
             bt_input_data['datetime'] = df['datetime'].to_numpy()
 
         bt_input = pd.DataFrame(bt_input_data)
-        bt_result = backtest_snapshot(bt_input, execution_lag_bars=1)
+        bt_result = backtest_snapshot(bt_input, execution_lag_bars=1, **cost_kwargs)
         if bt_result.empty:
             return {}
         return bt_result.iloc[0].to_dict()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaquum_limen"
-version = "3.17.0"
+version = "3.18.0"
 description = "Limen unifies parameter search across machine learning and rule-based strategies, with built-in analytics that show not just what works, but why it works."
 readme = "README.md"
 authors = [

--- a/tests/run.py
+++ b/tests/run.py
@@ -480,6 +480,10 @@ from tests.test_reference_architecture import test_rule_based_or_compound_condit
 from tests.test_reference_architecture import test_rule_based_not_operator
 from tests.test_reference_architecture import test_rule_based_empty_operands_raises
 from tests.test_reference_architecture import test_rule_based_unknown_operator_raises
+from tests.test_reference_architecture import test_compute_backtest_honours_injected_cost
+from tests.test_reference_architecture import test_manifest_backtest_config_resolves_and_sweeps
+from tests.test_reference_architecture import test_architectures_do_not_expose_cost_parameters
+from tests.test_reference_architecture import test_invalid_backtest_config_is_rejected
 from tests.test_manifest_prepare_data import test_price_data_for_backtest_has_ohlc_columns
 from tests.test_manifest_prepare_data import test_price_data_for_backtest_row_count_matches_test
 from tests.test_manifest_prepare_data import test_price_data_for_backtest_datetime_alignment
@@ -1395,6 +1399,10 @@ tests = [
     test_rule_based_not_operator,
     test_rule_based_empty_operands_raises,
     test_rule_based_unknown_operator_raises,
+    test_compute_backtest_honours_injected_cost,
+    test_manifest_backtest_config_resolves_and_sweeps,
+    test_architectures_do_not_expose_cost_parameters,
+    test_invalid_backtest_config_is_rejected,
     test_price_data_for_backtest_has_ohlc_columns,
     test_price_data_for_backtest_row_count_matches_test,
     test_price_data_for_backtest_datetime_alignment,

--- a/tests/test_reference_architecture.py
+++ b/tests/test_reference_architecture.py
@@ -9,6 +9,7 @@ from limen.backtest.backtest_snapshot import BACKTEST_SNAPSHOT_COLUMNS
 from limen.calibration import grid_threshold_optimizer
 from limen.calibration import sklearn_probability_calibrator
 from limen.experiment import CalibrationConfig
+from limen.experiment import MLManifest
 from limen.sfd.foundational_sfd import logreg_binary as foundational_logreg_binary
 from limen.sfd.reference_architecture import LogRegBinary
 from limen.sfd.reference_architecture import RandomBinary
@@ -16,6 +17,9 @@ from limen.sfd.reference_architecture import RuleBasedStrategy
 from limen.sfd.reference_architecture import TabPFNBinary
 from limen.sfd.reference_architecture import XGBoostRegressor
 from limen.sfd.reference_architecture import logreg_binary
+from limen.sfd.reference_architecture import random_binary
+from limen.sfd.reference_architecture import tabpfn_binary
+from limen.sfd.reference_architecture import xgboost_regressor
 from limen.sfd.reference_architecture.rule_based import rule_based
 
 
@@ -332,3 +336,61 @@ def test_rule_based_unknown_operator_raises():
         assert False, 'Expected ValueError'
     except ValueError as e:
         assert 'Unknown logical operator' in str(e)
+
+
+def test_compute_backtest_honours_injected_cost():
+
+    base = _make_data(binary=True, with_price=True)
+    model = LogRegBinary().train(_make_data(binary=True, with_price=True), solver='lbfgs', max_iter=200)
+
+    zero = model.evaluate({**base, 'backtest_fee_bps': 0.0, 'backtest_slip_bps': 0.0})
+    high = model.evaluate({**base, 'backtest_fee_bps': 20.0, 'backtest_slip_bps': 20.0})
+
+    assert zero['backtest_cost_drag_bps_p50'] == 0.0
+    assert high['backtest_cost_drag_bps_p50'] > zero['backtest_cost_drag_bps_p50']
+    assert zero['backtest_trade_pnl_net_bps_p50'] > high['backtest_trade_pnl_net_bps_p50']
+
+
+def test_manifest_backtest_config_resolves_and_sweeps():
+
+    swept = {}
+    MLManifest().set_backtest_config(fee_bps='fee', slip_bps=3.0)._apply_backtest_cost(swept, {'fee': 7.0})
+    assert swept['backtest_fee_bps'] == 7.0
+    assert swept['backtest_slip_bps'] == 3.0
+
+    literal = {}
+    MLManifest().set_backtest_config(fee_bps=2.0, slip_bps=4.0)._apply_backtest_cost(literal, {})
+    assert literal['backtest_fee_bps'] == 2.0
+    assert literal['backtest_slip_bps'] == 4.0
+
+    unset = {}
+    MLManifest()._apply_backtest_cost(unset, {})
+    assert unset == {}
+
+
+def test_architectures_do_not_expose_cost_parameters():
+
+    architectures = [logreg_binary, random_binary, xgboost_regressor, rule_based]
+    if tabpfn_binary is not None:
+        architectures.append(tabpfn_binary)
+
+    for architecture in architectures:
+        params = inspect.signature(architecture).parameters
+        assert 'fee_bps' not in params, f"{architecture.__name__} should not expose fee_bps"
+        assert 'slip_bps' not in params, f"{architecture.__name__} should not expose slip_bps"
+
+
+def test_invalid_backtest_config_is_rejected():
+
+    bad = (
+        ({'fee_bps': -1.0}, {}),
+        ({'slip_bps': -1.0}, {}),
+        ({'fee_bps': 'fee'}, {'fee': float('inf')}),
+        ({'slip_bps': 'slip'}, {'slip': float('nan')}),
+    )
+    for config_kwargs, round_params in bad:
+        try:
+            MLManifest().set_backtest_config(**config_kwargs)._apply_backtest_cost({}, round_params)
+            assert False, 'Expected ValueError for invalid backtest cost'
+        except ValueError as e:
+            assert 'bps' in str(e)

--- a/tests/test_reference_architecture.py
+++ b/tests/test_reference_architecture.py
@@ -394,6 +394,7 @@ def test_invalid_backtest_config_is_rejected():
             assert False, 'Expected ValueError for invalid backtest cost'
         except ValueError as e:
             assert 'bps' in str(e)
+            assert 'got ' in str(e)
 
     try:
         MLManifest().set_backtest_config(fee_bps='missing_param')._apply_backtest_cost({}, {})

--- a/tests/test_reference_architecture.py
+++ b/tests/test_reference_architecture.py
@@ -394,3 +394,9 @@ def test_invalid_backtest_config_is_rejected():
             assert False, 'Expected ValueError for invalid backtest cost'
         except ValueError as e:
             assert 'bps' in str(e)
+
+    try:
+        MLManifest().set_backtest_config(fee_bps='missing_param')._apply_backtest_cost({}, {})
+        assert False, 'Expected ValueError for unresolved param reference'
+    except ValueError as e:
+        assert 'unknown search-param' in str(e)

--- a/tests/test_reference_architecture.py
+++ b/tests/test_reference_architecture.py
@@ -387,6 +387,7 @@ def test_invalid_backtest_config_is_rejected():
         ({'slip_bps': -1.0}, {}),
         ({'fee_bps': 'fee'}, {'fee': float('inf')}),
         ({'slip_bps': 'slip'}, {'slip': float('nan')}),
+        ({'fee_bps': 'fee'}, {'fee': 'oops'}),
     )
     for config_kwargs, round_params in bad:
         try:
@@ -395,6 +396,7 @@ def test_invalid_backtest_config_is_rejected():
         except ValueError as e:
             assert 'bps' in str(e)
             assert 'got ' in str(e)
+            assert 'unknown search-param' not in str(e)
 
     try:
         MLManifest().set_backtest_config(fee_bps='missing_param')._apply_backtest_cost({}, {})


### PR DESCRIPTION
Implements slice [#577](https://github.com/Vaquum/Limen/issues/577) (PRD [#575](https://github.com/Vaquum/Limen/issues/575)). Towards #534.

Closes #577

## What

Backtest cost is now configured **on the manifest**, not on each model — the redesign agreed after the per-architecture approach (closed #578) was found to be the wrong layer.

- `Manifest.set_backtest_config(fee_bps, slip_bps)` stores a `BacktestConfig`.
- `run_model` resolves it against the round's params via the existing `_resolve_params` convention (**a number is fixed; a string is a search-param reference**, so `set_backtest_config(fee_bps='fee')` + `params={'fee': [2,5,10]}` sweeps cost), validates it non-negative and finite, and injects `backtest_fee_bps`/`backtest_slip_bps` into the prepared `data` dict — the channel that already carries `price_data_for_backtest`.
- `ReferenceModel._compute_backtest` and `RuleBasedStrategy._backtest_split` forward the cost to `backtest_snapshot` via a shared `_cost_kwargs(data)`, defaulting to `backtest_snapshot`'s own `5.0`/`5.0` when unset.

**The five model architectures are untouched** — `fee_bps`/`slip_bps` never enter the model surface (guarded by a test), so nothing leaks into the template/foundational param-surface contracts.

```python
manifest.set_backtest_config(fee_bps=2.0, slip_bps=3.0)        # fixed
manifest.set_backtest_config(fee_bps='fee', slip_bps='slip')   # swept via params 'fee'/'slip'
```

## Tests (`tests/test_reference_architecture.py`)

- `test_compute_backtest_honours_injected_cost` — injected `backtest_fee_bps=0` → `cost_drag_p50 == 0`; high cost raises drag and lowers net PnL.
- `test_manifest_backtest_config_resolves_and_sweeps` — literal and swept reference resolve and inject; no config → no injection.
- `test_architectures_do_not_expose_cost_parameters` — none of the five entry signatures contain `fee_bps`/`slip_bps` (decoupling guard).
- `test_invalid_backtest_config_is_rejected` — negative / `inf` / `nan` resolved cost raises.

## Scope

Exactly the slice's Surfaces (`manifest_core.py`, `base.py`, `rule_based.py`, the test + `tests/run.py`, `docs/Backtest.md`, CHANGELOG, version → v3.18.0). The four model architectures, `limen/yaml/`, and `backtest_snapshot.py` are untouched (slice Out of Scope). The YAML `backtest:` block follows as slice #579.

## Validation

- `ruff check .` clean; `tests/test_reference_architecture.py` 23 passed; full `tests.run` run locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)