### PR TITLE
Add a YAML backtest cost block compiling to set_backtest_config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1068,3 +1068,7 @@ Note: add all new changelog entries to the bottom of this file.
 ## v3.18.0 on 6th of June, 2026
 
 - Add a manifest-level backtest cost config: `Manifest.set_backtest_config(fee_bps, slip_bps)` stores a `BacktestConfig` that `run_model` resolves against the round's params (a number is fixed; a string is a search-param reference, so `set_backtest_config(fee_bps='fee')` sweeps cost via `params()`), validates non-negative and finite, and injects into the prepared `data` dict. `ReferenceModel._compute_backtest` and the rule-based backtest forward the resolved cost to `backtest_snapshot`, defaulting to the existing `5.0`/`5.0` when no config is set. The model architectures are untouched — cost stays off the model surface. Towards #534
+
+## v3.19.0 on 6th of June, 2026
+
+- Add a YAML `backtest:` block that compiles to `Manifest.set_backtest_config`, making the manifest-level cost config reachable from CLI/YAML manifests. The block sits under `sfd.manifest` (sibling to `target:`/`scaler:`) with `fee_bps`/`slip_bps`, each a fixed number or a `"{param}"` reference into `sfd.params` — `fee_bps: "{fee}"` sweeps cost across the search exactly like indicator and target params. It is optional and shared across `ml` and `rule_based` manifests via the compiler's `_apply_base` seam; omitting it keeps the `5.0`/`5.0` default. `validate` rejects a non-mapping block, an unknown key (hard error), a negative or non-finite cost, and a `"{param}"` reference missing from `sfd.params`. Towards #534, completes the YAML surface (#579)

--- a/docs/Backtest.md
+++ b/docs/Backtest.md
@@ -51,6 +51,20 @@ The current snapshot backtest is intentionally simple and opinionated:
 
 The fee and slippage rates default to `5.0` bps each per fill (a ~20 bps round trip) and are configured on the manifest, not on the model: `manifest.set_backtest_config(fee_bps=..., slip_bps=...)`. Each value is a fixed number or a search-param name — pass a param name to sweep cost across the search (for example `set_backtest_config(fee_bps='fee')` with `fee` in `params()`), to match a venue's costs, make cost a search dimension, or stress-test how sensitive an edge is to the cost assumption. Omitting the config keeps the 5 + 5 default, so existing experiments are unchanged.
 
+In a YAML/CLI manifest the same configuration is a `backtest:` block under `sfd.manifest`, sibling to `target:` and `scaler:`. Each cost is a fixed number or a `"{param}"` reference into `sfd.params`, mirroring how indicator and target params are swept:
+
+```yaml
+sfd:
+  manifest:
+    backtest:
+      fee_bps: "{fee}"   # swept across the search
+      slip_bps: 5.0      # fixed
+  params:
+    fee: [1.0, 5.0, 10.0]
+```
+
+The block is optional and applies to both `ml` and `rule_based` manifests; omitting it keeps the 5 + 5 default. `limen validate` rejects an unknown key, a negative or non-finite cost, and a `"{param}"` reference missing from `sfd.params`.
+
 This makes snapshot backtests fast and comparable across rounds, but it also means they are not trying to be a full execution simulator.
 
 ### Output columns

--- a/docs/Backtest.md
+++ b/docs/Backtest.md
@@ -63,7 +63,7 @@ sfd:
     fee: [1.0, 5.0, 10.0]
 ```
 
-The block is optional and applies to both `ml` and `rule_based` manifests; omitting it keeps the 5 + 5 default. `limen validate` rejects an unknown key, a negative or non-finite cost, and a `"{param}"` reference missing from `sfd.params`.
+The block is optional and applies to both `ml` and `rule_based` manifests; omitting it — or leaving it empty — keeps the 5 + 5 default. `limen validate` rejects an unknown key, a negative or non-finite cost, and a `"{param}"` reference missing from `sfd.params`.
 
 This makes snapshot backtests fast and comparable across rounds, but it also means they are not trying to be a full execution simulator.
 

--- a/limen/yaml/compiler.py
+++ b/limen/yaml/compiler.py
@@ -139,6 +139,17 @@ def _apply_base(manifest: Manifest, m: dict[str, Any]) -> None:
             raise ValueError(f"'required_columns' must be a list, got {type(cols).__name__}")
         manifest.set_required_bar_columns(list(cols))
 
+    _apply_backtest(manifest, m)
+
+
+def _apply_backtest(manifest: Manifest, m: dict[str, Any]) -> None:
+
+    backtest = m.get('backtest')
+    if backtest is None:
+        return
+    kwargs = {key: backtest[key] for key in ('fee_bps', 'slip_bps') if key in backtest}
+    manifest.set_backtest_config(**kwargs)
+
 
 def _apply_split(manifest: Manifest, m: dict[str, Any]) -> None:
 

--- a/limen/yaml/compiler.py
+++ b/limen/yaml/compiler.py
@@ -145,7 +145,7 @@ def _apply_base(manifest: Manifest, m: dict[str, Any]) -> None:
 def _apply_backtest(manifest: Manifest, m: dict[str, Any]) -> None:
 
     backtest = m.get('backtest')
-    if backtest is None:
+    if not backtest:
         return
     kwargs = {key: backtest[key] for key in ('fee_bps', 'slip_bps') if key in backtest}
     manifest.set_backtest_config(**kwargs)

--- a/limen/yaml/rules.py
+++ b/limen/yaml/rules.py
@@ -1,4 +1,5 @@
 import inspect
+import math
 import re
 from datetime import date
 from itertools import pairwise
@@ -999,6 +1000,62 @@ class ParamKeyFields:
                     message=f"'{field_name}' must be a non-empty string",
                     path=f'{self._path}.{field_name}',
                     suggestion=f"Use a param name string, e.g. {field_name}: my_param_name",
+                ))
+
+
+class BacktestCostSpec:
+
+    '''Each backtest cost (fee_bps, slip_bps) must be a non-negative finite number or a {param} reference in sfd.params.'''
+
+    def check(self,
+              yaml_dict: dict[str, Any],
+              errors: list[YAMLError],
+              _warnings: list[YAMLError]) -> None:
+
+        sfd = yaml_dict.get('sfd') or {}
+        manifest = sfd.get('manifest') or {}
+        backtest = manifest.get('backtest')
+        if not isinstance(backtest, dict):
+            return
+
+        sfd_params = set(sfd.get('params') or {})
+
+        for key in ('fee_bps', 'slip_bps'):
+            if key not in backtest:
+                continue
+            value = backtest[key]
+            path = f'sfd.manifest.backtest.{key}'
+            if isinstance(value, bool):
+                errors.append(YAMLError(
+                    message=f"'backtest.{key}' must be a non-negative number or a {{param}} reference (got bool)",
+                    path=path,
+                    suggestion=f'Use a number like {key}: 5.0 or a reference like {key}: "{{fee}}"',
+                ))
+            elif isinstance(value, (int, float)):
+                if not math.isfinite(value) or value < 0:
+                    errors.append(YAMLError(
+                        message=f"'backtest.{key}' must be a non-negative finite number (got {value})",
+                        path=path,
+                        suggestion=f'Use a non-negative number, e.g. {key}: 5.0',
+                    ))
+            elif isinstance(value, str):
+                ref = _PARAM_REF_RE.fullmatch(value.strip())
+                if ref is None:
+                    errors.append(YAMLError(
+                        message=f"'backtest.{key}' must be a number or a {{param}} reference (got '{value}')",
+                        path=path,
+                        suggestion=f'Reference a search param, e.g. {key}: "{{fee}}", or use a number',
+                    ))
+                elif ref.group(1) not in sfd_params:
+                    errors.append(YAMLError(
+                        message=f"'backtest.{key}' references '{{{ref.group(1)}}}' which is not in sfd.params",
+                        path=path,
+                        suggestion=f"Add '{ref.group(1)}' to sfd.params",
+                    ))
+            else:
+                errors.append(YAMLError(
+                    message=f"'backtest.{key}' must be a number or a {{param}} reference (got {type(value).__name__})",
+                    path=path,
                 ))
 
 

--- a/limen/yaml/schema.py
+++ b/limen/yaml/schema.py
@@ -13,7 +13,7 @@ METADATA_OPTIONAL = {'author', 'created_at', 'description', 'tags', 'limen_versi
 SFD_REQUIRED = {'manifest', 'params'}
 
 MANIFEST_REQUIRED = {'type', 'data_source', 'reference_architecture'}
-MANIFEST_OPTIONAL_SHARED = {'required_columns', 'split_dates', 'indicators'}
+MANIFEST_OPTIONAL_SHARED = {'required_columns', 'split_dates', 'indicators', 'backtest'}
 
 ML_MANIFEST_REQUIRED = {'target'}
 ML_MANIFEST_OPTIONAL = {
@@ -52,6 +52,7 @@ SCALER_FROM_PARAMS_REQUIRED = {'from_params'}
 
 FEATURE_ABLATION_OPTIONAL = {'drop_count_key', 'seed_key'}
 PCA_COMPRESSION_OPTIONAL = {'enabled_param', 'n_components_param', 'scaler_param_name', 'component_prefix'}
+BACKTEST_OPTIONAL = {'fee_bps', 'slip_bps'}
 
 CALIBRATION_OPTIONAL = {'probability_calibration', 'threshold_function'}
 CALIBRATION_FUNC_REQUIRED = {'func'}

--- a/limen/yaml/validator.py
+++ b/limen/yaml/validator.py
@@ -3,6 +3,7 @@ from dataclasses import field
 from typing import Any
 
 from limen.yaml.errors import YAMLError
+from limen.yaml.rules import BacktestCostSpec
 from limen.yaml.rules import BlockSpec
 from limen.yaml.rules import CalibrationCrossRef
 from limen.yaml.rules import CalibrationPresence
@@ -28,6 +29,7 @@ from limen.yaml.rules import SplitSpec
 from limen.yaml.rules import WarnIfPresent
 from limen.yaml.rules import When
 from limen.yaml.rules import get_at
+from limen.yaml.schema import BACKTEST_OPTIONAL
 from limen.yaml.schema import CALIBRATION_FUNC_OPTIONAL
 from limen.yaml.schema import CALIBRATION_FUNC_REQUIRED
 from limen.yaml.schema import CALIBRATION_OPTIONAL
@@ -102,6 +104,10 @@ _MAIN_ENGINE = RuleEngine([
 
     Required('sfd.manifest.reference_architecture', str),
     Resolvable('sfd.manifest.reference_architecture'),
+
+    BlockSpec('sfd.manifest.backtest'),
+    NoUnknownKeys('sfd.manifest.backtest', BACKTEST_OPTIONAL, severity='error'),
+    BacktestCostSpec(),
 
     When('sfd.manifest.type', 'ml', [
         Required('sfd.manifest.target', dict),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaquum_limen"
-version = "3.18.0"
+version = "3.19.0"
 description = "Limen unifies parameter search across machine learning and rule-based strategies, with built-in analytics that show not just what works, but why it works."
 readme = "README.md"
 authors = [

--- a/tests/run.py
+++ b/tests/run.py
@@ -118,6 +118,15 @@ from tests.test_yaml import test_all_templates_have_valid_limen_version
 from tests.test_yaml import test_tabpfn_binary_template_is_valid_and_arch_surface_complete
 from tests.test_yaml import test_xgboost_regressor_template_is_valid_and_arch_surface_complete
 from tests.test_yaml import test_rule_based_template_is_valid_and_compiles
+from tests.test_yaml import test_validate_valid_for_fixed_and_swept_backtest_cost
+from tests.test_yaml import test_validate_error_for_backtest_not_a_mapping
+from tests.test_yaml import test_validate_error_for_backtest_unknown_key
+from tests.test_yaml import test_validate_error_for_backtest_cost_ref_not_in_sfd_params
+from tests.test_yaml import test_validate_error_for_backtest_cost_invalid_value
+from tests.test_yaml import test_build_manifest_backtest_config_fixed
+from tests.test_yaml import test_build_manifest_backtest_config_swept_resolves
+from tests.test_yaml import test_build_manifest_no_backtest_block_leaves_config_none
+from tests.test_yaml import test_build_manifest_rule_based_backtest_config_resolves
 from tests.test_profiler import test_complexity_rating_low
 from tests.test_profiler import test_complexity_rating_medium
 from tests.test_profiler import test_complexity_rating_high
@@ -1254,6 +1263,15 @@ tests = [
     test_validate_error_for_manifest_ref_not_in_sfd_params,
     test_validate_no_error_when_manifest_ref_is_in_sfd_params,
     test_validate_no_unused_param_warning_for_pca_defaults,
+    test_validate_valid_for_fixed_and_swept_backtest_cost,
+    test_validate_error_for_backtest_not_a_mapping,
+    test_validate_error_for_backtest_unknown_key,
+    test_validate_error_for_backtest_cost_ref_not_in_sfd_params,
+    test_validate_error_for_backtest_cost_invalid_value,
+    test_build_manifest_backtest_config_fixed,
+    test_build_manifest_backtest_config_swept_resolves,
+    test_build_manifest_no_backtest_block_leaves_config_none,
+    test_build_manifest_rule_based_backtest_config_resolves,
     test_resolve_func_params_resolves_limen_path_to_callable,
     test_resolve_func_params_preserves_round_param_ref_as_string,
     test_resolve_func_params_preserves_non_limen_string_on_resolution_failure,

--- a/tests/run.py
+++ b/tests/run.py
@@ -126,6 +126,7 @@ from tests.test_yaml import test_validate_error_for_backtest_cost_invalid_value
 from tests.test_yaml import test_build_manifest_backtest_config_fixed
 from tests.test_yaml import test_build_manifest_backtest_config_swept_resolves
 from tests.test_yaml import test_build_manifest_no_backtest_block_leaves_config_none
+from tests.test_yaml import test_build_manifest_empty_backtest_block_leaves_config_none
 from tests.test_yaml import test_build_manifest_rule_based_backtest_config_resolves
 from tests.test_profiler import test_complexity_rating_low
 from tests.test_profiler import test_complexity_rating_medium
@@ -1271,6 +1272,7 @@ tests = [
     test_build_manifest_backtest_config_fixed,
     test_build_manifest_backtest_config_swept_resolves,
     test_build_manifest_no_backtest_block_leaves_config_none,
+    test_build_manifest_empty_backtest_block_leaves_config_none,
     test_build_manifest_rule_based_backtest_config_resolves,
     test_resolve_func_params_resolves_limen_path_to_callable,
     test_resolve_func_params_preserves_round_param_ref_as_string,

--- a/tests/test_yaml.py
+++ b/tests/test_yaml.py
@@ -852,6 +852,13 @@ def test_build_manifest_no_backtest_block_leaves_config_none() -> None:
     assert manifest.backtest_config is None
 
 
+def test_build_manifest_empty_backtest_block_leaves_config_none() -> None:
+    yaml_dict, _ = parse(_MINIMAL_ML_YAML)
+    yaml_dict['sfd']['manifest']['backtest'] = {}
+    manifest = build_manifest(yaml_dict)
+    assert manifest.backtest_config is None
+
+
 def test_build_manifest_rule_based_backtest_config_resolves() -> None:
     yaml_dict, _ = parse(_MINIMAL_RULE_BASED_YAML)
     yaml_dict['sfd']['manifest']['backtest'] = {'fee_bps': '{dummy_param}'}

--- a/tests/test_yaml.py
+++ b/tests/test_yaml.py
@@ -784,6 +784,84 @@ def test_validate_no_unused_param_warning_for_pca_defaults() -> None:
     assert not any(w.path in ('sfd.params.auto_pca', 'sfd.params.pca_k') for w in result.warnings)
 
 
+def test_validate_valid_for_fixed_and_swept_backtest_cost() -> None:
+    yaml_dict, _ = parse(_MINIMAL_ML_YAML)
+    yaml_dict['sfd']['manifest']['backtest'] = {'fee_bps': '{fee}', 'slip_bps': 5.0}
+    yaml_dict['sfd']['params']['fee'] = [1.0, 5.0, 10.0]
+    result = validate(yaml_dict)
+    assert result.valid
+    assert not any(w.path == 'sfd.params.fee' for w in result.warnings)
+
+
+def test_validate_error_for_backtest_not_a_mapping() -> None:
+    yaml_dict, _ = parse(_MINIMAL_ML_YAML)
+    yaml_dict['sfd']['manifest']['backtest'] = 'cheap'
+    result = validate(yaml_dict)
+    assert not result.valid
+    assert any('backtest' in e.path and 'mapping' in e.message for e in result.errors)
+
+
+def test_validate_error_for_backtest_unknown_key() -> None:
+    yaml_dict, _ = parse(_MINIMAL_ML_YAML)
+    yaml_dict['sfd']['manifest']['backtest'] = {'fee_bps': 5.0, 'slippage': 3.0}
+    result = validate(yaml_dict)
+    assert not result.valid
+    assert any('slippage' in e.message for e in result.errors)
+
+
+def test_validate_error_for_backtest_cost_ref_not_in_sfd_params() -> None:
+    yaml_dict, _ = parse(_MINIMAL_ML_YAML)
+    yaml_dict['sfd']['manifest']['backtest'] = {'fee_bps': '{nonexistent_fee}'}
+    result = validate(yaml_dict)
+    assert not result.valid
+    assert any('nonexistent_fee' in e.message for e in result.errors)
+
+
+def test_validate_error_for_backtest_cost_invalid_value() -> None:
+    for value in [-1.0, float('inf'), float('nan'), 'fee', True, [5.0]]:
+        yaml_dict, _ = parse(_MINIMAL_ML_YAML)
+        yaml_dict['sfd']['manifest']['backtest'] = {'fee_bps': value}
+        result = validate(yaml_dict)
+        assert not result.valid, f'backtest fee_bps={value!r} should be invalid'
+        assert any(e.path == 'sfd.manifest.backtest.fee_bps' for e in result.errors)
+
+
+def test_build_manifest_backtest_config_fixed() -> None:
+    yaml_dict, _ = parse(_MINIMAL_ML_YAML)
+    yaml_dict['sfd']['manifest']['backtest'] = {'fee_bps': 8.0, 'slip_bps': 3.0}
+    manifest = build_manifest(yaml_dict)
+    assert manifest.backtest_config is not None
+    assert manifest.backtest_config.fee_bps == 8.0
+    assert manifest.backtest_config.slip_bps == 3.0
+
+
+def test_build_manifest_backtest_config_swept_resolves() -> None:
+    yaml_dict, _ = parse(_MINIMAL_ML_YAML)
+    yaml_dict['sfd']['manifest']['backtest'] = {'fee_bps': '{fee}', 'slip_bps': 5.0}
+    yaml_dict['sfd']['params']['fee'] = [1.0, 5.0, 10.0]
+    manifest = build_manifest(yaml_dict)
+    data: dict = {}
+    manifest._apply_backtest_cost(data, {'fee': 10.0})
+    assert data['backtest_fee_bps'] == 10.0
+    assert data['backtest_slip_bps'] == 5.0
+
+
+def test_build_manifest_no_backtest_block_leaves_config_none() -> None:
+    yaml_dict, _ = parse(_MINIMAL_ML_YAML)
+    manifest = build_manifest(yaml_dict)
+    assert manifest.backtest_config is None
+
+
+def test_build_manifest_rule_based_backtest_config_resolves() -> None:
+    yaml_dict, _ = parse(_MINIMAL_RULE_BASED_YAML)
+    yaml_dict['sfd']['manifest']['backtest'] = {'fee_bps': '{dummy_param}'}
+    assert validate(yaml_dict).valid
+    manifest = build_manifest(yaml_dict)
+    data: dict = {}
+    manifest._apply_backtest_cost(data, {'dummy_param': 2})
+    assert data['backtest_fee_bps'] == 2.0
+
+
 def test_build_manifest_data_source_method_is_callable_with_correct_params() -> None:
     yaml_dict, _ = parse(_MINIMAL_ML_YAML)
     manifest = build_manifest(yaml_dict)


### PR DESCRIPTION
## What

Adds a YAML `backtest:` block that compiles to `Manifest.set_backtest_config`, making the manifest-level backtest cost config (shipped in #580) reachable from CLI/YAML manifests. This is **Slice B** of the cost-model work (#534); Slice A (#580, the Python `set_backtest_config`) is already merged.

The block sits under `sfd.manifest`, sibling to `target:`/`scaler:`:

```yaml
sfd:
  manifest:
    backtest:
      fee_bps: "{fee}"    # swept across the search
      slip_bps: 5.0       # fixed
  params:
    fee: [1.0, 5.0, 10.0]
```

Each cost is a fixed number **or** a `"{param}"` reference into `sfd.params` — `fee_bps: "{fee}"` sweeps cost exactly like indicator/target params (the runtime `_resolve_params` already turns a sole `"{fee}"` into the real float, and `ParamCoverage` already cross-checks the reference).

## Design

- **One shared seam.** Compiled in `_apply_base`, which both `_build_ml_manifest` and `_build_rule_based_manifest` call, so the block works for **`ml` and `rule_based`** with no per-type duplication. The architectures stay untouched — cost remains off the model surface.
- **Optional.** Omitting the block keeps the existing `5.0`/`5.0` default; existing manifests are unchanged.
- **Validated** by a focused `BacktestCostSpec` rule (mirroring `CalibrationCrossRef`): rejects a non-mapping block, an unknown key (hard error — a typo'd `slippage:` must not silently no-op a cost), a negative or non-finite cost, a bare (non-`{param}`) string, and a `"{param}"` reference missing from `sfd.params`.

## Testing

Proven end-to-end with a real CLI manifest:
- `limen validate` ✓ and `limen run --dry-run` ✓
- compiled manifest **sweeps** the fee per round (fee=1/5/10 → `backtest_fee_bps` 1/5/10; slip fixed)
- shared path confirmed for `ml` **and** `rule_based`
- every invalid form rejected with a clear message

9 new tests in `tests/test_yaml.py` (registered in `tests/run.py`); ruff clean; full `tests.run` suite passes locally (exit 0).

Towards #534, completes the YAML surface (#579).
