### PR TITLE
Document that a PRD's last-slice PR also closes the PRD

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,3 +18,4 @@ _(Fill in at least a short description of the the intent of the change.)_
 - [ ] I validated changes with LLM
 - [ ] I removed any extraneous examples/comments
 - [ ] I linked issue to auto-close on merge (e.g., “Fixes #123”) when applicable
+- [ ] If this PR delivers a PRD’s **last** remaining slice, I also linked the parent PRD to close with it (e.g., “Closes #120”), so the PRD closes on merge instead of by hand


### PR DESCRIPTION
## What does this PR change?

Adds one checklist item to the PR template so that a **PRD parent closes automatically** when its work is done — closing the gap where PRD #590 had to be closed by hand after both its slices ([#591](https://github.com/Vaquum/Limen/issues/591) / [#592](https://github.com/Vaquum/Limen/issues/592)) merged.

## Why

Slices already auto-close: their PRs carry `Closes #<slice>`, and GitHub closes the slice on merge (the existing checklist item, unchanged). But a PRD has **no PR of its own**, and GitHub has **no native rule** that closes a parent issue when its children close. So the convention just needs to say: the PR that delivers the PRD's *last remaining* slice also carries a closing keyword for the PRD itself — then merging that PR closes both the slice and the PRD natively, no manual step.

```diff
 - [ ] I linked issue to auto-close on merge (e.g., “Fixes #123”) when applicable
+- [ ] If this PR delivers a PRD’s **last** remaining slice, I also linked the parent PRD to close with it (e.g., “Closes #120”), so the PRD closes on merge instead of by hand
```

Zero new infrastructure — it rides the same `Closes #` keyword that already works, and "last remaining" handles slices merging out of order (it's the one that completes the PRD).

Non-code change (template only), so no CHANGELOG / `pyproject.toml` bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)