### PR TITLE
docs: align docs with honesty rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   <br />
 </div>
 <br />
-<div align="center"><strong>Vaquum Limen turns Bitcoin market data into searchable signals, backtested outcomes, and decoder cohorts.</strong></div>
+<div align="center"><b>Vaquum Limen turns Bitcoin market data into searchable signals, backtested outcomes, and decoder cohorts.</b></div>
 
 <div align="center">
   <a href="#limen">Limen</a> •
@@ -15,7 +15,7 @@
 </div>
 <br />
 <div align="center">
-  <a href="https://www.bestpractices.dev/projects/11898"><img src="https://www.bestpractices.dev/projects/11898/badge" alt="OpenSSF Best Practices" /></a>
+  <a href="https://www.bestpractices.dev/projects/11898"><img src="https://www.bestpractices.dev/projects/11898/badge" alt="OpenSSF practices badge" /></a>
   <a href="https://scorecard.dev/viewer/?uri=github.com/Vaquum/Limen"><img src="https://img.shields.io/ossf-scorecard/github.com/Vaquum/Limen?label=openssf+scorecard&amp;style=flat" alt="OpenSSF Scorecard" /></a>
 </div>
 
@@ -23,11 +23,11 @@
 
 <a id="limen"></a>
 
-# Limen — The Research Engine
+# Limen — Research engine
 
 *Manifest-driven Bitcoin alpha research engine that turns market data into searchable signals, backtested outcomes, and decoder cohorts.*
 
-Limen unifies parameter search across machine learning and rule-based strategies, with built-in analytics that show not just what works, but why it works. It evolves from Talos, the hyperparameter optimization framework for TensorFlow and Keras cited in over 1,000 scientific papers with zero breaking bugs in six years.
+Limen unifies parameter search across machine learning and rule-based strategies. Built-in analytics connect experiment outputs to benchmark, backtest, and cohort workflows. The project evolves from Talos, a hyperparameter optimization framework for TensorFlow and Keras.
 
 ## What Limen Is Not
 
@@ -43,7 +43,7 @@ In the wider Vaquum architecture, Origo sits upstream as the data layer. Nexus, 
 
 - Manifest-driven experiment pipelines
 - Search across models, rules, features, targets, and hyperparameters
-- Extensive built-in indicator and feature library for Bitcoin research
+- Built-in indicator and feature library for Bitcoin research
 - Support for both machine learning and rule-based strategy research
 - Bitcoin-native transforms, scaling, and target construction
 - Leakage-safe train, validation, and test workflows
@@ -53,7 +53,7 @@ In the wider Vaquum architecture, Origo sits upstream as the data layer. Nexus, 
 
 ## First Experiment
 
-The fastest first success is a small parameter sweep on the bundled BTC/USDT kline dataset with the built-in logistic-regression decoder.
+The first runnable path is a small parameter sweep on the bundled BTC/USDT kline dataset with the built-in logistic-regression decoder.
 
 1. Install the package:
 
@@ -84,13 +84,13 @@ uel.run(
 - `uel.experiment_confusion_metrics` for confusion analytics
 - `uel.experiment_backtest_results` for backtest results
 
-That path is the simplest way to get a real Limen run on your machine without relying on repo-local fixture files. If you want richer run directories, checkpoints, resumability, and stored round artefacts, continue into the UEL documentation below.
+That path runs against public BTC/USDT data without relying on repo-local fixture files. The UEL documentation covers run directories, checkpoints, resumability, and stored round artefacts.
 
-## Learn More
+## Learn more
 
 - Start with the full docs hub in [docs/README.md](docs/README.md)
 - Define research units in [docs/Single-File-Decoder.md](docs/Single-File-Decoder.md), [docs/Built-In-SFDs.md](docs/Built-In-SFDs.md), and [docs/Experiment-Manifest.md](docs/Experiment-Manifest.md)
-- Run experiments in [docs/Universal-Experiment-Loop.md](docs/Universal-Experiment-Loop.md) and extend the artifact-rich path through [docs/Advanced-Search.md](docs/Advanced-Search.md) and [docs/Reducers-And-Feedback.md](docs/Reducers-And-Feedback.md)
+- Run experiments in [docs/Universal-Experiment-Loop.md](docs/Universal-Experiment-Loop.md) and extend the artifact-backed path through [docs/Advanced-Search.md](docs/Advanced-Search.md) and [docs/Reducers-And-Feedback.md](docs/Reducers-And-Feedback.md)
 - Analyze results in [docs/Log.md](docs/Log.md), [docs/Benchmark.md](docs/Benchmark.md), and [docs/Backtest.md](docs/Backtest.md)
 - Understand the model layer in [docs/Reference-Architecture.md](docs/Reference-Architecture.md) and the helper layer in [docs/Utilities.md](docs/Utilities.md)
 - Promote finished runs into reusable outputs with [docs/Trainer.md](docs/Trainer.md) and [docs/Cohort.md](docs/Cohort.md)
@@ -98,7 +98,7 @@ That path is the simplest way to get a real Limen run on your machine without re
 
 ## Contributing
 
-The simplest way to start contributing is by [joining an open discussion](https://github.com/Vaquum/Limen/issues?q=is%3Aissue%20state%3Aopen%20label%3Aquestion%2Fdiscussion), contributing to [the docs](https://github.com/Vaquum/Limen/tree/main/docs), or by [picking up an open issue](https://github.com/Vaquum/Limen/issues?q=is%3Aissue%20state%3Aopen%20label%3Abug%20OR%20label%3Aenhancement%20OR%20label%3A%22good%20first%20issue%22%20OR%20label%3A%22help%20wanted%22%20OR%20label%3APriority%20OR%20label%3Aprocess).
+Contribution starts through [open discussions](https://github.com/Vaquum/Limen/issues), [docs changes](https://github.com/Vaquum/Limen/tree/main/docs), or [open issues](https://github.com/Vaquum/Limen/issues).
 
 Before contributing, start with [docs/Developer/README.md](docs/Developer/README.md).
 
@@ -108,7 +108,7 @@ Report vulnerabilities privately through [GitHub Security Advisories](https://gi
 
 ## Citations
 
-If you use Limen for published work, please cite:
+Published work should cite:
 
 Vaquum Limen [Computer software]. (2026). Retrieved from https://github.com/Vaquum/Limen.
 

--- a/docs/Advanced-Search.md
+++ b/docs/Advanced-Search.md
@@ -1,8 +1,8 @@
 # Advanced Search
 
-Advanced search is Limen's artifact-rich experiment path. It adds a mutable parameter domain, a search strategy abstraction, checkpointing, resumability, and mid-run feedback on top of the normal Universal Experiment Loop.
+Advanced search is Limen's artifact-backed experiment path. It adds a mutable parameter domain, a search strategy abstraction, checkpointing, resumability, and mid-run feedback on top of the normal Universal Experiment Loop.
 
-Use this page when you want:
+This page covers:
 
 - a search strategy that is not the legacy `ParamSpace` sweep
 - a durable `experiment_dir` with resumable artifacts
@@ -11,7 +11,7 @@ Use this page when you want:
 
 For a first experiment, stay on the standard UEL path. Advanced search is real and supported, but it is the extension-oriented layer of Limen.
 
-## The Core Pieces
+## The core pieces
 
 | Piece | What it owns |
 |---|---|
@@ -28,9 +28,9 @@ The important mental model is:
 3. feedback mutates `MSQ` and sometimes the underlying `ParamDomain`
 4. checkpoints preserve enough state to continue later with `resume=True`
 
-## Minimal Custom `SearchStrategy`
+## Minimal custom `SearchStrategy`
 
-Limen ships two built-in strategies (`GridStrategy` for exhaustive search, `RandomStrategy` for lazy sampling) and the `SearchStrategy` abstraction for writing your own. A strategy must at minimum:
+Limen ships two built-in strategies (`GridStrategy` for exhaustive search, `RandomStrategy` for lazy sampling) and the `SearchStrategy` abstraction for custom strategies. A strategy must at minimum:
 
 - hold a reference to a shared `ParamDomain`
 - yield dictionaries of round parameters
@@ -84,7 +84,7 @@ class MiniGrid(SearchStrategy):
         self._generated_count = state['generated_count']
 ```
 
-## First Artifact-Rich Run
+## First artifact-backed run
 
 ```python
 import limen
@@ -125,7 +125,7 @@ The reducer intervention that caused the trim was:
 {'op': 'trim', 'target_count': 4, 'reason': 'budget trim to 4 total permutations'}
 ```
 
-## What `experiment_dir` Stores
+## What `experiment_dir` stores
 
 When `experiment_dir` is set, advanced search writes:
 
@@ -136,11 +136,11 @@ When `experiment_dir` is set, advanced search writes:
 | `checkpoint.json` | search state for resume |
 | `audit.jsonl` | feedback-cycle audit trail |
 | `metadata.json` | experiment metadata used by `Trainer` |
-| `interventions.json` | optional input file polled by the feedback controller if you create it |
+| `interventions.json` | optional input file polled by the feedback controller when the file exists |
 
 Unlike the other files above, `interventions.json` is not produced by the run. It is an optional external control file that the feedback controller watches when `experiment_dir` is present.
 
-## Resume Flow
+## Resume flow
 
 Resumption belongs to the advanced path only.
 
@@ -166,9 +166,9 @@ For resume to work cleanly, keep these stable:
 - the same parameter content
 - the same configured reducer stack
 
-## What Advanced Search Adds Beyond Standard UEL
+## What advanced search adds beyond standard UEL
 
-Compared to the standard path, advanced search gives you:
+Compared to the standard path, advanced search adds:
 
 - mutable pruning and focus during a run
 - stored round-level predictions and alignment data
@@ -182,8 +182,8 @@ What it does not change:
 - manifests still govern split-first prep
 - post-run analysis still flows through `Log`
 
-## Read Next
+## Read next
 
 - Continue to [Reducers And Feedback](Reducers-And-Feedback.md) for the intervention system that acts on the mutable search queue.
 - Continue to [Universal Experiment Loop](Universal-Experiment-Loop.md) for the broader run contract around standard and advanced execution.
-- Continue to [Trainer](Trainer.md) if you want to promote finished advanced runs into reusable sensors.
+- Continue to [Trainer](Trainer.md) for promotion of finished advanced runs into reusable sensors.

--- a/docs/Backtest.md
+++ b/docs/Backtest.md
@@ -100,9 +100,19 @@ from limen.backtest.long_flat_strategy import ExecutionResult
 
 def my_strategy(predictions, open_px, close_px, price_change, *,
                 execution_lag_bars, fee_bps, slip_bps) -> ExecutionResult:
-    position = predictions.astype(float)
+    position = predictions.astype(float).shift(execution_lag_bars, fill_value=0.0)
     gross_return = position * price_change / open_px
-    net_return = gross_return
+
+    entry_mask = (position == 1.0) & (position.shift(1, fill_value=0.0) == 0.0)
+    exit_mask = (position == 1.0) & (position.shift(-1, fill_value=0.0) == 0.0)
+    fee = fee_bps / 10_000.0
+    slip = slip_bps / 10_000.0
+    cost_mult = position.copy()
+    cost_mult[:] = 1.0
+    cost_mult.loc[entry_mask] *= (1.0 - fee) / (1.0 + slip)
+    cost_mult.loc[exit_mask] *= (1.0 - fee) * (1.0 - slip)
+
+    net_return = ((1.0 + gross_return) * cost_mult) - 1.0
     return ExecutionResult(pos=position, gross=gross_return, net=net_return)
 ```
 

--- a/docs/Backtest.md
+++ b/docs/Backtest.md
@@ -2,13 +2,13 @@
 
 Backtest is Limen's trading-economics layer. It takes prediction outputs and asks the next question after benchmark:
 
-if we traded this signal as a simple long-only strategy, what would the return profile look like after costs?
+The layer maps a binary signal into long-only returns after fees and slippage.
 
 Limen exposes a vectorized snapshot backtest, used throughout the `Log` layer.
 
-## Where Backtest Lives
+## Where backtest lives
 
-The most common backtest outputs are:
+Backtest outputs are exposed through:
 
 - `uel.experiment_backtest_results`
 - `uel._log.experiment_backtest_results()`
@@ -28,7 +28,7 @@ and returns one summary row.
 
 ### Current assumptions
 
-The current snapshot backtest is intentionally simple and opinionated:
+The current snapshot backtest has a fixed long-flat contract:
 
 - long-only
 - direct snapshot predictions must already be binary `0/1`
@@ -46,9 +46,9 @@ The current snapshot backtest is intentionally simple and opinionated:
 - distribution columns carry p5/p50/p95; the rest are single intensive (run-length-invariant) scalars
 - return and cost outputs are basis-point scaled
 
-The fee and slippage rates default to `5.0` bps each per fill (a ~20 bps round trip) and are configured on the manifest, not on the model: `manifest.set_backtest_config(fee_bps=..., slip_bps=...)`. Each value is a fixed number or a search-param name — pass a param name to sweep cost across the search (for example `set_backtest_config(fee_bps='fee')` with `fee` in `params()`), to match a venue's costs, make cost a search dimension, or stress-test how sensitive an edge is to the cost assumption. Omitting the config keeps the 5 + 5 default, so existing experiments are unchanged.
+The fee and slippage rates default to `5.0` bps each per fill (`20.0` bps for one entry and one exit) and are configured on the manifest, not on the model: `manifest.set_backtest_config(fee_bps=5.0, slip_bps=5.0)`. Each value is a fixed number or a search-param name — pass a param name to sweep cost across the search (for example `set_backtest_config(fee_bps='fee')` with `fee` in `params()`), to match a venue's costs, make cost a search dimension, or stress-test how sensitive an edge is to the cost assumption. Omitting the config keeps the 5 + 5 default, so existing experiments are unchanged.
 
-`set_backtest_config` also takes `notional_rate` — the fraction of capital deployed while in position, in `(0, 1]` (default `1.0`, all-in; a 10% book is `notional_rate=0.1`). It scales `edge`, `pnl`, and `cost` together so the ledger reflects the account at that bet size (`drawdown` also moves with bet size, but path-dependently — it compounds against a running peak, so it is not a clean multiple of the full-size drawdown), leaves `wins_per_bar` and `trades_per_bar` untouched, and turns `inventory_per_bar` into the average deployed notional. Like the costs it is a fixed number or a search-param name, so one search can sweep bet size.
+`set_backtest_config` also takes `notional_rate` — the fraction of capital deployed while in position, in `(0, 1]` (default `1.0`, all-in; a 10% book is `notional_rate=0.1`). It scales `edge`, `pnl`, and `cost` together so the ledger reflects the account at that bet size (`drawdown` also moves with bet size, but path-dependently — it compounds against a running peak, so it is not a linear multiple of the full-size drawdown), leaves `wins_per_bar` and `trades_per_bar` untouched, and turns `inventory_per_bar` into the average deployed notional. Like the costs it is a fixed number or a search-param name, so one search can sweep bet size.
 
 In a YAML/CLI manifest the same configuration is a `backtest:` block under `sfd.manifest`, sibling to `target:` and `scaler:`. Each value is a fixed number or a `"{param}"` reference into `sfd.params`, mirroring how indicator and target params are swept:
 
@@ -100,8 +100,10 @@ from limen.backtest.long_flat_strategy import ExecutionResult
 
 def my_strategy(predictions, open_px, close_px, price_change, *,
                 execution_lag_bars, fee_bps, slip_bps) -> ExecutionResult:
-    ...
-    return ExecutionResult(pos=..., gross=..., net=...)
+    position = predictions.astype(float)
+    gross_return = position * price_change / open_px
+    net_return = gross_return
+    return ExecutionResult(pos=position, gross=gross_return, net=net_return)
 ```
 
 `ExecutionResult` carries three per-bar series over every bar in the window: `pos` (position held — `0`/`1` here, a deployed fraction once sizing exists), `gross` (per-bar return before costs), and `net` (per-bar return after costs). Every ledger column flows from that triple. Pass a strategy through the `strategy` argument:
@@ -114,7 +116,7 @@ The strategy owns its own signal contract — `long_flat_strategy` requires bina
 
 `backtest_snapshot` forwards only the fill-shaping kwargs (`execution_lag_bars`, `fee_bps`, `slip_bps`) to the strategy. `notional_rate` is *not* a strategy concern — it is a uniform scale on the returned triple, so `backtest_snapshot` applies it after the strategy returns, leaving the strategy contract stable as that knob (and others like it) is added.
 
-### Typical use
+### Usage
 
 ```python
 backtest = uel.experiment_backtest_results
@@ -129,9 +131,9 @@ perf = uel._log.permutation_prediction_performance(round_id=0)
 round0_backtest = backtest_snapshot(perf)
 ```
 
-Use the experiment-wide table to compare many rounds. Use the single-round snapshot when you want to study a specific permutation.
+Use the experiment-wide table to compare rounds. Use the single-round snapshot for one permutation.
 
-## Backtest Versus Benchmark
+## Backtest versus benchmark
 
 Benchmark and backtest should be read together, not treated as substitutes.
 
@@ -140,13 +142,13 @@ Benchmark and backtest should be read together, not treated as substitutes.
 
 Examples of why the layers diverge:
 
-- a signal can have decent precision but still spend too much time in market
-- a signal can separate TP and FP weakly yet still avoid the worst losses
-- a signal can score well statistically but lose most of its edge once costs are charged
+- a signal can have high precision but excessive market exposure
+- a signal can have low TP/FP separation yet still avoid the largest losses
+- a signal can score high statistically but lose edge after costs
 
 That is why Limen keeps the layers separate in both the API and the docs.
 
-## What Snapshot Backtest Does Not Try To Do
+## What snapshot backtest does not try to do
 
 The snapshot backtest is not:
 
@@ -157,8 +159,8 @@ The snapshot backtest is not:
 
 Those concerns belong downstream from Limen or in more specialized evaluation layers.
 
-## Read Next
+## Read next
 
-- Continue to [Trainer](Trainer.md) if you want to promote strong experiment rounds into reusable trained sensors.
+- Continue to [Trainer](Trainer.md) for promotion of selected experiment rounds into reusable trained sensors.
 - Continue to [Log](Log.md) for the broader post-run workflow that produces the backtest inputs.
-- Continue to [Benchmark](Benchmark.md) if you want the prediction-quality layer that should usually be inspected before the trading-economics layer.
+- Continue to [Benchmark](Benchmark.md) for the prediction-quality layer that precedes trading-economics inspection.

--- a/docs/Benchmark.md
+++ b/docs/Benchmark.md
@@ -2,15 +2,9 @@
 
 In Limen, benchmark is the prediction-quality layer between the raw experiment log and the trading backtest.
 
-It answers questions like:
+It measures signal activity, positive-class accuracy, and true-positive versus false-positive outcome separation. Benchmark comes before PnL compression so prediction quality remains visible before a trading rule is applied.
 
-- is the signal calling positives at a sensible rate?
-- when it calls positive, is it usually right?
-- do true positives look materially better than false positives on the outcome we care about?
-
-That is a different question from "does this make money under a trading rule?" Benchmark comes first so you can understand the signal before you compress everything into PnL.
-
-## Where Benchmark Lives
+## Where benchmark lives
 
 Benchmark analytics are built on top of `Log`.
 
@@ -22,7 +16,7 @@ The main surfaces are:
 
 The first two are the same analysis surfaced in two places: UEL computes the experiment-wide confusion table automatically at the end of a run.
 
-## Typical Benchmark Workflow
+## Benchmark workflow
 
 ```python
 benchmark = uel.experiment_confusion_metrics
@@ -35,7 +29,7 @@ round0 = uel._log.permutation_confusion_metrics(
 
 Use the experiment-wide table to compare rounds. Use the single-round table when one permutation deserves a closer look.
 
-## What Benchmark Measures
+## What benchmark measures
 
 The current benchmark table focuses on long-only prediction quality and outcome separation.
 
@@ -53,56 +47,52 @@ Key fields include:
 - `tp_fp_cohen_d`
 - `tp_fp_ks`
 
-When `x='price_change'`, the table is asking:
+When `x='price_change'`, the table reports the long-call rate, realized long-class accuracy, and realized price-change separation between true positives and false positives.
 
-- how often did the model call long?
-- how often was long actually the right class?
-- among the bars the model called long, how different were the true positives from the false positives on realized price change?
-
-## How To Read It
+## How to read it
 
 ### Signal rate
 
-`pred_pos_rate_pct` tells you how active the signal is. A round with strong precision but a trivially small positive rate may not be operationally interesting.
+`pred_pos_rate_pct` reports signal activity. High precision with a low positive rate can leave too few candidate bars for downstream use.
 
 ### Precision and recall
 
-- `precision_pct` asks: when the model predicted positive, how often was it right?
-- `recall_pct` asks: when the true class was positive, how often did the model catch it?
+- `precision_pct` is the share of predicted positives that were true positives.
+- `recall_pct` is the share of actual positives captured by the model.
 
-You usually want to interpret these together. High precision with very low recall means a selective signal. High recall with weak precision means a noisy signal.
+Interpret precision and recall together. High precision with low recall means a selective signal. High recall with low precision means a noisy signal.
 
 ### TP versus FP quality
 
-The most useful part of Limen's benchmark layer is that it does not stop at precision and recall.
+Limen's benchmark layer extends precision and recall with outcome-separation metrics.
 
 - `tp_x_mean` and `tp_x_median` describe the chosen outcome inside true positives
 - `fp_x_mean` and `fp_x_median` do the same for false positives
 - `tp_fp_cohen_d` and `tp_fp_ks` estimate how separated those two distributions are
 
-If TP and FP are not meaningfully separated on the outcome you care about, a round may be statistically correct without being especially useful.
+If TP and FP are not separated on the chosen outcome, a round can be statistically correct while adding little downstream signal value.
 
-## Benchmark Versus Backtest
+## Benchmark versus backtest
 
 Benchmark and backtest are intentionally separate:
 
 - benchmark asks whether the signal has predictive structure
 - backtest asks whether that structure survives a concrete long-only trading rule with costs
 
-This separation matters because the layers often disagree.
+This separation matters because the layers can disagree.
 
 Common cases:
 
-- a round can have attractive benchmark metrics but weak trading economics
-- a round can have modest benchmark metrics yet produce decent backtest behavior because of position profile and cost structure
+- a round can have high benchmark metrics but low trading economics
+- a round can have modest benchmark metrics yet produce usable backtest behavior because of position profile and cost structure
 
-That is why Limen exposes both layers instead of forcing you to choose a single score too early.
+Limen exposes both layers so one score does not hide either prediction quality or trading economics.
 
 ## Choosing `x`
 
 `permutation_confusion_metrics()` and `experiment_confusion_metrics()` work on a chosen column `x`.
 
-The most common choice is:
+The default analysis column is:
 
 ```python
 'price_change'
@@ -110,18 +100,18 @@ The most common choice is:
 
 because it is available in the reconstructed prediction-performance table and gives a straightforward economic interpretation.
 
-You can use other numeric columns when they exist in the reconstructed round table and match the question you are asking.
+Other numeric columns are valid when they exist in the reconstructed round table and match the analysis question.
 
-## Outlier Handling
+## Outlier handling
 
 Single-round confusion summaries support outlier handling through:
 
 - `outlier_quantiles=(lo, hi)`
 - `outlier_mode='filter'` or `'winsor'`
 
-This is useful when a few extreme outcome values would otherwise dominate the TP/FP comparison.
+This protects the TP/FP comparison from domination by extreme outcome values.
 
-## Read Next
+## Read next
 
-- Continue to [Backtest](Backtest.md) to see how benchmark-quality signals translate into simple trading economics.
+- Continue to [Backtest](Backtest.md) to see how benchmark-quality signals translate into long-only trading economics.
 - Continue to [Log](Log.md) for the broader post-run workflow around benchmark, backtest, and parameter correlation.

--- a/docs/Built-In-SFDs.md
+++ b/docs/Built-In-SFDs.md
@@ -1,24 +1,24 @@
-# Built-In SFDs
+# Built-in SFDs
 
-Limen ships a small set of foundational SFDs under `limen.sfd.foundational_sfd`. These are the packaged decoders you can run immediately without authoring your own experiment module first.
+Limen ships foundational SFDs under `limen.sfd.foundational_sfd`. These packaged decoders run without a custom experiment module.
 
-They are the fastest way to learn how Limen is shaped in practice because each one already combines:
+They show the packaged Limen experiment shape because each one combines:
 
 - `params()`
 - `manifest()`
 - a matching reference-architecture model surface
 
-## The Current Catalog
+## The current catalog
 
 | SFD | Task shape | Notes |
 |---|---|---|
-| `logreg_binary` | binary classification | the main manifest-driven logistic-regression reference flow |
+| `logreg_binary` | binary classification | canonical manifest-driven logistic-regression reference flow |
 | `lightgbm_binary` | binary classification | the tradeline long-binary experiment: line-geometry features, train-fitted breakout target, LightGBM classifier |
-| `random_binary` | binary classification baseline | useful for sanity checks and control comparisons |
+| `random_binary` | binary classification baseline | sanity-check and control-comparison flow |
 | `xgboost_regressor` | regression | tree-based regression workflow |
 | `tabpfn_binary` | binary classification | optional, available only when `tabpfn` is installed |
 
-## Foundational SFD Versus Reference Architecture
+## Foundational SFD versus reference architecture
 
 Each built-in SFD has a matching model module in [Reference Architecture](Reference-Architecture.md).
 
@@ -29,7 +29,7 @@ The split is:
 | foundational SFD | search space plus manifest pipeline |
 | reference architecture | class-based model contract and function wrapper |
 
-So, for example:
+For the logistic-regression SFD:
 
 - `limen.sfd.foundational_sfd.logreg_binary` owns the packaged experiment
 - `limen.sfd.reference_architecture.logreg_binary` owns the model implementation
@@ -40,7 +40,7 @@ This separation is what lets [Trainer](Trainer.md) reconstruct a finished experi
 
 `logreg_binary` is the standard manifest-driven binary classifier in the package.
 
-It currently combines:
+It combines:
 
 - indicators such as `roc`, `atr`, `ppo`, and `wilder_rsi`
 - features such as `vwap` and `kline_imbalance`
@@ -51,7 +51,7 @@ It currently combines:
 
 The classifier parameter surface mirrors the sklearn `LogisticRegression` constructor through manifest params: `solver`, `penalty`, `dual`, `tol`, `C`, `fit_intercept`, `intercept_scaling`, `class_weight`, `random_state`, `max_iter`, `multi_class`, `verbose`, `warm_start`, `n_jobs`, and `l1_ratio`.
 
-The calibration search space includes `use_calibration`, `use_threshold`, `cal_method`, `threshold_min`, `threshold_max`, and `threshold_step`, giving a full grid of calibration modes within a single experiment run.
+The calibration search space includes `use_calibration`, `use_threshold`, `cal_method`, `threshold_min`, `threshold_max`, and `threshold_step`, creating a grid of calibration modes within a single experiment run.
 
 On a live local smoke run over the bundled test dataset in this repo, it prepared:
 
@@ -62,7 +62,7 @@ On a live local smoke run over the bundled test dataset in this repo, it prepare
 
 `lightgbm_binary` is the tradeline long-binary experiment: the line-geometry research track packaged on Limen rails.
 
-It currently combines:
+It combines:
 
 - the grouped line transforms `price_lines` and `quantile_price_lines` with swept geometry (`max_duration_hours`, `min_height_pct`, `quantile_threshold`)
 - context from `roc`, `distance_from_high`/`distance_from_low`/`price_range_position`, `parkinson_volatility`/`volatility_ratio`, and `cyclical_time_features`
@@ -76,13 +76,7 @@ The matching YAML template is `limen/yaml/templates/lightgbm_binary.yaml` (`lime
 
 ## `random_binary`
 
-`random_binary` is the baseline binary classifier. It is deliberately simple and deliberately stochastic.
-
-Use it when you want:
-
-- a control run
-- a smoke-test decoder
-- a deliberately weak comparison point
+`random_binary` is the baseline binary classifier. It is stochastic and intended for control runs, smoke tests, and low-skill comparison points.
 
 On a live local smoke run in this repo, it prepared:
 
@@ -95,7 +89,7 @@ Because it is stochastic, it is a poor fit for deterministic reconstruction in [
 
 `xgboost_regressor` is the regression-oriented foundational SFD.
 
-Use it when the target is better treated as continuous rather than binary.
+Use this SFD for continuous targets rather than binary targets.
 
 On a live local smoke run in this repo, it prepared:
 
@@ -112,9 +106,9 @@ It uses `CalibrationBuilder` with the same probability calibration and threshold
 
 That optional status matters at import time and in local documentation examples. In a live local smoke pass in this repo, it was unavailable because `tabpfn` was not installed.
 
-## Running One Immediately
+## Running one immediately
 
-The simplest way to use a built-in SFD is:
+A built-in SFD can run with only `sfd=`:
 
 ```python
 import limen
@@ -130,17 +124,17 @@ uel.run(
 )
 ```
 
-If you omit `data=`, the manifest fetches data using `fetch_data()`. Pass `test_mode=True` to UEL to use the test data source instead.
+When `data=` is omitted, the manifest fetches data using `fetch_data()`. Passing `test_mode=True` to UEL uses the test data source instead.
 
-## How To Choose
+## How to choose
 
-- Choose `logreg_binary` when you want the clearest canonical Limen path.
-- Choose `random_binary` when you want a baseline or smoke-test decoder.
-- Choose `xgboost_regressor` when the target is continuous and tree-based regression is the better fit.
-- Choose `tabpfn_binary` only when that dependency is installed and you specifically want the TabPFN workflow.
+- Choose `logreg_binary` for the canonical Limen path.
+- Choose `random_binary` for a baseline or smoke-test decoder.
+- Choose `xgboost_regressor` for continuous targets that should use tree-based regression.
+- Choose `tabpfn_binary` only when that dependency is installed and the TabPFN workflow is required.
 
-## Read Next
+## Read next
 
 - Continue to [Single-File Decoder](Single-File-Decoder.md) for the general SFD contract.
 - Continue to [Reference Architecture](Reference-Architecture.md) for the class-based model layer underneath these built-in decoders.
-- Continue to [Experiment Manifest](Experiment-Manifest.md) if you want to adapt one of these into your own custom SFD.
+- Continue to [Experiment Manifest](Experiment-Manifest.md) to adapt one of these into a custom SFD.

--- a/docs/Calibration.md
+++ b/docs/Calibration.md
@@ -1,12 +1,12 @@
 # Calibration
 
-Calibration controls two things that raw model output typically gets wrong: the reliability of predicted probabilities, and where the decision boundary sits. Limen's calibration layer is declarative — it is configured on the manifest and injected automatically into each experiment round.
+Calibration controls two model-output surfaces: the reliability of predicted probabilities, and where the decision boundary sits. Limen's calibration layer is declarative — it is configured on the manifest and injected automatically into each experiment round.
 
 ## What Calibration Does
 
-Binary classifiers return raw probabilities, but those probabilities are rarely well-calibrated. A model that says 0.7 rarely means there is a 70% chance the positive class is correct. Probability calibration fits a post-hoc correction on a held-out validation set so the output probabilities better reflect actual class frequencies.
+Binary classifiers return raw probabilities, but raw probabilities can be miscalibrated. A model output of `0.7` is not automatically a calibrated `70%` positive-class probability. Probability calibration fits a post-hoc correction on a held-out validation set so the output probabilities align with actual class frequencies.
 
-Threshold optimization solves a different problem. The default decision boundary at 0.5 is rarely optimal when the metric you care about is not symmetric — for example, when recall and precision have unequal importance. Limen's `grid_threshold_optimizer` sweeps a range of candidate thresholds, scores each one with a chosen metric, and selects the best.
+Threshold optimization solves a different problem. The default decision boundary at `0.5` can be suboptimal when the target metric is asymmetric, such as when recall and precision have unequal importance. Limen's `grid_threshold_optimizer` sweeps a range of candidate thresholds, scores each one with a chosen metric, and selects the highest-scoring candidate.
 
 The two steps are independent and can be used together or separately.
 
@@ -29,18 +29,30 @@ The minimum setup: add `with_calibration()` to the manifest.
 
 ```python
 from limen.calibration import grid_threshold_optimizer, sklearn_probability_calibrator
-from limen.experiment import MLManifest
+from limen.data import HistoricalData
+from limen.experiment import Manifest, MLManifest
+from limen.indicators import roc
 from limen.metrics.balanced_metric import balanced_metric
+from limen.scalers import LogRegScaler
 from limen.sfd.reference_architecture import logreg_binary
+from limen.targets import QuantileBinaryTarget
 
-def manifest():
+def manifest() -> Manifest:
     return (
         MLManifest()
-        .set_data_source(...)
+        .set_data_source(
+            method=HistoricalData.get_spot_klines,
+            params={'kline_size': 3600, 'row_count_limit': 5000},
+        )
         .set_split_config(8, 1, 2)
-        .add_indicator(...)
-        .with_target_label(...)
-        .set_scaler(...)
+        .add_indicator(roc, period=14)
+        .with_target_label(
+            'quantile_flag',
+            QuantileBinaryTarget,
+            fit_params={'source_column': 'roc_14', 'quantile': 0.40},
+            transform_params={'shift': -1},
+        )
+        .set_scaler(LogRegScaler)
         .with_reference_architecture(logreg_binary)
         .with_calibration()
         .probability_calibration(func=sklearn_probability_calibrator, method='isotonic')
@@ -53,11 +65,11 @@ def manifest():
 
 `sklearn_probability_calibrator` wraps sklearn's `CalibratedClassifierCV` with `FrozenEstimator` to avoid the deprecation that came with sklearn 1.6. It accepts `method='isotonic'` (default) or `method='sigmoid'`.
 
-`grid_threshold_optimizer` sweeps a bounded range of thresholds, scores each with the chosen metric, and returns the best one. `balanced_metric` is Limen's built-in `precision * sqrt(trade_rate)` score, which balances signal quality with trade frequency — appropriate when both accuracy and trading activity matter.
+`grid_threshold_optimizer` sweeps a bounded range of thresholds, scores each with the chosen metric, and returns the highest-scoring threshold. `balanced_metric` is Limen's built-in `precision * sqrt(trade_rate)` score, which balances signal quality with trade frequency — appropriate when both accuracy and trading activity matter.
 
 ## Threshold-Only Path
 
-If you want threshold optimization without probability recalibration, call `threshold_function()` only:
+`threshold_function()` configures threshold optimization without probability recalibration. In an existing manifest chain, the calibration fragment is:
 
 ```python
 .with_calibration()
@@ -80,10 +92,23 @@ def params():
         'threshold_step':  [0.05, 0.10],
     }
 
-def manifest():
+def manifest() -> Manifest:
     return (
         MLManifest()
-        ...
+        .set_data_source(
+            method=HistoricalData.get_spot_klines,
+            params={'kline_size': 3600, 'row_count_limit': 5000},
+        )
+        .set_split_config(8, 1, 2)
+        .add_indicator(roc, period=14)
+        .with_target_label(
+            'quantile_flag',
+            QuantileBinaryTarget,
+            fit_params={'source_column': 'roc_14', 'quantile': 0.40},
+            transform_params={'shift': -1},
+        )
+        .set_scaler(LogRegScaler)
+        .with_reference_architecture(logreg_binary)
         .with_calibration()
         .probability_calibration(func=sklearn_probability_calibrator, method='cal_method')
         .threshold_function(
@@ -110,11 +135,10 @@ def params():
     return {
         'use_calibration': [True, False],
         'use_threshold':   [True, False],
-        ...
     }
 ```
 
-All four modes produce comparable metrics in the same experiment log, so you can evaluate the effect of each step directly from the results.
+All four modes produce comparable metrics in the same experiment log, so each step's effect is visible directly from the results.
 
 ## Custom Calibrators and Optimizers
 
@@ -123,28 +147,22 @@ The calibration layer is protocol-based. Any function that matches the expected 
 **Calibrator protocol** — `(clf, x_val, y_val, **params) -> fitted model with predict_proba()`:
 
 ```python
-from limen.calibration import CalibratorProtocol
-
-def my_calibrator(clf, x_val, y_val, **params):
-    # fit and return anything with predict_proba()
-    ...
-
-.probability_calibration(func=my_calibrator)
+def passthrough_calibrator(clf, x_val, y_val, **params):
+    return clf
 ```
+
+Pass `passthrough_calibrator` as the `func=` value in `probability_calibration()`.
 
 **Threshold optimizer protocol** — `(y_val, val_proba, **params) -> tuple[float, float]`:
 
 ```python
-from limen.calibration import ThresholdOptimizerProtocol
-
-def my_optimizer(y_val, val_proba, **params) -> tuple[float, float]:
-    # return (best_threshold, best_score)
-    ...
-
-.threshold_function(func=my_optimizer)
+def fixed_threshold_optimizer(y_val, val_proba, **params) -> tuple[float, float]:
+    return 0.5, 0.0
 ```
 
-The two protocols are independent. You can mix Limen's built-in calibrator with a custom optimizer, or vice versa.
+Pass `fixed_threshold_optimizer` as the `func=` value in `threshold_function()`.
+
+The two protocols are independent. Limen's built-in calibrator can be paired with a custom optimizer, and a custom calibrator can be paired with Limen's built-in optimizer.
 
 ## What Gets Added to Results
 
@@ -177,7 +195,7 @@ The optimizer returns the `default_threshold` with score `0.0` when every candid
 
 When a calibrated model is promoted to a `Sensor`, the calibrator is fitted once during training evaluation (on validation data) and stored inside the model instance. Subsequent `predict()` calls — including all sensor inference calls — reuse the stored calibrator without needing `x_val` or `y_val`. Calibrated sensors therefore work identically to uncalibrated ones from the caller's perspective: pass `x_test`, receive predictions.
 
-`fit_calibrator` is the low-level function that encapsulates this fit step. It is called internally by `LogRegBinary.predict()` and `TabPFNBinary.predict()` on first use, and is also available as a public API if you need to fit a calibrator outside the standard pipeline.
+`fit_calibrator` is the low-level function that encapsulates this fit step. It is called internally by `LogRegBinary.predict()` and `TabPFNBinary.predict()` on first use, and is also available as a public API for calibrator fitting outside the standard pipeline.
 
 ## Where To Look
 

--- a/docs/Cohort.md
+++ b/docs/Cohort.md
@@ -2,44 +2,44 @@
 
 `Cohort` is Limen's inference-time ensemble surface for combining multiple trained sensors reconstructed from one completed experiment.
 
-Use it when you want to move from single-round predictions to a controlled multi-member prediction surface while staying inside Limen artefacts (`metadata.json`, `round_data.jsonl`, Trainer-reconstructed sensors).
+`Cohort` moves single-round predictions into a controlled multi-member prediction surface while staying inside Limen artefacts (`metadata.json`, `round_data.jsonl`, Trainer-reconstructed sensors).
 
-## What This Page Covers
+## What this page covers
 
 - what a Cohort is and where it sits in the Limen workflow
 - construction and validation rules
 - selector contract and built-in selectors
 - aggregation behavior (probability-weighted vs fallback majority vote)
-- output contracts for `predict(...)` and `predict_all(...)`
+- output contracts for `predict(raw_klines)` and `predict_all(raw_klines)`
 - a real end-to-end example from experiment artefacts
 
 ## Prerequisites
 
-Before constructing a Cohort, you need:
+A Cohort requires:
 
 1. a completed UEL experiment directory
 2. valid experiment artefacts (`metadata.json`, `round_data.jsonl`)
 3. selected permutation IDs, or a selector that chooses them
-4. trained members (typically from `Trainer.train(...)`)
+4. trained members from `Trainer.train(permutation_ids)`
 
-If you are new to this flow, read:
+Read these pages first:
 
 - [Universal Experiment Loop](Universal-Experiment-Loop.md)
 - [Trainer](Trainer.md)
 
-## Where Cohort Fits In The Pipeline
+## Where Cohort fits in the pipeline
 
-Typical path:
+Pipeline path:
 
 1. run experiment search with UEL
 2. identify permutations to promote, manually or with a selector
 3. reconstruct/train those permutations with Trainer
 4. create Cohort from experiment source + permutation IDs or selector
-5. bind trained members via `set_members(...)`
+5. bind trained members via `set_members(sensors)`
 6. infer with:
    - `predict(raw_klines)` → one `BarPrediction` for the last bar
    - `predict_all(raw_klines)` → one `BarPrediction` per bar
-   - `__call__(raw_klines)` as an alias of `predict_all(...)` → `list[BarPrediction]`
+   - `__call__(raw_klines)` as an alias of `predict_all(raw_klines)` → `list[BarPrediction]`
 
 ## Construction
 
@@ -61,10 +61,10 @@ cohort = Cohort(
 
 ### Experiment source rules
 
-You must provide exactly one source:
+Exactly one source is required:
 
-- `experiment_id=...`
-- or `experiment_log_path=...`
+- `experiment_id`
+- `experiment_log_path`
 
 Providing none or both raises `ValueError`.
 
@@ -87,7 +87,7 @@ After `set_members()`:
 
 - `cohort.cohort_id` — `'sha256:<hex>'` derived from `manifest_id` and the sorted set of `permutation_ids`
 
-## Selector Contract
+## Selector contract
 
 Selectors choose Cohort members before any training or inference work starts.
 
@@ -114,7 +114,7 @@ The selector receives:
 The selector must return permutation IDs only. Cohort still owns ID validation,
 architecture consistency, member binding, and prediction aggregation.
 
-### Single-File Cohort Selectors
+### Single-file Cohort selectors
 
 ```python
 Cohort(experiment_log_path='experiments/my_exp')
@@ -180,7 +180,7 @@ backtest columns are unavailable.
 
 All selected permutation IDs must resolve to the same architecture identifier. Mixed-architecture selection raises `ValueError`.
 
-## Binding Members
+## Binding members
 
 After construction, bind trained sensor members:
 
@@ -199,7 +199,7 @@ Each member must expose `permutation_id` for binding. `set_members()` validates 
 
 After a successful `set_members()` call, `cohort.cohort_id` is populated.
 
-## Aggregation Modes
+## Aggregation modes
 
 Aggregation mode is selected at construction based on architecture capability hints.
 For YAML CLI runs, Cohort reads `metadata.json["yaml_reference"]` to recover the
@@ -220,7 +220,7 @@ compatible with Trainer-reconstructed sensors.
 - applies strict threshold `> 0.5`
 - exact ties resolve to class `0`
 
-## Output Contracts
+## Output contracts
 
 ### `predict(raw_klines) -> BarPrediction`
 
@@ -244,7 +244,7 @@ if bar_pred.reason is None:
 | `'null-features'` | highest-priority blocking reason |
 | `'sensor-error'` | all members returned `sensor-error`; no valid prediction available |
 
-When some members return `sensor-error` but not all, those members are excluded from
+When one or more members return `sensor-error` but at least one member remains valid, failed members are excluded from
 aggregation and a warning is logged. The cohort still produces a valid prediction from
 the remaining members.
 
@@ -263,9 +263,9 @@ for bar in all_preds:
 
 ### `__call__(raw_klines)`
 
-Alias of `predict_all(raw_klines)`. Returns `list[BarPrediction]`, one entry per bar. Use this in replay loops where you want all bars from a window.
+Alias of `predict_all(raw_klines)`. Returns `list[BarPrediction]`, one entry per bar. Replay loops use this form for every bar in a window.
 
-## Real End-To-End Example
+## Real end-to-end example
 
 ```python
 import polars as pl
@@ -289,8 +289,8 @@ cohort = Cohort(
 )
 cohort.set_members(sensors)
 
-print(cohort.cohort_id)    # 'sha256:...'
-print(cohort.manifest_id)  # 'sha256:...'
+print(cohort.cohort_id.startswith('sha256:'))
+print(cohort.manifest_id.startswith('sha256:'))
 
 # 4a) predict last bar
 bar_pred = cohort.predict(raw_klines)
@@ -302,21 +302,21 @@ all_preds = cohort.predict_all(raw_klines)
 valid = [p for p in all_preds if p.reason is None]
 print(f'{len(valid)} valid bars out of {len(all_preds)}')
 
-# 4c) callable alias — same as predict_all, useful in replay loops
+# 4c) callable alias, same as predict_all
 all_preds2 = cohort(raw_klines)  # list[BarPrediction]
 ```
 
-## Failure Cases And Caveats
+## Failure cases and caveats
 
 - missing experiment artefacts (`metadata.json` / `round_data.jsonl`) raise `FileNotFoundError`
 - unresolvable or ambiguous experiment ID resolution raises `ValueError`
 - no bound members at inference raises `RuntimeError`
 - member sensor lists of different lengths raise `ValueError` in `predict_all`
 - when a member returns `sensor-error` for a bar, it is excluded from aggregation for that bar; only when all members return `sensor-error` does the cohort return `reason='sensor-error'`
-- architecture capability detection is currently hint-based; validate behavior in your target architecture set
+- architecture capability detection is currently hint-based; validate behavior for the target architecture set
 - selectors that depend on `results.csv` raise if the required columns are missing
 
-## Read Next
+## Read next
 
 - [Trainer](Trainer.md) for reconstruction and promotion flows
 - [Reference Architecture](Reference-Architecture.md) for model output conventions

--- a/docs/Command-Line-Interface.md
+++ b/docs/Command-Line-Interface.md
@@ -1,6 +1,6 @@
 # Command Line Interface
 
-The Limen CLI is the supported shell surface for YAML-first experiment work. Use it when you want validation, profiling, template scaffolding, committed manifests, resumable runs, and standard result directories without writing Python orchestration code.
+The Limen CLI is the supported shell surface for YAML-first experiment work. It provides validation, profiling, template scaffolding, committed manifests, resumable runs, and standard result directories without Python orchestration code.
 
 ## Scope
 
@@ -14,7 +14,7 @@ The CLI owns project and manifest operations around declarative YAML experiments
 | `limen profile <yaml_file>` | Estimate YAML parameter-space size without executing data or model work. | Complexity rating, parameter counts, and runtime-sampling skipped status. |
 | `limen run <yaml_file>` | Validate, compile, and execute a YAML experiment. | Results directory with `results.csv`, optional `results.parquet`, metadata, round data, and checkpoints when configured. |
 | `limen run --dry-run <yaml_file>` | Validate and compile without executing permutations. | Compile success or validation/runtime setup errors. |
-| `limen run --resume <results_dir>` | Resume an artifact-rich run from a checkpoint directory. | Updated result artifacts in the existing run directory. |
+| `limen run --resume <results_dir>` | Resume an artifact-backed run from a checkpoint directory. | Updated result artifacts in the existing run directory. |
 | `limen init <output> --template <name>` | Copy a bundled YAML template and set `metadata.name` from the output filename. | New YAML file. |
 | `limen list-templates` | List bundled YAML templates under `limen/yaml/templates`. | Template names. |
 | `limen commit <yaml_file>` | Validate, content-address, store, index, and git-commit a manifest inside a Limen project. | Committed manifest under `manifests/committed/` plus index update. |
@@ -96,7 +96,7 @@ Options:
 
 ## YAML Run Contract
 
-`limen run` accepts either a YAML file path or a committed `manifest://sha256:...` URI. The command resolves the manifest, validates it, compiles all `limen.*` references, builds the parameter search domain, and then runs UEL.
+`limen run` accepts either a YAML file path or a committed `manifest://sha256:` URI. The command resolves the manifest, validates it, compiles all `limen.*` references, builds the parameter search domain, and then runs UEL.
 
 `metadata.mode` controls the default result path:
 
@@ -110,7 +110,7 @@ Set `uel.output_format: parquet` to also write `results.parquet`. Set `uel.outpu
 
 ## Validation Boundaries
 
-`limen validate` and the validation step inside `limen run` check structure and resolvability before execution. They do not prove that custom callables are statistically useful, that a remote data source is available at run time, or that a production run is safe to promote downstream.
+`limen validate` and the validation step inside `limen run` check structure and resolvability before execution. They do not prove that custom callables have predictive value, that a remote data source is available at run time, or that a production run is valid for downstream promotion.
 
 Runtime boundaries:
 

--- a/docs/Conserved-Flux-Renormalization.md
+++ b/docs/Conserved-Flux-Renormalization.md
@@ -7,7 +7,7 @@ In practical Limen terms, CFR turns raw trades into:
 - a kline-like frame
 - plus six additional columns that describe multi-scale flow stability and entropy behavior
 
-Use CFR when you want a compact diagnostic of whether trade flow looks scale-stable or anomalous inside each bar.
+CFR provides a compact diagnostic for scale-stable or anomalous trade flow inside each bar.
 
 ## Input And Output
 
@@ -77,41 +77,41 @@ Variance of that entropy ladder across levels.
 
 ### `Δflux_rms`
 
-Root-mean-square deviation from an ideal flat flux-variability ladder.
+Root-mean-square deviation from the flat flux-variability reference ladder.
 
 Higher values mean one or more scales dominate the traded-value flow instead of the flow looking scale-stable.
 
 ### `Δentropy_rms`
 
-Root-mean-square deviation from an ideal one-bit-per-octave entropy ladder.
+Root-mean-square deviation from the one-bit-per-octave entropy reference ladder.
 
 Higher values mean trade-size diversity changes unevenly across scales.
 
-## When CFR Is Useful
+## When CFR fits
 
-Good fits:
+Suitable fits:
 
 - anomaly detection in trade flow
 - regime features for microstructure-heavy experiments
-- identifying bars where traded value is concentrated on a few scales
+- identifying bars where traded value is concentrated on a subset of scales
 - identifying bars where trade-size diversity behaves unusually
 
 Poor fits:
 
 - workflows where only OHLCV-level information is available
 - experiments that never touch raw trade data
-- cases where simpler activity features already capture the behavior you care about
+- cases where lower-dimensional activity features already capture the target behavior
 
 ## The Intuition
 
 The conserved-flux idea treats traded value as conserved "stuff." Renormalization then asks:
 
-what happens to that flow when we repeatedly zoom out in time?
+CFR measures how that flow changes under repeated time-scale aggregation.
 
 The function starts from a base window such as 60 seconds and repeatedly coarse-grains the trade stream:
 
 ```text
-60s -> 120s -> 240s -> 480s -> ...
+60s -> 120s -> 240s -> 480s
 ```
 
 At each scale it measures two things:
@@ -123,7 +123,7 @@ Instead of returning the entire multi-scale ladder, CFR compresses it into a sma
 
 ## Interpreting The Deviation Metrics
 
-The two most important anomaly-style outputs are:
+The anomaly-style outputs are:
 
 - `Δflux_rms`
 - `Δentropy_rms`
@@ -141,4 +141,4 @@ These are interpretation aids, not hard universal thresholds.
 ## Read Next
 
 - Continue to [Features](Features.md) for the broader feature layer CFR belongs to.
-- Continue to [Historical Data](Historical-Data.md) if you need the trade-data surfaces CFR expects upstream.
+- Continue to [Historical Data](Historical-Data.md) for the trade-data surfaces CFR expects upstream.

--- a/docs/Data-Bars.md
+++ b/docs/Data-Bars.md
@@ -1,10 +1,10 @@
-# Data Bars
+# Data bars
 
-Limen currently supports threshold-based bar formation over existing kline data. This is an optional preprocessing step inside a manifest: you start from regular time-based klines, then aggregate consecutive rows until a volume, trade-count, or liquidity threshold is reached.
+Limen currently supports threshold-based bar formation over existing kline data. This optional manifest preprocessing step starts from regular time-based klines, then aggregates consecutive rows until a volume, trade-count, or liquidity threshold is reached.
 
-Use bars when time-based candles are not the best surface for the behavior you want to study. Skip them when fixed-interval klines already match the rhythm of the research problem.
+Use bars when time-based candles do not match the studied behavior. Skip bars when fixed-interval klines already match the research rhythm.
 
-## Current Scope
+## Current scope
 
 The implemented bar surface today is:
 
@@ -14,23 +14,23 @@ The implemented bar surface today is:
 
 Limen does not currently expose imbalance bars, run bars, or tick bars as a supported public surface.
 
-## When Bars Help
+## When bars help
 
-Bars usually help when you want each row to represent a more comparable amount of market activity instead of a fixed amount of clock time.
+Bars help when each row should represent a comparable amount of market activity instead of a fixed amount of clock time.
 
-Typical good fits:
+Suitable fits:
 
 - high-volatility periods where fixed-time candles contain very uneven activity
-- strategies that care more about activity intensity than about wall-clock spacing
+- strategies that depend more on activity intensity than wall-clock spacing
 - research where volume or liquidity concentration matters more than elapsed time
 
-Typical poor fits:
+Unsuitable fits:
 
 - experiments where explicit time-of-day structure matters
 - workflows that depend on regular calendar spacing
 - cases where the added aggregation step makes the experiment harder to interpret than the base klines
 
-## Shared Output Schema
+## Shared output schema
 
 All supported bar functions return a `pl.DataFrame` with this shared schema:
 
@@ -48,9 +48,9 @@ All supported bar functions return a `pl.DataFrame` with this shared schema:
 | `bar_count` | number of source klines merged into the bar |
 | `base_interval` | source kline interval in seconds |
 
-Your source dataframe must already contain the columns needed to compute the chosen bar type. In practice that means using kline-style input with fields such as `volume`, `no_of_trades`, and `liquidity_sum`.
+The source dataframe must already contain the columns needed to compute the chosen bar type. Kline-style input must include fields such as `volume`, `no_of_trades`, and `liquidity_sum`.
 
-## Supported Functions
+## Supported functions
 
 ### `volume_bars(data, volume_threshold)`
 
@@ -64,7 +64,7 @@ Aggregate rows until cumulative trade count reaches `trade_threshold`.
 
 Aggregate rows until cumulative liquidity reaches `liquidity_threshold`.
 
-## Manifest Usage
+## Manifest usage
 
 Bar formation is configured through `Manifest.set_bar_formation()` and is applied separately inside each split. That matters because Limen's manifest pipeline is split-first by design.
 
@@ -112,8 +112,8 @@ def manifest():
 
 Two important details:
 
-- `bar_type` must be present in `round_params` if you want the bar step to switch between bar modes.
-- `set_required_bar_columns()` is an assertion layer. It verifies that the bar step still leaves the downstream columns your experiment needs.
+- `bar_type` must be present in `round_params` when the bar step switches between bar modes.
+- `set_required_bar_columns()` is an assertion layer. It verifies that the bar step still leaves the downstream columns required by the experiment.
 
 ## `compute_data_bars()`
 
@@ -128,7 +128,7 @@ It currently supports these `bar_type` values:
 
 `base` returns the input data unchanged. The other values dispatch to the corresponding threshold-bar function and require the matching threshold parameter.
 
-## How Bars Fit Into The Manifest Pipeline
+## How bars fit into the manifest pipeline
 
 Inside a manifest-driven experiment, the order is:
 
@@ -140,8 +140,8 @@ Inside a manifest-driven experiment, the order is:
 
 This keeps train-only fitting and test-only evaluation aligned with the actual post-bar data seen by each fold.
 
-## Read Next
+## Read next
 
-- Continue to [Single File Decoder](Single-File-Decoder.md) if you are deciding how to package the experiment.
+- Continue to [Single File Decoder](Single-File-Decoder.md) for experiment packaging.
 - Continue to [Experiment Manifest](Experiment-Manifest.md) for the full declarative pipeline that bar formation plugs into.
 - Continue to [Universal Experiment Loop](Universal-Experiment-Loop.md) to run the resulting experiment.

--- a/docs/Developer/Contributing-Foundational-SFDs.md
+++ b/docs/Developer/Contributing-Foundational-SFDs.md
@@ -1,12 +1,12 @@
-# Contributing Foundational SFDs
+# Contributing foundational SFDs
 
 This guide covers how to propose and implement a new foundational SFD in Limen.
 
-Foundational SFDs are Limen's reference-grade experiment templates. They are not one-off research scripts. A strong foundational SFD should be reusable, reviewable, and analytically valuable inside a large Limen scan.
+Foundational SFDs are Limen's reference-grade experiment templates. They are not one-off research scripts. A foundational SFD should be reusable, reviewable, and analytically justified inside a large Limen scan.
 
-## What A Foundational SFD Owns
+## What a foundational SFD owns
 
-A foundational SFD usually packages three things:
+A foundational SFD packages:
 
 - a `params()` search space
 - a manifest-driven experiment pipeline
@@ -19,20 +19,20 @@ Canonical example:
 
 The foundational SFD owns experiment design and parameter exposure. The reference architecture owns the train, predict, and evaluate logic for the model family itself.
 
-## Before You Start
+## Before work starts
 
-Do the research work first. A good foundational SFD proposal should answer:
+Do the research work first. A foundational SFD proposal should answer:
 
 - what problem or modeling thesis this SFD is meant to capture
-- why this reference architecture is the right fit
+- why this reference architecture fits the thesis
 - which indicators and features are justified
 - how the target should be constructed
 - which scaler or transform choices belong in the default design
-- which parameters are worth exposing as a real search space
+- which parameters materially affect the search space
 
-If these answers are still hand-wavy, the design is not ready.
+If these answers remain unsupported, the design is not ready.
 
-## Design Rules
+## Design rules
 
 - Keep the SFD manifest-driven.
 - Put experiment intelligence in `params()` and `manifest()`, not inside bespoke hidden code paths.
@@ -40,7 +40,7 @@ If these answers are still hand-wavy, the design is not ready.
 - If a workflow improvement is reusable, contribute it as a shared Limen building block instead of hiding it inside one SFD.
 - Expose only meaningful search dimensions. A parameter that does not materially change the experiment should not be in `params()`.
 
-## Contribution Surface
+## Contribution surface
 
 A foundational SFD may compose these existing Limen building blocks:
 
@@ -58,18 +58,20 @@ If a needed building block does not exist yet, add it in the right package first
 - `limen.data` for retrieval or bar-prep logic
 - `limen.indicators` for low-level signal primitives
 - `limen.features` for derived signals and target helpers
-- `limen.transforms` for lightweight transform helpers
+- `limen.transforms` for stateless transform helpers
 - `limen.scalers` for train-fitted preprocessing
 
-## Gold-Standard Shape
+## Reference shape
 
-A strong foundational SFD should look roughly like this:
+A foundational SFD can follow this concrete shape:
 
 ```python
 from limen.data import HistoricalData
 from limen.experiment import Manifest
 from limen.experiment import MLManifest
-from limen.sfd.reference_architecture import your_model
+from limen.indicators import roc
+from limen.sfd.reference_architecture import logreg_binary
+from limen.targets import QuantileBinaryTarget
 
 
 def params():
@@ -92,28 +94,32 @@ def manifest() -> Manifest:
             params={'kline_size': 7200, 'row_count_limit': 5000},
         )
         .set_split_config(8, 1, 2)
-        .add_indicator(...)
-        .add_feature(...)
-        .with_target_label(...)
+        .add_indicator(roc, period='lookback')
+        .with_target_label(
+            'quantile_flag',
+            QuantileBinaryTarget,
+            fit_params={'source_column': 'roc_{lookback}', 'quantile': 0.40},
+            transform_params={'shift': -1},
+        )
         .set_scaler_from_params('scaler_type')
-        .with_reference_architecture(your_model)
+        .with_reference_architecture(logreg_binary)
     )
 ```
 
 The return type is always `Manifest` (the base class) even though the body constructs `MLManifest`. This keeps the interface uniform across all foundational SFDs. For rule-based SFDs, use `RuleBasedManifest` instead — it provides `with_strategy()` and does not expose scalers or ablation.
 
-That is not the only valid shape, but it captures the important properties:
+That shape captures the required properties:
 
 - split-first manifest execution
 - explicit parameter exposure
 - reusable shared building blocks
 - no hidden manual glue
 
-## Review Checklist
+## Review checklist
 
-Before calling a foundational SFD ready for review, check all of the following:
+Before review, check all of the following:
 
-- the thesis is clear and literature-backed or otherwise strongly justified
+- the thesis is explicit and literature-backed or otherwise justified
 - `params()` exposes real search dimensions
 - the manifest is readable and uses shared Limen primitives where possible
 - target construction is split-safe
@@ -122,7 +128,7 @@ Before calling a foundational SFD ready for review, check all of the following:
 - docs and docstrings are updated for any new public helpers added along the way
 - the SFD can run inside Limen without custom manual intervention
 
-## Anti-Patterns
+## Anti-patterns
 
 Avoid these:
 
@@ -130,11 +136,11 @@ Avoid these:
 - turning every implementation detail into a parameter
 - mixing model-family logic into the foundational SFD when it belongs in the reference architecture
 - introducing a new helper in an arbitrary location just because the SFD needs it once
-- writing the SFD around a one-off dataset or private workflow assumption
+- writing the SFD for a one-off dataset or private workflow assumption
 
 ## Deliverables
 
-For a serious foundational SFD contribution, expect to provide:
+A foundational SFD contribution includes:
 
 - a short research thesis or rationale
 - the foundational SFD file
@@ -142,7 +148,7 @@ For a serious foundational SFD contribution, expect to provide:
 - updated docs for any new public surfaces
 - tests or validation appropriate to the added behavior
 
-## Read Next
+## Read next
 
 - [Experiment Manifest](../Experiment-Manifest.md)
 - [Single File Decoder](../Single-File-Decoder.md)

--- a/docs/Developer/Documentation-System.md
+++ b/docs/Developer/Documentation-System.md
@@ -4,14 +4,14 @@
 
 This page defines how Limen documentation should be structured, written, built, and improved. It is the operating contract for the docs overhaul and the reference point for every later documentation change.
 
-The goal is not only to make individual pages better. The goal is to make Limen documentation behave like one coherent product.
+The goal is not only page-level correctness. The goal is one coherent Limen documentation product.
 
 ## What 10/10 Means
 
 For Limen, 10/10 docs means the full system is:
 
 - accurate to the code and current Vaquum architecture
-- easy to enter for a new user
+- direct entry path for a new user
 - deep enough for serious research and contributor work
 - coherent across product pages, reference pages, and package READMEs
 - grounded in real runnable workflows and real artefacts
@@ -41,7 +41,7 @@ The long-term target is `docs.vaquum.fi` as the Vaquum documentation entry point
 
 ## Canonical Source Rules
 
-Limen documentation should have one clear ownership model.
+Limen documentation should have one ownership model.
 
 - [README.md](../../README.md) is the product home page and first-success entry point.
 - [docs/README.md](../README.md) is the canonical public docs hub.
@@ -78,7 +78,7 @@ Every major public page should reinforce the same core Limen story:
 
 1. Limen turns Bitcoin market data into searchable signals, backtested outcomes, and decoder cohorts.
 2. Data enters through native Limen data access or external OHLC-style data.
-3. An experiment is defined through an SFD, usually manifest-driven.
+3. An experiment is defined through an SFD, manifest-driven by default.
 4. Universal Experiment Loop executes a parameter search across the chosen search space.
 5. Log, benchmark-style analytics, and backtest outputs show what happened and why.
 6. Trainer and Cohort turn finished experiment outputs into reusable downstream artefacts.
@@ -106,7 +106,7 @@ All Limen documentation should use the same register:
 - Prefer examples that show inputs, outputs, and artefacts.
 - Do not use unexplained internal jargon.
 - Do not duplicate large sections of content across pages.
-- End pages with explicit reading routes or next steps when useful.
+- End pages with explicit reading routes or next steps when they affect task completion.
 
 ## Page Types And Required Blocks
 
@@ -122,7 +122,7 @@ Required blocks:
 - what Limen is not
 - capability summary
 - first successful workflow
-- clear routes into the rest of the docs
+- explicit routes into the rest of the docs
 
 ### Docs Hub
 
@@ -260,15 +260,15 @@ The overhaul should be tracked in the following order.
 | --- | --- | --- | --- |
 | 1 | Docs System Contract | Define structure, voice, page types, ownership, navigation model, site boundary, and rewrite slices. | This contract exists, is linked from developer docs, and is accepted as the operating manual for later slices. |
 | 2 | Docs-Site Build | Add the site build, docs assembly model, product metadata, local dev/build/check commands, and navigation shell. | The Limen docs site builds locally, renders the current corpus, and enforces link integrity. |
-| 3 | Top-Level Narrative | Rewrite the product home and docs hub so Limen has one clear entry story and reading flow. | A new user can enter the docs without guessing what to read next. |
+| 3 | Top-level narrative | Rewrite the product home and docs hub so Limen has one entry story and reading flow. | A new user can enter the docs without guessing what to read next. |
 | 4 | Core Workflow Guides | Rewrite data, bars, SFD, manifest, and UEL pages as one connected workflow layer. | A reader can go from data to running an experiment using only the guide layer. |
 | 5 | Analysis And Outcomes | Rewrite log, benchmark, backtest, trainer, cohort, metrics, and CFR pages. | A reader can understand what Limen produces after a run and how to interpret it. |
 | 6 | Reference Layer | Rewrite indicators, features, transforms, and scalers as coordinated reference pages. | The large reference pages are scannable, consistent, and trusted. |
-| 7 | Developer Layer | Rewrite contributor, release, and versioning docs around current practice. | A contributor can follow the maintenance workflow without external tribal knowledge. |
+| 7 | Developer layer | Rewrite contributor, release, and versioning docs for current practice. | A contributor can follow the maintenance workflow without external tribal knowledge. |
 | 8 | Package README Alignment | Align package READMEs with the same contract and route them to canonical docs. | Package READMEs feel like part of one system rather than isolated notes. |
-| 9 | Final Cohesion Pass | Sweep the entire corpus for terminology, duplication, examples, links, navigation, and consistency. | The docs read as one coherent product and meet the 10/10 acceptance bar. |
+| 9 | Final cohesion pass | Sweep the entire corpus for terminology, duplication, examples, links, navigation, and consistency. | The docs read as one coherent product and meet the acceptance bar. |
 
-## Acceptance Bar For The Whole Overhaul
+## Acceptance bar for the overhaul
 
 The overhaul should be considered complete when all of the following are true:
 
@@ -276,7 +276,7 @@ The overhaul should be considered complete when all of the following are true:
 - a serious user can understand how Limen fits into the broader Vaquum architecture
 - a contributor can find the canonical page for any subsystem quickly
 - examples are grounded in real Limen runs and artefacts
-- large reference pages are easy to navigate and trustworthy
+- large reference pages have explicit navigation and code-true claims
 - the standalone Limen docs site feels complete
 - the same docs system can later plug into a Vaquum-wide docs portal without conceptual rework
 

--- a/docs/Developer/Pruning-Strategies.md
+++ b/docs/Developer/Pruning-Strategies.md
@@ -37,7 +37,7 @@ FeedbackController.trigger()
   │      → returns list of intervention dicts
   │
   ├─ Dispatch each intervention to MSQ
-  │    (remove_is, remove_ge, keep_between, trim, inject, ...)
+  │    (remove_is, remove_ge, keep_between, trim, inject, inject_value)
   │
   ├─ Notify SearchStrategy of changes
   │
@@ -76,7 +76,7 @@ All reducers return intervention dicts with an `op` key. Available operations:
 
 ### 3.1 Sanity Reducer
 
-**Signal dimension:** Validity — is the combination physically viable?
+**Signal dimension:** Validity — combination violates feasibility constraints.
 
 **Trigger:** A completed permutation produces NaN results or other failure
 indicators.
@@ -113,7 +113,7 @@ pruning_strategies:
 ### 3.2 Correlation Reducer
 
 **Signal dimension:** Trend — is a parameter value consistently associated
-with poor performance?
+with low metric values
 
 **Trigger:** Sufficient observations accumulated to compute reliable
 correlations.
@@ -147,14 +147,14 @@ pruning_strategies:
 2. Compute bootstrap correlations between each parameter and the target metric
 3. If `|correlation| < prune_threshold` and
    `sign_stability > sign_stability_threshold`, the parameter is low-impact —
-   fix to its best-performing value via `keep_is`
+   fix to its highest-performing value via `keep_is`
 
 ---
 
 ### 3.3 Saturation Reducer
 
 **Signal dimension:** Variance — is continued sampling yielding new
-information?
+information deficit
 
 **Trigger:** A parameter value's result variance drops below threshold.
 
@@ -187,13 +187,13 @@ pruning_strategies:
 2. Compute coefficient of variation: `CV = std / mean`
 3. If `CV < cv_threshold` and `samples >= min_samples_per_value`, the value
    is saturated — remove `(1 - retain_fraction)` of its pending combinations
-4. `retain_fraction` keeps a small sample for continued monitoring
+4. `retain_fraction` keeps a bounded sample for continued monitoring
 
 ---
 
 ### 3.4 Focus Reducer
 
-**Signal dimension:** Local optimality — has a breakthrough been found?
+**Signal dimension:** Local optimality — metric crosses the configured breakthrough threshold.
 
 **Trigger:** A permutation result crosses `breakthrough_threshold`, switching
 from exploration to exploitation.
@@ -239,7 +239,7 @@ pruning_strategies:
 
 ### 3.5 Budget Reducer
 
-**Signal dimension:** Resource — can we afford to continue at this rate?
+**Signal dimension:** Resource — projected resource use exceeds the configured budget.
 
 **Trigger:** Elapsed time or completed permutations approach configured limits.
 
@@ -393,7 +393,7 @@ When multiple reducers run together:
 
 | Asset | Location | Purpose |
 |---|---|---|
-| `StubPruningStrategy` | `tests/stubs/stubs.py` | Configurable mock returning preset interventions |
+| `StubPruningStrategy` | `tests/stubs/stubs.py` | Configurable test double returning preset interventions |
 | `StubStrategy` | `tests/stubs/stubs.py` | Stub `SearchStrategy` for MSQ construction |
 | `make_msq()` | `tests/stubs/stubs.py` | Create MSQ with configurable params for testing |
 | `random_binary` SFD | `limen/sfd/foundational_sfd/` | Produces real Log data with metrics |
@@ -435,7 +435,7 @@ A `make_log()` test helper producing controlled `pl.DataFrame` with:
 - Verify variation injection when `inject_variations` is enabled
 
 **Budget Reducer**
-- Mock time progression; verify `trim` fires when projected over budget
+- Simulate time progression; verify `trim` fires when projected over budget
 - Verify `check_after_pct` gate: no action before threshold
 - Verify both trim strategies (`random`, `worst_first`)
 

--- a/docs/Developer/README.md
+++ b/docs/Developer/README.md
@@ -1,20 +1,20 @@
-# Developer Home
+# Developer home
 
-This is the starting point for contributing to Limen itself. Use it to find the right maintenance path before you change code, docs, or release metadata.
+This page routes Limen contribution work to the matching maintenance path before code, docs, or release metadata changes.
 
-For cross-product Vaquum process and organization-wide norms, see the external [Vaquum Developer Docs](https://dev-docs.vaquum.fi/#/). Release process and versioning guidance now also live there. Use the pages below for Limen-specific contribution and maintenance rules that still belong in this repo.
+For cross-product Vaquum process and organization-wide norms, see the external [Vaquum Developer Docs](https://dev-docs.vaquum.fi/#/). Release process and versioning guidance now also live there. The pages below cover Limen-specific contribution and maintenance rules that still belong in this repo.
 
-## Read This First
+## Read this first
 
 Before opening or updating a Limen PR:
 
-- read the relevant Limen page for the task you are doing
+- read the relevant Limen page for the task
 - check the repo PR template and satisfy every applicable item
 - update docs, changelog, tests, and version metadata when the change requires it
 
-## Route By Task
+## Route by task
 
-| If you are doing this | Read this next | Why |
+| Task | Read this next | Why |
 |---|---|---|
 | changing docs structure, navigation, or page roles | [Documentation System Contract](Documentation-System.md) | Defines the docs architecture, page types, site model, and rewrite rules. |
 | updating reducer behavior | [Pruning Strategies](Pruning-Strategies.md) | Defines reducer semantics, YAML shape, testing, and failure modes. |
@@ -24,29 +24,29 @@ Before opening or updating a Limen PR:
 | deciding how to bump the version | [Semantic Versioning](https://github.com/Vaquum/dev-docs/blob/main/src/Semantic-Versioning.md) | Uses the shared Vaquum versioning guidance rather than a repo-local copy. |
 | assessing recorded known risk | [Technical Debt](../TechnicalDebt.md) | Tracks accepted debt, trigger conditions, and candidate remedies. |
 
-## Common Contributor Workflow
+## Contributor workflow
 
 1. Understand the affected subsystem and read the canonical page for it.
 2. Make the code change, doc change, or release metadata change together when they belong together.
 3. Run the relevant validation locally.
-4. Review the full GitHub diff yourself before requesting review.
-5. Make sure the PR template items are genuinely true, not just checked.
+4. Review the full GitHub diff before requesting review.
+5. Confirm the PR template items are true, not just checked.
 
-## Test Runtime Budget
+## Test runtime budget
 
 - `PR Validation` now publishes a `test-runtime-profile` artifact from the canonical `python -m coverage run -m tests.run` path.
 - `PR Checks Runtime` enforces the suite ceiling committed in `tests/runtime_budget.json`.
 - Update `tests/runtime_budget.json` only when recent green `main` CI runs show a real new baseline, and keep that evidence in the linked issue or PR.
 - Do not raise the budget to absorb avoidable slow tests; everything executed through `tests/run.py` is timed automatically.
 
-## Scope Notes
+## Scope notes
 
 - `/docs` is the canonical public docs layer.
 - `/docs/Developer` is the canonical Limen contributor layer.
 - package `README`s under `/limen` are orientation pages, not the main contributor process docs.
 - release and versioning policy lives in the shared Vaquum developer docs; Limen pages record local release surfaces, automation inputs, and review notes.
 
-## Read Next
+## Read next
 
 - [Documentation System Contract](Documentation-System.md)
 - [Pruning Strategies](Pruning-Strategies.md)

--- a/docs/Developer/Writing-Docstrings.md
+++ b/docs/Developer/Writing-Docstrings.md
@@ -1,12 +1,12 @@
-# Writing Docstrings
+# Writing docstrings
 
 This page defines Limen's current docstring expectations for public code.
 
-Use it when you add or change a public function, class, or method. The goal is not decorative docstrings. The goal is code-true guidance that saves future contributors and users from reading the implementation to answer basic questions.
+This page applies when a public function, class, or method changes. The goal is code-true guidance that lets future contributors and users answer basic questions without opening the implementation.
 
-## When A Docstring Is Required
+## When a docstring is required
 
-Update or add a docstring when you change:
+Update or add a docstring when a change touches:
 
 - a public function
 - a public class
@@ -15,7 +15,7 @@ Update or add a docstring when you change:
 
 If behavior changed, the docstring should change with it.
 
-## House Style
+## House style
 
 Follow the style already used across Limen:
 
@@ -41,17 +41,17 @@ Current expectations:
 - document return behavior under `Returns:`
 - keep the wording direct and concrete
 
-## What Good Docstrings Include
+## What docstrings include
 
-A strong Limen docstring should answer:
+A Limen docstring should answer:
 
 - what the function or class does
 - what inputs it expects
 - what it returns or mutates
 - what columns it adds or requires when the surface is DataFrame-based
-- any important caveat a caller needs to know
+- caveats that affect caller behavior
 
-## What To Avoid
+## What to avoid
 
 - repeating the function name without adding meaning
 - documenting obvious assignments line by line
@@ -59,25 +59,20 @@ A strong Limen docstring should answer:
 - describing future intended behavior as if it already exists
 - hiding important side effects such as overwriting a column or depending on train-fitted state
 
-## DataFrame-Specific Guidance
+## DataFrame-specific guidance
 
-Much of Limen's public surface is Polars-based. For those functions, docstrings should be especially clear about:
+Much of Limen's public surface is Polars-based. For those functions, docstrings should specify:
 
 - required input columns
 - output column names or naming patterns
 - whether rows are filtered, appended, or only transformed
 - whether the helper is stateless or fitted on train data
 
-## Review Standard
+## Review standard
 
-When reviewing a docstring, ask:
+Docstring review checks that the text remains true after the change, names the relevant columns, params, or artifacts, and gives callers enough information without opening the implementation.
 
-- is it still true after this change
-- could a caller understand the surface without opening the implementation
-- does it name the important columns, params, or artifacts
-- is it concise enough to stay readable
-
-## Read Next
+## Read next
 
 - [Developer Home](README.md)
 - [Documentation System Contract](Documentation-System.md)

--- a/docs/Experiment-Manifest.md
+++ b/docs/Experiment-Manifest.md
@@ -646,8 +646,17 @@ The model function must accept the prepared `data_dict` as its first argument.
 All remaining parameters are auto-mapped from `round_params` by signature inspection. For a model function with this signature:
 
 ```python
+from limen.sfd.reference_architecture.logreg_binary import LogRegBinary
+
 def logreg_binary(data, C=1.0, class_weight=None, max_iter=100, solver='lbfgs'):
-    return LogRegBinary().evaluate(data, inline_metrics=True, C=C, class_weight=class_weight, max_iter=max_iter, solver=solver)
+    model = LogRegBinary().train(
+        data,
+        C=C,
+        class_weight=class_weight,
+        max_iter=max_iter,
+        solver=solver,
+    )
+    return model.evaluate(data, inline_metrics=True)
 ```
 
 then manifest execution will automatically pull `C`, `class_weight`, `max_iter`, and `solver` from the current round when those keys exist in `round_params`.

--- a/docs/Experiment-Manifest.md
+++ b/docs/Experiment-Manifest.md
@@ -1,8 +1,8 @@
 # Experiment Manifest
 
-The Experiment Manifest is Limen's declarative pipeline builder. Instead of hand-writing `prep()` and threading every step yourself, you describe how data should be fetched, split, transformed, targeted, scaled, and handed to a model.
+The Experiment Manifest is Limen's declarative pipeline builder. Instead of hand-written `prep()` orchestration, the manifest describes how data is fetched, split, transformed, targeted, scaled, and handed to a model.
 
-This is the default path for Limen work because it gives you:
+This is the default path for Limen work because it provides:
 
 - split-first execution
 - train-only fitting for targets and scalers
@@ -10,7 +10,7 @@ This is the default path for Limen work because it gives you:
 - cleaner collaboration surfaces
 - reproducible experiment definitions
 
-Use a manifest when you want Limen's opinionated pipeline. Skip it only when the workflow genuinely needs fully custom `prep()` and `model()` functions.
+Use a manifest for Limen's opinionated pipeline. Use custom `prep()` and `model()` functions only when the workflow cannot fit the declarative pipeline.
 
 ## Manifest Types
 
@@ -110,7 +110,7 @@ The execution order is:
 
 This ordering is one of the main reasons to use a manifest: the leak-prevention rules come built in.
 
-The manifest is deliberately opinionated. It forces split-first execution, train-only fitting, and immutable dataframe-style transforms because those guardrails prevent the most common financial-ML mistakes.
+The manifest is deliberately opinionated. It forces split-first execution, train-only fitting, and immutable dataframe-style transforms because those guardrails prevent leakage-prone financial-ML mistakes.
 
 There is one more protection step after feature engineering: non-empty splits are aligned to a shared column set before the final `data_dict` is built. If a transform such as `fractional_diff` produces a column in one split but not another because the shorter split lacks enough history, Limen drops that extra column from the non-empty splits so the downstream model still receives a consistent schema.
 
@@ -146,7 +146,7 @@ Pass `test_mode=True` to `UniversalExperimentLoop` to fetch from the test data s
 When `test_mode=True` and a test data source is configured, `fetch_test_data()` is called; otherwise `fetch_data()` is used.
 
 That is why foundational SFDs can run locally with no explicit `data=` and still use the configured test data source.
-To keep local runs lightweight, configure `set_test_data_source()` with explicit `kline_size` and `row_count_limit`.
+To keep local runs bounded, configure `set_test_data_source()` with explicit `kline_size` and `row_count_limit`.
 
 ## Pipeline Configuration
 
@@ -189,7 +189,7 @@ Behavior rules:
 - Every bound must be a `date` or `datetime` instance. Strings, ints, and floats raise `TypeError` at the API boundary.
 - `val_predict_guard` and `test_predict_guard` are keyword-only and default `True`. They control whether the served `Sensor` masks predictions inside the val and test windows. Both `True` masks the full `[train_start, test_end)` envelope — every served prediction is identical to omitting them; setting one to `False` makes that window emit real `0/1` predictions instead of `None`, so a served cohort can be checked against its own test-split backtest. Train is always masked (the model trains on it) and has no flag. Each flag must be a `bool` or `set_split_dates` raises `TypeError`.
 - When `split_dates` is set it takes precedence over `set_split_config` in both `prepare_data` and `compute_test_bars`. The split runs on the raw data (before per-split feature transforms), so transforms can still drop rows inside a slice but cannot move rows across slice boundaries.
-- `with_params_override(split_config=...)` clears any previously-pinned `split_dates`, so the retraining override (e.g. `Trainer.train_sensors` passing `(1, 0, 0)`) is never silently shadowed by an earlier date pin.
+- `with_params_override(split_config=(1, 0, 0))` clears any previously-pinned `split_dates`, so the retraining override (e.g. `Trainer.train_sensors` passing `(1, 0, 0)`) is never silently shadowed by an earlier date pin.
 
 Use this when the train / val / test boundaries must land on specific datetimes (e.g. honouring a deployment date), and `set_split_config` when proportions of the row count are the natural way to express the split.
 
@@ -223,7 +223,7 @@ from limen.data.utils import random_slice
 )
 ```
 
-Use this when you want smaller or controlled slices of the raw dataset before the normal split-first pipeline begins.
+Use this for smaller or controlled slices of the raw dataset before the normal split-first pipeline begins.
 
 ### `set_bar_formation(func, **params)`
 
@@ -243,7 +243,7 @@ See [Data Bars](Data-Bars.md) for the supported bar types and output schema.
 
 ### `set_required_bar_columns(columns)`
 
-Assert that bar formation still leaves the downstream columns your experiment requires.
+Assert that bar formation still leaves the downstream columns required by the experiment.
 
 ```python
 .set_required_bar_columns([
@@ -257,7 +257,7 @@ Assert that bar formation still leaves the downstream columns your experiment re
 ])
 ```
 
-This is especially useful when your model or backtest assumes OHLC fields are present after bars have been formed.
+This assertion protects model or backtest paths that require OHLC fields after bar formation.
 
 ## Indicators And Features
 
@@ -322,7 +322,7 @@ Use `include_if=` when a transform should only run if a boolean round parameter 
 
 ## Parameter-Controlled Perturbations
 
-The manifest builder now supports several perturbation-style workflows directly in the declarative surface.
+The manifest builder supports perturbation-style workflows directly in the declarative surface.
 
 ### Feature-group selection
 
@@ -389,7 +389,7 @@ On a live local prep run in this repo, `feature_drop_count=1` and `feature_drop_
 round_params['_dropped_features'] == ['vol_5']
 ```
 
-In artifact-rich runs, that `_dropped_features` payload is stored into `round_data.jsonl`, and [Trainer](Trainer.md) reproduces the same drop set during promotion.
+In artifact-backed runs, that `_dropped_features` payload is stored into `round_data.jsonl`, and [Trainer](Trainer.md) reproduces the same drop set during promotion.
 
 ### Scaler choice from parameters
 
@@ -410,15 +410,15 @@ On live local manifest-prep runs in this repo, this resolved correctly to:
 
 ### Manifest-level overrides
 
-Use `with_params_override(...)` when you want a manifest clone with structural changes that should not come from the round search itself.
+Use `with_params_override(split_config=(1, 0, 0))` for a manifest clone with structural changes that should not come from the round search itself.
 
-Typical examples:
+Examples:
 
 - `split_config=(1, 0, 0)` for full-data retraining in [Trainer](Trainer.md)
-- `start_date_limit=...` for a controlled data-window variant
-- `row_count_limit=...` for test or smoke paths
+- `start_date_limit='2025-01-01'` for a controlled data-window variant
+- `row_count_limit=5000` for test or smoke paths
 
-Use round parameters for search-time variation and `with_params_override(...)` for external structural control.
+Round parameters handle search-time variation. `with_params_override(split_config=(1, 0, 0))` handles external structural control.
 
 Then in `params()`:
 
@@ -479,7 +479,7 @@ Then in `params()`:
 }
 ```
 
-Use this when scaler choice is itself part of the search space.
+Use this when scaler choice is part of the search space.
 
 ## PCA Compression
 
@@ -603,10 +603,16 @@ The rule-based path produces a different `data_dict` than the ML path:
     'val':   pl.DataFrame,
     'test':  pl.DataFrame,
     'strategy': {
-        'conditions': [...],  # condition dicts as configured
+        'conditions': [
+            {'id': 'entry', 'type': 'threshold', 'column': 'wilder_rsi_14', 'operator': '<', 'value': 30},
+        ],
         'entry': 'entry',
     },
-    '_alignment': {...},
+    '_alignment': {
+        'first_test_datetime': None,
+        'last_test_datetime': None,
+        'missing_datetimes': [],
+    },
 }
 ```
 
@@ -637,11 +643,11 @@ from limen.sfd.reference_architecture import logreg_binary
 
 The model function must accept the prepared `data_dict` as its first argument.
 
-All remaining parameters are auto-mapped from `round_params` by signature inspection. For example, if your model function has:
+All remaining parameters are auto-mapped from `round_params` by signature inspection. For a model function with this signature:
 
 ```python
 def logreg_binary(data, C=1.0, class_weight=None, max_iter=100, solver='lbfgs'):
-    ...
+    return LogRegBinary().evaluate(data, inline_metrics=True, C=C, class_weight=class_weight, max_iter=max_iter, solver=solver)
 ```
 
 then manifest execution will automatically pull `C`, `class_weight`, `max_iter`, and `solver` from the current round when those keys exist in `round_params`.
@@ -724,7 +730,7 @@ Then in `params()`:
 }
 ```
 
-This is useful when you want feature robustness to be part of the search itself.
+This makes feature robustness part of the search itself.
 
 ## Data Dict Extension
 
@@ -752,11 +758,11 @@ Create a deep-copied manifest with selected overrides.
 manifest_full = manifest.with_params_override(split_config=(1, 0, 0))
 ```
 
-This is especially useful in retraining workflows where you want to promote a winning round from train/val/test mode into all-data training.
+This supports retraining workflows that promote a selected round from train/val/test mode into all-data training.
 
 Supported override behavior today:
 
-- `split_config=(...)` overrides the split ratios
+- `split_config=(1, 0, 0)` overrides the split ratios
 - other keys are interpreted as data-source parameter overrides and are validated against the configured data-source method signature
 
 Example:
@@ -792,11 +798,11 @@ Indicator and feature functions are applied during the feature stage over a Pola
 
 The practical contract is:
 
-- input: frame with the columns your transform expects
+- input: frame with the columns the transform expects
 - output: frame with the new columns added
 - behavior: deterministic with respect to the resolved parameters
 
-If you are adding custom manifest transforms, write them in the same style as Limen's built-ins: accept a frame plus keyword arguments, and return the transformed frame.
+Custom manifest transforms should match Limen's built-ins: accept a frame plus keyword arguments, and return the transformed frame.
 
 ### Fitted parameter computation functions
 
@@ -807,7 +813,7 @@ The contract is:
 - input: eager `pl.DataFrame` plus resolved kwargs
 - output: one fitted value
 
-That fitted value is then stored under the name you gave in `fit_param(...)` and can be referenced later in the target or scaler step.
+That fitted value is then stored under the fitted-parameter name and can be referenced later in the target or scaler step.
 
 ### Target transform functions
 
@@ -822,7 +828,7 @@ Use fitted transforms when the function depends on train-only fitted state. Use 
 
 ### Model functions
 
-The architecture function configured in `with_reference_architecture(...)` must:
+The architecture function configured in `with_reference_architecture(logreg_binary)` must:
 
 - accept the finalized `data_dict` as its first argument
 - accept any searched model parameters as named kwargs
@@ -884,6 +890,6 @@ That pattern is central to [Trainer](Trainer.md).
 
 - Continue to [Universal Experiment Loop](Universal-Experiment-Loop.md) to run a manifest-driven SFD.
 - Continue to [Calibration](Calibration.md) for the full calibration reference including custom calibrators, threshold optimisers, and all four calibration modes.
-- Continue to [Historical Data](Historical-Data.md) if you need the data surfaces a manifest can point at.
+- Continue to [Historical Data](Historical-Data.md) for data surfaces a manifest can reference.
 - Continue to [Data Bars](Data-Bars.md) if bar formation is part of the experiment design.
 - Use [Indicators](Indicators.md), [Features](Features.md), [Targets](Targets.md), [Transforms](Transforms.md), and [Scalers](Scalers.md) as the reference layer while authoring manifests.

--- a/docs/Features.md
+++ b/docs/Features.md
@@ -1,18 +1,18 @@
 # Features
 
-Features sit one layer above indicators. They usually combine, re-express, lag, or contextualize price and volume information into model-ready signals or regime flags.
+Features sit one layer above indicators. They combine, re-express, lag, or contextualize price and volume information into model-ready signals or regime flags.
 
-Use this page when you need to choose between feature helpers, understand their input requirements, or see what each helper adds to a frame. For lower-level signal primitives, see [Indicators](Indicators.md).
+This page covers feature-helper selection, input requirements, and added columns. For lower-level signal primitives, see [Indicators](Indicators.md).
 
 ## Conventions
 
-- Feature helpers usually append columns and return the original frame with the extra outputs attached.
-- Some helpers operate on plain kline data only. Others require trade-derived columns such as `maker_ratio`, `no_of_trades`, `price`, or `quantity`.
+- Feature helpers append columns and return the original frame with the extra outputs attached.
+- Helpers either operate on plain kline data or require trade-derived columns such as `maker_ratio`, `no_of_trades`, `price`, or `quantity`.
 - Not every helper is intended as a final predictor. Some are utilities used to build targets or wider feature families.
-- Several regime helpers output compact categorical-style columns such as `regime_ma_slope` or `regime_price_band`.
-- A few helpers return scalar values instead of frames. The main example is `find_min_d`, which searches for a stationarity-preserving fractional-differentiation order.
+- Regime helpers output compact categorical-style columns such as `regime_ma_slope` or `regime_price_band`.
+- `find_min_d` returns a scalar value instead of a frame; it searches for a stationarity-preserving fractional-differentiation order.
 
-## Quick Example
+## Quick example
 
 ```python
 from limen.data import HistoricalData
@@ -42,9 +42,9 @@ def manifest():
     )
 ```
 
-## Kline-Derived Position And Volatility Features
+## Kline-derived position and volatility features
 
-These helpers work directly on bar data and are usually the easiest feature layer to add to a first manifest.
+These helpers work directly on bar data and require only kline-style inputs.
 
 | Function | Adds by default | Notes |
 |---|---|---|
@@ -68,7 +68,7 @@ These helpers work directly on bar data and are usually the easiest feature laye
 | `vwap` | `vwap` | Requires a datetime-like `datetime` column because VWAP resets by trading day. |
 | `wick_proportion` | `wick_proportion` | Rolling mean wick share of full candle range. |
 
-## Calendar And Cyclical Time Features
+## Calendar and cyclical time features
 
 These helpers derive time-of-bar context from `datetime` without depending on earlier indicator columns.
 
@@ -80,7 +80,7 @@ These helpers derive time-of-bar context from `datetime` without depending on ea
 | `time_to_funding` | `hours_to_funding` | Continuous hours until the next funding settlement; default cadence is every `8` hours from `0` UTC, and zero at a settlement bar. |
 | `is_us_open_hour` | `is_us_open_hour` | Parameterized US open-hour indicator; default hour is `14`. |
 
-## Range-Based Volatility Features
+## Range-based volatility features
 
 These helpers estimate volatility directly from OHLC structure instead of relying only on close-to-close returns.
 
@@ -94,15 +94,15 @@ These helpers estimate volatility directly from OHLC structure instead of relyin
 | `volatility_spike` | `volatility_spike` | Current Parkinson variance divided by its fixed-lag value. |
 | `yang_zhang_volatility` | `yang_zhang_volatility` | Combines overnight, open-close, and range information into a higher-fidelity volatility estimate. Requires `window > 1`. |
 
-## Liquidity And Impact Features
+## Liquidity and impact features
 
-These helpers translate ordinary OHLCV bars into simple liquidity, impact, and slippage proxies.
+These helpers translate ordinary OHLCV bars into liquidity, impact, and slippage proxies.
 
 | Function | Adds by default | Notes |
 |---|---|---|
 | `dollar_volume` | `dollar_volume` | Price-times-volume activity proxy using close and volume. |
 | `amihud_illiquidity` | `amihud_illiquidity` | Absolute return per dollar of volume, a compact price-impact proxy. |
-| `return_per_dollar_volume` | `return_per_dollar_volume` | Signed return per dollar of volume, useful when direction matters as much as impact. |
+| `return_per_dollar_volume` | `return_per_dollar_volume` | Signed return per dollar of volume for directional impact analysis. |
 | `range_per_dollar_volume` | `range_per_dollar_volume` | Bar range scaled by dollar volume. |
 | `illiquidity_shock` | `illiquidity_shock` | Current Amihud-style illiquidity relative to its own trailing mean. |
 | `liquidity_drop` | `liquidity_drop` | Current LOB liquidity divided by fixed-lag LOB liquidity. |
@@ -118,7 +118,7 @@ These helpers translate ordinary OHLCV bars into simple liquidity, impact, and s
 | `order_flow_imbalance` | `order_flow_imbalance` plus `bvc_buy_volume`, `bvc_sell_volume` | Rolling net BVC-classified signed flow as a share of volume; a bar-level order-flow imbalance proxy, not level-2 OFI. |
 | `vpin` | `vpin` plus `bvc_buy_volume`, `bvc_sell_volume` | Volume-synchronized Probability of Informed Trading from the BVC buy/sell imbalance; a flow-toxicity gauge. Feed volume bars for canonical equal-volume buckets. |
 
-## Realized Risk And Tail Features
+## Realized risk and tail features
 
 These helpers describe the quality of recent movement, not just its level.
 
@@ -135,7 +135,7 @@ These helpers describe the quality of recent movement, not just its level.
 | `return_volatility_correlation` | `return_volatility_correlation` | Rolling correlation between returns and Parkinson variance. |
 | `volume_volatility_correlation` | `volume_volatility_correlation` | Rolling correlation between volume and Parkinson variance. |
 
-## Seasonality-Normalized Features
+## Seasonality-normalized features
 
 These helpers compare current bar behavior to the trailing mean for the same hour of the week.
 
@@ -145,7 +145,7 @@ These helpers compare current bar behavior to the trailing mean for the same hou
 | `relative_range_seasonality` | `relative_range_seasonality` | Current range percentage relative to the trailing hour-of-week baseline. |
 | `relative_volatility_seasonality` | `relative_volatility_seasonality` | Current absolute return magnitude relative to the trailing hour-of-week baseline. |
 
-## Candle Structure And Auction Features
+## Candle structure and auction features
 
 These helpers focus on how a bar moved internally, not just where it finished.
 
@@ -157,22 +157,22 @@ These helpers focus on how a bar moved internally, not just where it finished.
 | `rejection_intensity` | `rejection_intensity` | Wick-heavy rejection proxy based on total wick share and directional close location. |
 | `absorption_intensity` | `absorption_intensity` | High-volume, small-body absorption proxy using a trailing shifted volume baseline. |
 
-## Cross-Timescale Context Features
+## Cross-timescale context features
 
-These helpers summarize whether multiple horizons agree or disagree about market state.
+These helpers summarize cross-horizon agreement or disagreement on market state.
 
 | Function | Adds by default | Notes |
 |---|---|---|
 | `trend_coherence` | `trend_coherence` | Average sign agreement across short, medium, and long return horizons. |
 | `volatility_term_structure` | `volatility_term_structure` | Average ratio between short, medium, and long rolling volatility estimates. |
 
-## Breakout And Regime Features
+## Breakout and regime features
 
-These helpers are useful when you want state or structure, not just a continuous numeric series.
+These helpers provide state or structure rather than only a continuous numeric series.
 
 | Function | Adds by default | Notes |
 |---|---|---|
-| `breakout_features` | many lagged breakout columns plus `long_roll_mean`, `long_roll_std`, `short_roll_mean`, `short_roll_std`, `roc_long_12_1`, `roc_short_12_1` | Designed to enrich pre-existing breakout flags. |
+| `breakout_features` | lagged breakout columns plus `long_roll_mean`, `long_roll_std`, `short_roll_mean`, `short_roll_std`, `roc_long_12_1`, `roc_short_12_1` | Enriches pre-existing breakout flags. |
 | `breakout_percentile_regime` | `price_range_position`, `regime_breakout_pct` | Uses percentile thresholds over price-range position. |
 | `hh_hl_structure_regime` | `regime_hh_hl` | Captures higher-high and higher-low style structure. |
 | `ichimoku_cloud` | `tenkan`, `kijun`, `senkou_a`, `senkou_b`, `chikou` | Full Ichimoku feature set. |
@@ -181,7 +181,7 @@ These helpers are useful when you want state or structure, not just a continuous
 | `sma_crossover` | `crossover`, `signal` | Compact crossover-state helper. |
 | `window_return_regime` | `ret_24`, `regime_window_return` | Return plus regime thresholding over a window. |
 
-## Line-Based Context Features
+## Line-based context features
 
 These helpers summarize how recently and how densely price interacted with detected price lines — pairs of bars at most `max_duration_hours` apart whose close-to-close change is at least `min_height_pct` (positive lines are long, negative are short; quantile lines are those at or above the `quantile_threshold` height quantile per direction).
 
@@ -204,9 +204,9 @@ The per-column building blocks below take pre-computed line structures (`list[di
 | `hours_since_big_move` | `hours_since_big_move` | Bars since the most recent line end, capped at `lookback_hours`. |
 | `hours_since_quantile_line` | `hours_since_quantile_line` | Bars since the most recent quantile-line end, capped at `lookback_hours`. |
 
-## Lag Helpers And Threshold Utilities
+## Lag helpers and threshold utilities
 
-These helpers are mainly used to expand existing columns or define cutoffs for target construction.
+These helpers expand existing columns or define cutoffs for target construction.
 
 | Function | Adds or returns | Notes |
 |---|---|---|
@@ -217,9 +217,9 @@ These helpers are mainly used to expand existing columns or define cutoffs for t
 | `rolling_zscore` | configurable `*_zscore_*` column | Applies `identity`, `log1p`, or `abs` before rolling z-score standardization. |
 | `cusum_filter` | `cusum_event` | Int8 flag of symmetric CUSUM events on the close log-return path (`1` up, `-1` down, `0` none); gates which moves are worth sampling. |
 
-## Stationarity And Long-Memory Helpers
+## Stationarity and long-memory helpers
 
-These helpers are useful when you want to reduce non-stationarity while preserving more long-memory structure than a simple first difference would.
+These helpers reduce non-stationarity while preserving more long-memory structure than a first difference would.
 
 | Function | Adds or returns | Notes |
 |---|---|---|
@@ -228,26 +228,26 @@ These helpers are useful when you want to reduce non-stationarity while preservi
 
 Two practical details matter:
 
-- `fractional_diff` needs `cols=[...]` and writes new columns such as `close_fracdiff`.
+- `fractional_diff` needs `cols=['close']` and writes new columns such as `close_fracdiff`.
 - if one split is too short to produce the same fractional-diff column as another split, Manifest now drops that extra column during split alignment so the final `data_dict` stays consistent.
 
-## Trade-Shape And Microstructure Features
+## Trade-shape and microstructure features
 
 These helpers need richer data than ordinary OHLCV bars.
 
 | Function | Adds by default | Notes |
 |---|---|---|
-| `kline_imbalance` | `imbalance` | Requires `maker_ratio` and `no_of_trades`. Useful when those were carried through data retrieval or bar formation. |
+| `kline_imbalance` | `imbalance` | Requires `maker_ratio` and `no_of_trades` from data retrieval or bar formation. |
 | `conserved_flux_renormalization` | synthetic OHLCV plus `value_sum`, `vwap`, `flux_rel_std_mean`, `flux_rel_std_var`, `entropy_mean`, `entropy_var`, `Δflux_rms`, `Δentropy_rms` | Works on trade-level `datetime`, `price`, and `quantity`, then rolls those into kline-aligned diagnostics. |
 
-## Choosing Between Indicators And Features
+## Choosing between indicators and features
 
-- Use an indicator when you want a direct market calculation such as RSI, ATR, or MACD.
-- Use a feature when you want structure around those signals, such as lags, regimes, relative position, or multi-step aggregation.
+- Use an indicator for a direct market calculation such as RSI, ATR, or MACD.
+- Use a feature for structure around those signals, such as lags, regimes, relative position, or multi-step aggregation.
 - Use the lag helpers when the main value is temporal context rather than a new market calculation.
 - Use `fractional_diff` when stationarity itself is part of the design problem, not just a preprocessing afterthought.
 
-## Read Next
+## Read next
 
 - [Indicators](Indicators.md) for lower-level signal primitives
 - [Transforms](Transforms.md) for target shaping and post-model calibration helpers

--- a/docs/Historical-Data.md
+++ b/docs/Historical-Data.md
@@ -24,9 +24,9 @@ assert data is historical.data
 
 ## Current Surface
 
-| Method | Backend | Returns | Typical use |
+| Method | Backend | Returns | Use case |
 |---|---|---|---|
-| `get_spot_klines()` | Hugging Face BTCUSDT parquet datasets | BTCUSDT spot klines as `pl.DataFrame` | most common experiment input |
+| `get_spot_klines()` | Hugging Face BTCUSDT parquet datasets | BTCUSDT spot klines as `pl.DataFrame` | standard experiment input |
 | `get_spot_dollar_klines()` | Hugging Face BTCUSDT dollar-bar parquet datasets | BTCUSDT spot dollar bars as `pl.DataFrame` | event-time experiments |
 | `get_binance_file()` | direct Binance ZIP/CSV archive | normalized Binance file contents as `pl.DataFrame` | source-native Binance trade files |
 | `get_any_file()` | local path or URL (`.parquet`, `.csv`, `.zip`) | loaded file contents as `pl.DataFrame` | test fixtures, local research files, remote datasets |
@@ -105,7 +105,7 @@ trades = historical.get_binance_file(
 )
 ```
 
-Use this when you want Binance source files rather than the curated kline dataset.
+Use this for Binance source files rather than the curated kline dataset.
 
 ## `get_any_file()`
 
@@ -134,12 +134,12 @@ It is the right choice for:
 
 ## Manifest Integration
 
-Most manifest-driven experiments should use:
+Manifest-driven experiments should use:
 
 - `HistoricalData.get_spot_klines` for production data
 - `HistoricalData.get_spot_dollar_klines` for event-time dollar-bar production data
-- `HistoricalData.get_spot_klines` with a smaller `row_count_limit` and coarser `kline_size` for lightweight test runs
-- `HistoricalData.get_any_file` only when you intentionally want to load a specific local or remote file
+- `HistoricalData.get_spot_klines` with a bounded `row_count_limit` and coarser `kline_size` for test runs
+- `HistoricalData.get_any_file` only for a specific local or remote file
 
 ```python
 from limen.data import HistoricalData
@@ -160,9 +160,9 @@ manifest = (
 
 ## Choosing The Right Surface
 
-- Use `get_spot_klines()` for most Limen experiments and for manifest test sources that should stay on the public BTCUSDT path.
+- Use `get_spot_klines()` for standard Limen experiments and manifest test sources that should stay on the public BTCUSDT path.
 - Use `get_spot_dollar_klines()` when market activity, not wall-clock time, should define each row.
-- Use `get_binance_file()` when you want direct Binance archives.
+- Use `get_binance_file()` for direct Binance archives.
 - Use `get_any_file()` for local fixtures, URLs, and generic file-backed ingestion.
 
 ## Read Next

--- a/docs/Indicators.md
+++ b/docs/Indicators.md
@@ -1,19 +1,19 @@
 # Indicators
 
-Indicators are Limen's lowest-level signal helpers. They usually take a kline-style `pl.DataFrame`, append one or more derived columns, and return the same frame shape back for the rest of the manifest pipeline.
+Indicators are Limen's lowest-level signal helpers. They take a kline-style `pl.DataFrame`, append one or more derived columns, and return the same frame shape back for the rest of the manifest pipeline.
 
-Use this page when you need to choose an indicator, understand its naming convention, or see which columns it adds by default. For higher-level derived signals, see [Features](Features.md).
+This page covers indicator selection, naming conventions, and default added columns. For higher-level derived signals, see [Features](Features.md).
 
 ## Conventions
 
 - Indicators append columns. They do not replace the input frame with a reduced schema.
-- Most helpers assume the usual OHLCV names: `open`, `high`, `low`, `close`, `volume`.
+- Helpers assume the standard OHLCV names: `open`, `high`, `low`, `close`, `volume`.
 - TA-Lib-backed wrappers treat TA-Lib parity as the source of truth. If Limen and TA-Lib diverge, TA-Lib wins unless there is a deliberate, documented reason not to.
-- Output column names usually encode the main defaults, such as `rsi_14` or `apo_12_26_0`.
-- Candlestick pattern helpers add a same-named integer column, usually following TA-Lib's positive bullish, negative bearish, zero neutral convention.
-- A few helpers intentionally expose legacy compatibility behavior. The main example is `sma`, which adds both `sma_{period}` and `{price_col}_sma_{period}`.
+- Output column names encode key defaults, such as `rsi_14` or `apo_12_26_0`.
+- Candlestick pattern helpers add a same-named integer column following TA-Lib's positive bullish, negative bearish, zero neutral convention.
+- Legacy compatibility helpers intentionally expose legacy behavior. `sma` adds both `sma_{period}` and `{price_col}_sma_{period}`.
 
-## Quick Example
+## Quick example
 
 ```python
 from limen.data import HistoricalData
@@ -41,7 +41,7 @@ def manifest():
     )
 ```
 
-## Family Index
+## Family index
 
 - `Price and moving averages`: direct price transforms and smoothing helpers.
 - `Momentum and oscillators`: rate-of-change, oscillator, regression, and Hilbert-style cycle helpers.
@@ -49,16 +49,16 @@ def manifest():
 - `Volume, breadth, and bar diagnostics`: flow, bar-body, and return-style helpers.
 - `Candlestick patterns`: TA-Lib-style pattern flags over OHLC bars.
 
-## Price And Moving Averages
+## Price and moving averages
 
-These helpers usually take either a single `price_col` or basic OHLC inputs and add smoothed or transformed price views.
+These helpers take either a single `price_col` or basic OHLC inputs and add smoothed or transformed price views.
 
 | Function | Adds by default | Notes |
 |---|---|---|
 | `avgprice` | `avgprice` | Average OHLC price. |
 | `medprice` | `medprice` | Median of high and low. |
 | `midprice` | `midprice_14` | Rolling midpoint of high and low over `period`. |
-| `typprice` | `typprice` | Typical price from high, low, close. |
+| `typprice` | `typprice` | Mean of high, low, and close. |
 | `wclprice` | `wclprice` | Weighted close price. |
 | `midpoint` | `midpoint_14` | Rolling midpoint of a single `price_col`. |
 | `sma` | `sma_30`, `close_sma_30` | Adds both the canonical and compatibility alias columns. |
@@ -73,7 +73,7 @@ These helpers usually take either a single `price_col` or basic OHLC inputs and 
 | `ma` | `ma_30_0` | Generic moving average with explicit `ma_type`. |
 | `ht_trendline` | `ht_trendline` | Hilbert Transform instantaneous trendline. |
 
-## Momentum And Oscillators
+## Momentum and oscillators
 
 These helpers focus on rate of change, directional persistence, oscillator state, or cycle structure.
 
@@ -112,7 +112,7 @@ These helpers focus on rate of change, directional persistence, oscillator state
 | `ht_sine` | `ht_sine`, `ht_sine_lead` | Hilbert sine pair. |
 | `ht_trendmode` | `ht_trendmode` | Trend-versus-cycle mode flag. |
 
-## Volatility, Bands, And Range
+## Volatility, bands, and range
 
 These helpers quantify range, dispersion, band structure, or stop placement.
 
@@ -131,7 +131,7 @@ These helpers quantify range, dispersion, band structure, or stop placement.
 | `sar` | `sar` | Parabolic SAR. |
 | `sarext` | `sarext` | Extended SAR with separate long and short parameters. |
 
-## Volume, Breadth, And Bar Diagnostics
+## Volume, breadth, and bar diagnostics
 
 These helpers focus on participation, bar structure, or direct return transforms.
 
@@ -143,17 +143,17 @@ These helpers focus on participation, bar structure, or direct return transforms
 | `mfi` | `mfi_14` | Money Flow Index. |
 | `bop` | `bop` | Balance of Power. |
 | `price_change_pct` | `price_change_pct_1` | Point-to-point percent change. |
-| `returns` | `returns` | Single-step simple returns helper. |
+| `returns` | `returns` | Single-step returns helper. |
 | `body_pct` | `body_pct` | Candle body size as a share of the full range. |
 | `window_return` | `ret_24` | Return over a wider rolling window. |
 
-## Candlestick Patterns
+## Candlestick patterns
 
 All candlestick pattern helpers:
 
 - expect OHLC columns
 - append one integer column named after the function
-- are best treated as event flags rather than smooth continuous features
+- should be treated as event flags rather than smooth continuous features
 
 Only three patterns expose an extra parameter today.
 
@@ -207,15 +207,15 @@ Only three patterns expose an extra parameter today.
 | `cdltristar` | `cdltristar` | None |
 | `cdlunique3river` | `cdlunique3river` | None |
 
-## Choosing Between Similar Helpers
+## Choosing between similar helpers
 
-- Use `bbands` when you want TA-Lib parity and configurable moving-average type.
-- Use `bollinger_bands` when you want a lightweight native SMA-based band helper.
-- Use `stoch` or `stochf` when you want TA-Lib parity. Use `stochastic_oscillator` when you want a simpler native rolling implementation.
-- Use `sma` when you want the canonical moving average helper used across Limen manifests. Use `ma` when `ma_type` itself is part of the search space.
-- Use `returns`, `price_change_pct`, and `window_return` differently: one-bar simple returns, configurable percent change, and wider-window return summaries respectively.
+- Use `bbands` for TA-Lib parity and configurable moving-average type.
+- Use `bollinger_bands` for the native SMA-based band helper.
+- Use `stoch` or `stochf` for TA-Lib parity. Use `stochastic_oscillator` for the native rolling implementation.
+- Use `sma` for the canonical moving average helper used across Limen manifests. Use `ma` when `ma_type` itself is part of the search space.
+- Use `returns`, `price_change_pct`, and `window_return` for one-bar returns, configurable percent change, and wider-window return summaries respectively.
 
-## Read Next
+## Read next
 
 - [Features](Features.md) for higher-level derived signals built on top of raw bars or indicators
 - [Experiment Manifest](Experiment-Manifest.md) for how to wire indicators into a manifest pipeline

--- a/docs/Log.md
+++ b/docs/Log.md
@@ -2,17 +2,22 @@
 
 `Log` is Limen's post-run analysis layer. It sits on top of a finished experiment and turns raw round results into round-level prediction tables, benchmark-style summaries, backtest summaries, and parameter-correlation views.
 
-In most workflows you do not instantiate it yourself. `UniversalExperimentLoop` creates `uel._log` automatically at the end of a successful run and also exposes the most-used derived tables directly on the `uel` object.
+`UniversalExperimentLoop` creates `uel._log` automatically at the end of a successful run and exposes the primary derived tables directly on the `uel` object.
 
-## Two Ways To Use `Log`
+## Two ways to use `Log`
 
 ### UEL-backed `Log`
 
 This is the normal path.
 
 ```python
-uel = limen.UniversalExperimentLoop(...)
-uel.run(...)
+from limen.data import HistoricalData
+
+historical = HistoricalData()
+data = historical.get_spot_klines(kline_size=7200, row_count_limit=2000)
+
+uel = limen.UniversalExperimentLoop(data=data, sfd=limen.sfd.logreg_binary)
+uel.run(experiment_name='logreg-first', n_permutations=4, prep_each_round=True)
 
 log = uel._log
 ```
@@ -29,7 +34,7 @@ That is why the full post-run surface works from a UEL-backed `Log`.
 
 ### File-backed `Log`
 
-You can also load a CSV log from disk:
+A CSV log can also be loaded from disk:
 
 ```python
 import limen
@@ -37,21 +42,21 @@ import limen
 log = limen.Log(file_path='my_experiment.csv')
 ```
 
-This path is useful when you mainly want the cleaned experiment log itself, or experiment-log-only analysis such as parameter correlation.
+This path supports the cleaned experiment log itself and experiment-log-only analysis such as parameter correlation.
 
 Important limitation:
 
 - file-backed `Log` does not have `data`, `prep`, `preds`, or `_alignment`
 - methods that reconstruct per-round predictions or test windows require a UEL-backed `Log`
 
-## The Main Post-Run Workflow
+## The post-run workflow
 
-The most common sequence is:
+The standard sequence is:
 
 1. inspect one round's prediction table
 2. compare rounds with benchmark summaries
 3. compare rounds with backtest summaries
-4. inspect which parameters move with your target metric
+4. inspect which parameters move with the target metric
 
 ```python
 log = uel._log
@@ -64,7 +69,7 @@ correlation = log.experiment_parameter_correlation('auc', min_n=10)
 
 ## `permutation_prediction_performance(round_id)`
 
-This is the most concrete place to start. It reconstructs a single round's test-period table and joins:
+This method reconstructs a single round's test-period table and joins:
 
 - model predictions
 - actual outcomes
@@ -87,11 +92,11 @@ The resulting table has these columns:
 
 On a live local run in this repo, the table for one round contained 218 test rows with exactly that schema.
 
-Use this table when you want to understand a round before jumping to summary statistics. It is also the direct input to Limen's snapshot backtest.
+Use this table for round-level inspection before summary statistics. It is also the direct input to Limen's snapshot backtest.
 
-## Benchmark Surfaces
+## Benchmark surfaces
 
-The benchmark layer answers: is the signal making useful directional calls before we translate those calls into trading results?
+The benchmark layer measures directional signal quality before translation into trading results.
 
 ### `experiment_confusion_metrics(x, disable_progress_bar=False)`
 
@@ -123,7 +128,7 @@ uel._log.experiment_confusion_metrics('price_change')
 
 automatically at the end of the run.
 
-### `permutation_confusion_metrics(x, round_id, ...)`
+### `permutation_confusion_metrics(x, round_id)`
 
 Produces the same style of summary for one specific round.
 
@@ -134,18 +139,13 @@ round0_conf = uel._log.permutation_confusion_metrics(
 )
 ```
 
-This is the right view when a round looks interesting and you want to inspect its benchmark behavior in isolation.
+This view isolates benchmark behavior for one selected round.
 
 ### Reading the benchmark table
 
-Good questions to ask:
+Benchmark-table review should inspect whether high `precision_pct` comes from selectivity or low activity, whether `recall_pct` captures actual positives, whether `tp_x_mean` and `tp_x_median` exceed `fp_x_mean` and `fp_x_median`, and whether `tp_fp_cohen_d` indicates separation rather than noise.
 
-- is `precision_pct` high because the signal is selective, or because it barely predicts positives?
-- does `recall_pct` stay useful, or is the model missing most real positives?
-- are `tp_x_mean` and `tp_x_median` materially better than `fp_x_mean` and `fp_x_median`?
-- is `tp_fp_cohen_d` stable enough to suggest real separation rather than noise?
-
-This is exactly why benchmark and backtest are separate in Limen: a round can look statistically interesting before it proves itself economically.
+Benchmark and backtest stay separate because statistical signal quality and trading economics can diverge.
 
 When the confusion table includes:
 
@@ -156,7 +156,7 @@ When the confusion table includes:
 
 those four fields use the same immediate-next-execution-row contract as snapshot backtests for completed-bar pipelines. They are not same-row feature-bar returns.
 
-## Backtest Surface
+## Backtest surface
 
 ### `experiment_backtest_results(disable_progress_bar=False)`
 
@@ -185,7 +185,7 @@ Intensive scalars:
 
 - `wins_per_bar`, `pnl_per_bar_bps`, `avg_win_bps`, `avg_loss_bps`, `cvar_95_pnl_bps`, `trades_per_bar`, `inventory_per_bar`, `cost_per_bar_bps`
 
-Use this table to compare the trading-economics side of rounds after you have already inspected the benchmark layer.
+Use this table to compare trading economics after benchmark inspection.
 
 Post-run snapshot backtests currently support:
 
@@ -194,9 +194,9 @@ Post-run snapshot backtests currently support:
 
 Logged multiclass outputs are not supported on this surface and raise explicitly instead of being silently collapsed.
 
-## Parameter Correlation Surface
+## Parameter correlation surface
 
-### `experiment_parameter_correlation(metric, ...)`
+### `experiment_parameter_correlation(metric)`
 
 This method looks for robust relationships between experiment parameters and a chosen metric across explicit cohorts.
 
@@ -221,25 +221,25 @@ with columns:
 - `ci_hi`
 - `sign_stability`
 
-This is most useful after a run is large enough to support meaningful cohorts. On tiny runs, the output is still legal but usually too unstable to interpret with confidence.
+This method requires enough rows to support cohort-level interpretation. Tiny runs produce legal output but unstable estimates.
 
-## Persisting Predictions And Complex Artifacts
+## Persisting predictions and complex artifacts
 
-If you want `Log` to have enough information for round-level reconstruction:
+`Log` needs these fields for round-level reconstruction:
 
 - store test predictions as `round_results['_preds']`
 - keep prep deterministic with respect to `round_params`
 - use `prep_each_round=True` when the prep stage depends on round parameters
 
-If your model or prep returns large objects that should not be flattened into the experiment log, put them under:
+Large model or prep objects that should not be flattened into the experiment log belong under:
 
 ```python
-round_results['extras'] = ...
+round_results['extras'] = {'model': fitted_model}
 ```
 
 UEL preserves those in `uel.extras`.
 
-## Determinism Matters
+## Determinism matters
 
 `Log` reconstructs test data by replaying the relevant prep path. That means non-deterministic prep logic can break alignment between:
 
@@ -263,10 +263,10 @@ It:
 - trims whitespace in object columns
 - returns a cleaned pandas dataframe
 
-Use it when you need to recover or inspect an experiment log outside a live UEL object.
+Use `read_from_file()` to recover or inspect an experiment log outside a live UEL object.
 
-## Read Next
+## Read next
 
 - Continue to [Benchmark](Benchmark.md) for the prediction-quality layer built on top of `Log`.
 - Continue to [Backtest](Backtest.md) for the trading-economics layer built on top of `permutation_prediction_performance()`.
-- Continue to [Trainer](Trainer.md) if you want to promote selected experiment rounds into reusable sensors.
+- Continue to [Trainer](Trainer.md) for promotion of selected experiment rounds into reusable sensors.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,16 +1,16 @@
-# Limen Docs
+# Limen docs
 
-This page is the routing hub for the Limen docs. Use it to choose the right path based on what you are trying to do.
+This page routes Limen docs by task.
 
-## Limen In One Page
+## Limen in one page
 
 Limen is a Bitcoin alpha research engine for turning market data into experiments, logged analytics, backtests, and decoder cohorts. It keeps the research loop inside one Python system: data preparation, indicators, features, targets, scaling, parameter search, and post-run evaluation.
 
 Limen does not perform downstream trade decisioning or execution. In the wider Vaquum architecture, Origo sits upstream as the data layer, while Nexus, Praxis, and Veritas sit downstream for decisioning, execution, and oversight.
 
-## Start Here
+## Start here
 
-### If You Are New To Limen
+### New to Limen
 
 1. Read the [product home page](../README.md)
 2. Learn how data enters Limen in [Historical Data](Historical-Data.md)
@@ -20,33 +20,33 @@ Limen does not perform downstream trade decisioning or execution. In the wider V
 6. Run experiments in [Universal Experiment Loop](Universal-Experiment-Loop.md)
 7. Review outcomes in [Log](Log.md)
 
-### If You Want To Author Experiments
+### Author experiments
 
 1. Start with [Single-File Decoder](Single-File-Decoder.md)
 2. Review the shipped patterns in [Built-In SFDs](Built-In-SFDs.md)
 3. Continue to [Experiment Manifest](Experiment-Manifest.md)
-4. Use [Indicators](Indicators.md), [Features](Features.md), [Targets](Targets.md), [Transforms](Transforms.md), [Scalers](Scalers.md), [Calibration](Calibration.md), and [Reference Architecture](Reference-Architecture.md) as your reference layer
+4. Use [Indicators](Indicators.md), [Features](Features.md), [Targets](Targets.md), [Transforms](Transforms.md), [Scalers](Scalers.md), [Calibration](Calibration.md), and [Reference Architecture](Reference-Architecture.md) as the reference layer
 5. Run the search in [Universal Experiment Loop](Universal-Experiment-Loop.md)
-6. If you need adaptive search, continue to [Advanced Search](Advanced-Search.md) and [Reducers And Feedback](Reducers-And-Feedback.md)
+6. Adaptive search continues in [Advanced Search](Advanced-Search.md) and [Reducers And Feedback](Reducers-And-Feedback.md)
 7. Inspect results in [Log](Log.md), [Benchmark](Benchmark.md), and [Backtest](Backtest.md)
 
-### If You Want To Review Finished Runs
+### Review finished runs
 
 1. Start with [Log](Log.md)
 2. Compare model behavior in [Benchmark](Benchmark.md)
 3. Evaluate trading behavior in [Backtest](Backtest.md)
 4. Review helper metrics in [Standard Metrics Library](Standard-Metrics-Library.md) and [Reference Architecture](Reference-Architecture.md)
-5. Continue to [Trainer](Trainer.md) and [Cohort](Cohort.md) if you are promoting outputs downstream
+5. Continue to [Trainer](Trainer.md) and [Cohort](Cohort.md) for downstream promotion
 
-### If You Want To Extend Limen
+### Extend Limen
 
 1. Start with [Reference Architecture](Reference-Architecture.md) and [Built-In SFDs](Built-In-SFDs.md)
 2. Continue to [Advanced Search](Advanced-Search.md) for `SearchStrategy`, `ParamDomain`, `MSQ`, and checkpoints
 3. Continue to [Reducers And Feedback](Reducers-And-Feedback.md) for adaptive interventions
 4. Use [Command Line Interface](Command-Line-Interface.md) when the extension is YAML-first or shell-driven
-5. Use [Utilities](Utilities.md) when you need the helper layer rather than the main workflow
+5. Use [Utilities](Utilities.md) for the helper layer rather than the main workflow
 
-### If You Want To Contribute Or Maintain
+### Contribute or maintain
 
 1. Start with [Developer Guidelines](Developer/README.md)
 2. Read the docs contract in [Documentation System](Developer/Documentation-System.md)
@@ -55,19 +55,19 @@ Limen does not perform downstream trade decisioning or execution. In the wider V
 5. Use [Technical Debt](TechnicalDebt.md) when assessing recorded known-risk items
 6. Use [Making Release](Developer/Making-Release.md) and [Semantic Versioning](Semantic-Versioning.md) for maintenance work
 
-## How Limen Flows
+## How Limen flows
 
 1. Data enters through [Historical Data](Historical-Data.md) or compatible external OHLC data.
 2. Data can be reshaped with [Data Bars](Data-Bars.md) when threshold bars are the right research surface.
 3. Indicators, features, transforms, and scalers define the research surface. Targets define supervised labels; calibration adjusts probabilities and thresholds after model output.
-4. An experiment is packaged in an [SFD](Single-File-Decoder.md), often starting from [Built-In SFDs](Built-In-SFDs.md) and usually expressed through an [Experiment Manifest](Experiment-Manifest.md).
-5. [Universal Experiment Loop](Universal-Experiment-Loop.md) executes the search, with [Advanced Search](Advanced-Search.md) and [Reducers And Feedback](Reducers-And-Feedback.md) extending the artifact-rich path.
+4. An experiment is packaged in an [SFD](Single-File-Decoder.md), starts from [Built-In SFDs](Built-In-SFDs.md) when a packaged decoder fits, and is expressed through an [Experiment Manifest](Experiment-Manifest.md) by default.
+5. [Universal Experiment Loop](Universal-Experiment-Loop.md) executes the search, with [Advanced Search](Advanced-Search.md) and [Reducers And Feedback](Reducers-And-Feedback.md) extending the artifact-backed path.
 6. [Log](Log.md), [Benchmark](Benchmark.md), and [Backtest](Backtest.md) explain what happened and why.
 7. [Trainer](Trainer.md) turns selected rounds into reusable sensors.
 8. [Cohort](Cohort.md) defines selector-driven ensemble inference for multi-member decoder aggregation.
 9. Those outputs then move downstream into Nexus and the rest of the Vaquum stack.
 
-## Docs Map
+## Docs map
 
 - `Overview`: [Product Home](../README.md), [this docs hub](README.md)
 - `Guides`: [Historical Data](Historical-Data.md), [Data Bars](Data-Bars.md), [Single-File Decoder](Single-File-Decoder.md), [Built-In SFDs](Built-In-SFDs.md), [Experiment Manifest](Experiment-Manifest.md), [Universal Experiment Loop](Universal-Experiment-Loop.md), [Advanced Search](Advanced-Search.md), [Reducers And Feedback](Reducers-And-Feedback.md), [Log](Log.md), [Benchmark](Benchmark.md), [Backtest](Backtest.md), [Trainer](Trainer.md), [Cohort](Cohort.md), [Conserved Flux Renormalization](Conserved-Flux-Renormalization.md)
@@ -75,9 +75,9 @@ Limen does not perform downstream trade decisioning or execution. In the wider V
 - `Developer`: [Developer Guidelines](Developer/README.md), [Documentation System](Developer/Documentation-System.md), [Pruning Strategies](Developer/Pruning-Strategies.md), [Writing Docstrings](Developer/Writing-Docstrings.md), [Contributing Foundational SFDs](Developer/Contributing-Foundational-SFDs.md), [Making Release](Developer/Making-Release.md), [Semantic Versioning](Semantic-Versioning.md), [Technical Debt](TechnicalDebt.md)
 - `Packages`: package `README`s under `/limen` for `data`, `experiment`, `sfd`, `indicators`, `features`, `transforms`, `scalers`, `metrics`, `log`, `cohort`, `backtest`, `utils`, `calibration`, `cli`, `targets`, and `yaml`
 
-## Product Boundary
+## Product boundary
 
-### Limen Owns
+### Limen owns
 
 - experiment-oriented data access
 - indicator, feature, transform, and scaler composition
@@ -87,14 +87,14 @@ Limen does not perform downstream trade decisioning or execution. In the wider V
 - benchmark-style analytics and backtesting
 - retraining and cohort construction
 
-### Limen Does Not Own
+### Limen does not own
 
 - upstream source-of-truth market data infrastructure
 - downstream trade decisioning
 - execution and exchange operations
 - system-wide oversight and audit
 
-## Read Next
+## Read next
 
 - For a first real run, continue to [Historical Data](Historical-Data.md), then [Single-File Decoder](Single-File-Decoder.md), then [Universal Experiment Loop](Universal-Experiment-Loop.md)
 - For architecture and system boundaries, continue to [Trainer](Trainer.md) and [Cohort](Cohort.md)

--- a/docs/Reducers-And-Feedback.md
+++ b/docs/Reducers-And-Feedback.md
@@ -1,4 +1,4 @@
-# Reducers And Feedback
+# Reducers and feedback
 
 Reducers and feedback are the control layer inside Limen's advanced search path. They are what let a run react to its own results instead of sweeping the full original domain unchanged.
 
@@ -8,7 +8,7 @@ This layer is coordinated by `FeedbackController`, which can collect interventio
 - an in-process `intra_callback`
 - an optional JSON intervention file
 
-## Feedback Cycle Order
+## Feedback cycle order
 
 Each feedback trigger runs sources in this order:
 
@@ -23,7 +23,7 @@ Two other behavior rules matter:
 - failures are isolated per source, so one bad source does not block the others
 - suggestion interventions are logged but not dispatched to the queue
 
-## The Intervention Surface
+## The intervention surface
 
 The `MSQ` layer currently supports these intervention families:
 
@@ -37,9 +37,9 @@ The `MSQ` layer currently supports these intervention families:
 | `set_filter`, `clear_filter` | apply or remove named multi-combination filters |
 | `remove_custom` | direct callback-only custom combo filtering |
 
-Reducers usually return declarative dicts. The `intra_callback` is different: it receives direct `MSQ` access and can call queue methods itself.
+Reducers return declarative dicts by default. The `intra_callback` receives direct `MSQ` access and can call queue methods itself.
 
-## Built-In Reducers
+## Built-in reducers
 
 ### `BudgetReducer`
 
@@ -54,21 +54,21 @@ In direct `worst_first` analysis, it emitted:
 
 ```python
 [
-    {'op': 'remove_is', 'param': 'a', 'value': 1, ...},
-    {'op': 'remove_is', 'param': 'b', 'value': 'x', ...},
-    {'op': 'trim', 'target_count': 5, ...},
+    {'op': 'remove_is', 'param': 'a', 'value': 1, 'reason': 'sanity rule'},
+    {'op': 'remove_is', 'param': 'b', 'value': 'x', 'reason': 'sanity rule'},
+    {'op': 'trim', 'target_count': 5, 'reason': 'budget limit'},
 ]
 ```
 
 ### `FocusReducer`
 
-`FocusReducer` reacts to a breakthrough score and narrows the search around the current winner.
+`FocusReducer` reacts to a breakthrough score and narrows the search near the current winner.
 
 In a live direct reducer run, a breakthrough above `0.9` emitted:
 
 - one `keep_between` filter for a numeric parameter
 - one `keep_values` filter for a categorical parameter
-- multiple `inject_value` variations around the winning numeric value
+- multiple `inject_value` variations near the winning numeric value
 
 This is the exploitation-style reducer in the current package.
 
@@ -121,19 +121,19 @@ In a live direct run, it detected a wrong-direction parameter and emitted:
     'op': 'remove_is',
     'param': 'a',
     'value': 1,
-    'reason': 'wrong-direction (negative) correlation ...',
+    'reason': 'wrong-direction negative correlation on auc',
 }
 ```
 
 It can also emit suggestion-style `keep_is` interventions for low-impact parameters.
 
-## Feedback Sources Beyond Reducers
+## Feedback sources beyond reducers
 
 ### `intra_callback`
 
 `intra_callback` receives `(log, msq)` and can call queue methods directly.
 
-Use it when you want:
+Use `ManualReducer` for:
 
 - arbitrary Python-side control logic
 - direct queue mutation that is too custom for declarative reducer output
@@ -158,7 +158,7 @@ Example:
 ]
 ```
 
-## Audit Trail
+## Audit trail
 
 Each feedback trigger writes one JSONL entry to `audit.jsonl` when the advanced path is using an `experiment_dir`.
 
@@ -172,7 +172,7 @@ A live local run in this repo recorded:
 
 That audit trail is the main way to explain why the search changed mid-run.
 
-## One Concrete Mixed Feedback Cycle
+## One concrete mixed feedback cycle
 
 In a live local controller run in this repo, one trigger applied all three sources in the same cycle:
 
@@ -183,12 +183,12 @@ In a live local controller run in this repo, one trigger applied all three sourc
 All three were:
 
 - applied to the queue
-- passed to `strategy.update_from_feedback(...)`
+- passed to `strategy.update_from_feedback(interventions)`
 - written into `audit.jsonl`
 
 On the next trigger, changing the file to inject `a=123` produced a second audit entry with the updated file-driven intervention.
 
-## Reducer Registry
+## Reducer registry
 
 All built-in reducers are available via `REDUCER_REGISTRY` for params-based or programmatic selection:
 
@@ -204,8 +204,8 @@ from limen.experiment.reducer import REDUCER_REGISTRY
 | `'sanity'` | `SanityReducer` |
 | `'saturation'` | `SaturationReducer` |
 
-## Read Next
+## Read next
 
-- Continue to [Advanced Search](Advanced-Search.md) for the full artifact-rich run path around this feedback system.
+- Continue to [Advanced Search](Advanced-Search.md) for the full artifact-backed run path for this feedback system.
 - Continue to [Universal Experiment Loop](Universal-Experiment-Loop.md) for where feedback triggers are scheduled during a run.
-- Continue to [Trainer](Trainer.md) if you want to use the finished artifacts downstream.
+- Continue to [Trainer](Trainer.md) for downstream use of finished artifacts.

--- a/docs/Reference-Architecture.md
+++ b/docs/Reference-Architecture.md
@@ -1,12 +1,12 @@
-# Reference Architecture
+# Reference architecture
 
 The reference architecture is Limen's class-based model layer. It sits underneath the foundational SFDs and underneath `Trainer`.
 
-This is the page to read when you want to understand:
+This page covers:
 
 - what a `ReferenceModel` must implement
 - how the built-in model classes behave
-- what `evaluate(..., inline_metrics=True)` really adds
+- what `evaluate(data, inline_metrics=True)` adds
 - how class-based models relate to the simpler function wrappers used in manifests
 
 ## Public Surface
@@ -43,7 +43,7 @@ In a live local reference-architecture run in this repo, the prepared `data_dict
 - `_alignment`
 - `_scaler`
 
-Not every model needs every key, but this is the standard Limen shape that the class-based models are designed around.
+Models consume the subset of keys they need from the standard Limen shape.
 
 ## The Built-In Model Classes
 
@@ -66,7 +66,7 @@ Architectures that expose valid P(1) may use Cohort's probability-weighted aggre
 
 | Architecture | Returns probabilities P(1) | Cohort mode | Notes |
 |---|---:|---|---|
-| `LogRegBinary` | yes | probability | `predict()` returns `_probs = predict_proba(... )[:, 1]`, which is directly the class-1 probability P(1). |
+| `LogRegBinary` | yes | probability | `predict()` returns `_probs = predict_proba(x_test)[:, 1]`, which is directly the class-1 probability P(1). |
 | `RandomBinary` | yes | probability | `predict()` returns `_probs`, but they are synthetic confidence values (`0.9` for predicted 1, `0.1` for predicted 0), not model-derived calibrated probabilities. Still usable as P(1)-shaped output if Cohort accepts implementation-defined probability-like outputs. |
 | `TabPFNBinary` | yes | probability | `predict()` returns `_probs` as positive-class probability. When a `CalibrationConfig` is configured, probabilities are optionally recalibrated and the threshold optimised before `_preds` are produced. This is compatible with P(1). |
 | `XGBoostRegressor` | no | fallback | `predict()` returns only `_preds` and does not expose `_probs`. Since this is a regressor, any Cohort use would have to fall back unless a separate binary-probability wrapper is introduced. |
@@ -106,7 +106,7 @@ With `inline_metrics=True`, `evaluate()` adds:
 - `confusion_*` metrics
 - `backtest_*` metrics when `price_data_for_backtest` is present
 
-On that same live local run, `LogRegBinary.evaluate(..., inline_metrics=True)` added keys such as:
+On that same live local run, `LogRegBinary.evaluate(data, inline_metrics=True)` added keys such as:
 
 - `backtest_edge_bps_p50`
 - `backtest_pnl_bps_p50`
@@ -139,25 +139,25 @@ This is the same contract that `Trainer` eventually relies on when it promotes f
 
 ## Function Wrappers Versus Classes
 
-Most foundational manifests call the function wrapper:
+Foundational manifests call the function wrapper:
 
 ```python
 .with_reference_architecture(logreg_binary)
 ```
 
-That wrapper typically:
+That wrapper:
 
 1. instantiates the matching class
 2. trains it
 3. evaluates it with `inline_metrics=True`
 
-The class is the canonical reusable architecture surface. The function wrapper is the convenient manifest-facing adapter.
+The class is the canonical reusable architecture surface. The function wrapper is the manifest-facing adapter.
 
 ## Trainer Relationship
 
 `Trainer` resolves the `ReferenceModel` subclass from the model module used by the original manifest.
 
-That is why the class-based layer matters even if your day-to-day work mostly touches foundational SFDs:
+The class-based layer matters even when daily work touches foundational SFDs:
 
 - foundational SFDs package the experiment
 - reference architecture owns the model contract
@@ -185,7 +185,12 @@ It expects a `data_dict` produced by a manifest configured with `with_strategy()
     'train': pl.DataFrame,  # with pre-computed boolean predicate columns
     'val':   pl.DataFrame,
     'test':  pl.DataFrame,
-    'strategy': {'conditions': [...], 'entry': 'entry_id'},
+    'strategy': {
+        'conditions': [
+            {'id': 'entry_id', 'type': 'threshold', 'column': 'wilder_rsi_14', 'operator': '<', 'value': 30},
+        ],
+        'entry': 'entry_id',
+    },
 }
 ```
 

--- a/docs/Scalers.md
+++ b/docs/Scalers.md
@@ -2,7 +2,7 @@
 
 Scalers are train-fitted preprocessing objects. A manifest fits the scaler on `x_train`, then reuses that fitted state to transform validation and test data without refitting.
 
-Use this page when you need to choose a scaler, understand how `set_scaler()` and `set_scaler_from_params()` behave, or see the interface a custom scaler must follow.
+This page covers scaler selection, `set_scaler()` and `set_scaler_from_params()` behavior, and the custom scaler interface.
 
 ## How Scalers Fit In Limen
 
@@ -18,10 +18,10 @@ That is why scalers live separately from the stateless helpers in [Transforms](T
 
 ## Choosing A Scaler
 
-| Scaler | Best fit | Inverse support | Notes |
+| Scaler | Fit | Inverse support | Notes |
 |---|---|---|---|
 | `LogRegScaler` | the reference logistic-regression style feature sets used in foundational flows | yes | Uses a fixed per-column rule map. Columns outside the rule map are left alone. |
-| `LinearScaler` | mixed feature sets where regex-based scaling rules are useful | yes | The most flexible built-in scaler. Supports `standard`, `log_standard`, `divide_100`, and `none`. |
+| `LinearScaler` | mixed feature sets needing regex-based scaling rules | yes | Broadest built-in scaler rule surface. Supports `standard`, `log_standard`, `divide_100`, and `none`. |
 | `RobustScaler` | outlier-heavy numeric features | yes | Uses median and IQR instead of mean and standard deviation. |
 | `CausalRollingRobustScaler` | non-stationary features whose scale drifts over time | no | Median and IQR from a strictly trailing rolling window, so no look-ahead. Not row-wise invertible from the fitted scaler. |
 | `RankGaussScaler` | numeric features that benefit from a Gaussianized shape | approximate | The inverse is only approximate because rank-based transforms are lossy. |
@@ -82,7 +82,7 @@ On live local manifest-prep runs in this repo, `set_scaler_from_params('scaler_t
 - divides `wilder_rsi` by `100`
 - leaves columns such as `maker_ratio` unchanged
 
-This is the most opinionated scaler in the package. It is a good default for old-style foundational SFDs, but less flexible than `LinearScaler`.
+This is the logistic-regression-oriented scaler in the package. It remains the legacy default for old-style foundational SFDs and exposes fewer rules than `LinearScaler`.
 
 ### `LinearScaler`
 
@@ -95,7 +95,7 @@ It supports:
 - `divide_100`
 - `none`
 
-Use it when you want explicit control over scaling policy or when scaler choice itself is part of the search space.
+Use `set_scaler_from_params()` for explicit scaling-policy control or search-time scaler choice.
 
 ### `RobustScaler`
 
@@ -105,11 +105,11 @@ Use it when you want explicit control over scaling policy or when scaler choice 
 (x - median) / IQR
 ```
 
-It skips datetime and non-numeric columns automatically and is usually the safest choice when heavy tails or outliers are distorting standardization.
+It skips datetime and non-numeric columns automatically and fits heavy-tail or outlier-distorted standardization cases.
 
 ### `RankGaussScaler`
 
-`RankGaussScaler(x_train, n_quantiles=1000)` maps numeric columns to an approximately Gaussian distribution through quantiles and the inverse normal CDF.
+`RankGaussScaler(x_train, n_quantiles=1000)` maps numeric columns to a quantile-Gaussian distribution through quantiles and the inverse normal CDF.
 
 Use it when relative ordering matters more than preserving original spacing. Its inverse transform is approximate, not exact.
 
@@ -132,19 +132,19 @@ It skips datetime and non-numeric columns automatically. It provides no inverse 
 All custom scalers should follow the same interface:
 
 ```python
-class YourScaler:
+class IdentityScaler:
     def __init__(self, x_train: pl.DataFrame, **kwargs):
-        ...
+        self.columns = x_train.columns
 
     def transform(self, df: pl.DataFrame) -> pl.DataFrame:
-        ...
+        return df
 ```
 
 Optional inverse helper:
 
 ```python
-def inverse_transform(df: pl.DataFrame, scaler: YourScaler) -> pl.DataFrame:
-    ...
+def inverse_transform(df: pl.DataFrame, scaler: IdentityScaler) -> pl.DataFrame:
+    return df
 ```
 
 That contract is what makes the scaler usable from `Manifest.set_scaler()` and compatible with post-processing flows that need to return to the original scale.
@@ -153,7 +153,7 @@ That contract is what makes the scaler usable from `Manifest.set_scaler()` and c
 
 - `RobustScaler`, `CausalRollingRobustScaler`, and `RankGaussScaler` automatically skip datetime and non-numeric columns.
 - `LogRegScaler` and `LinearScaler` are rule-driven, so only columns matched by their rule sets are transformed.
-- `LinearScaler` is the better choice when new feature names are expected to appear frequently.
+- `LinearScaler` fits cases where new feature names are expected to appear frequently.
 - If a prediction post-processing step needs original scale values, prefer a scaler with a meaningful inverse path.
 
 ## Read Next

--- a/docs/Semantic-Versioning.md
+++ b/docs/Semantic-Versioning.md
@@ -8,7 +8,7 @@ Use the current guide here:
 
 That external page is now the canonical source for version-bump policy across Vaquum projects.
 
-## Limen Local Scope
+## Limen local scope
 
 Use this page to find the policy, then apply the result to Limen's local version surfaces.
 
@@ -21,22 +21,18 @@ Limen-local version surfaces:
 | git tag `v<version>` | release identity expected by `scripts/create_release.py` |
 | docs and package references | update only when the changed behavior affects documented public surfaces |
 
-## Local Rules
+## Local rules
 
 - Do not invent a Limen-specific version policy here; use the shared Vaquum policy.
 - Keep `pyproject.toml`, changelog entry, release tag, and release notes aligned to the same version.
 - Treat docs-only changes as version-affecting only when the shared policy says the published package metadata should move.
 - If code behavior changes, update docs and changelog in the same PR when they are part of the public surface.
 
-## Review Notes
+## Review notes
 
-Version review should answer:
+Version review records the shared-policy category, the local files requiring version or changelog updates, and whether the release script reads the intended version from `pyproject.toml`.
 
-1. Which shared-policy category applies?
-2. Which local files need the version or changelog update?
-3. Does the release script already see the intended version in `pyproject.toml`?
-
-## Read Next
+## Read next
 
 - [Making a Release](Developer/Making-Release.md)
 - [Developer Home](Developer/README.md)

--- a/docs/Single-File-Decoder.md
+++ b/docs/Single-File-Decoder.md
@@ -1,21 +1,21 @@
-# Single File Decoder
+# Single file decoder
 
 A Single File Decoder (SFD) is the unit of experiment definition in Limen. It is a Python module that packages the parameter space together with either a declarative manifest or fully custom preparation and model functions.
 
-When you pass an SFD into `UniversalExperimentLoop`, Limen knows how to turn that module into an actual parameter sweep.
+`UniversalExperimentLoop` turns an SFD module into a parameter sweep.
 
-## Choose The SFD Style
+## Choose the SFD style
 
 Limen supports two SFD styles.
 
-| Style | Best for | Required functions | Data handling |
+| Style | Fit | Required functions | Data handling |
 |---|---|---|---|
-| manifest-driven | most Limen experiments, reproducible shared research, built-in workflows | `params()`, `manifest()` | data can be fetched automatically from the manifest |
-| custom functions | non-standard prep logic, external libraries, experimental flows | `params()`, `prep()`, `model()` | you pass `data=` explicitly to `UniversalExperimentLoop` |
+| manifest-driven | standard Limen experiments, reproducible shared research, built-in workflows | `params()`, `manifest()` | data can be fetched automatically from the manifest |
+| custom functions | non-standard prep logic, external libraries, experimental flows | `params()`, `prep()`, `model()` | caller passes `data=` explicitly to `UniversalExperimentLoop` |
 
-In practice, the manifest-driven path should be your default. Reach for the custom path only when the declarative pipeline is too restrictive for the job.
+The manifest-driven path is the default. Use the custom path only when the declarative pipeline is too restrictive for the job.
 
-## What Every SFD Must Expose
+## What every SFD must expose
 
 Every SFD must expose `params()`.
 
@@ -30,14 +30,14 @@ def params():
 
 `params()` returns the search space dictionary. Each key is a parameter name and each value must be a list, even when only one value is present.
 
-### `params()` Rules
+### `params()` rules
 
 - the return value must be a dictionary
 - every value must be a list
-- the individual values are usually scalars such as ints, floats, strings, booleans, or callables
-- structured values are possible when a manifest step explicitly expects them, but keep them deterministic and easy to inspect
+- individual values are scalars such as ints, floats, strings, booleans, or callables
+- structured values are possible when a manifest step explicitly expects them; keep them deterministic and inspectable
 
-## Manifest-Driven SFDs
+## Manifest-driven SFDs
 
 Manifest-driven SFDs expose `manifest()` instead of custom `prep()` and `model()` functions.
 
@@ -85,22 +85,22 @@ def manifest() -> Manifest:
 
 This style is how Limen's foundational SFDs are built.
 
-### What You Get From The Manifest Path
+### What the manifest path provides
 
 - declarative data fetching
 - split-first prep with train-only fitting
 - automatic prep/model wiring inside `UniversalExperimentLoop`
-- better reproducibility and clearer collaboration surface
+- reproducible collaboration surface
 
-### Runtime Rules For Manifest-Driven SFDs
+### Runtime rules for manifest-driven SFDs
 
-- `UniversalExperimentLoop.run(..., prep_each_round=True)` is required
-- you cannot override `prep` or `model` in `run()`
-- if you do not pass `data=`, Limen fetches data from the manifest
+- `UniversalExperimentLoop.run(prep_each_round=True)` is required
+- `prep` and `model` cannot be overridden in `run()`
+- when `data=` is omitted, Limen fetches data from the manifest
 
 ## Custom SFDs
 
-Custom SFDs expose `prep()` and `model()` directly. Use this path when you need full control over data preparation or do not want to express the pipeline through a manifest.
+Custom SFDs expose `prep()` and `model()` directly. Use this path for full control over data preparation or workflows that do not fit the manifest pipeline.
 
 ```python
 import polars as pl
@@ -135,7 +135,7 @@ def model(data: dict, round_params: dict):
     return results
 ```
 
-In this style you pass the input dataframe explicitly:
+This style passes the input dataframe explicitly:
 
 ```python
 import limen
@@ -149,39 +149,39 @@ uel = limen.UniversalExperimentLoop(data=data, sfd=my_custom_sfd)
 
 Custom `prep()` receives the experiment dataframe and the round-specific parameters. It must return a `data_dict` that the model function can consume.
 
-Good defaults:
+Defaults:
 
 - keep `datetime` in the dataframe until just before `split_data_to_prep_output()`
-- capture `all_datetimes = data['datetime'].to_list()` before dropping rows if you want correct alignment metadata
+- capture `all_datetimes = data['datetime'].to_list()` before dropping rows when alignment metadata is required
 - make the function deterministic with respect to `round_params`
 
 ### `model(data, round_params)`
 
-Custom `model()` receives the prepared `data_dict` and the round parameters. It must return a results dictionary, typically produced by one of:
+Custom `model()` receives the prepared `data_dict` and the round parameters. It must return a results dictionary produced by one of:
 
 - `limen.metrics.binary_metrics`
 - `limen.metrics.multiclass_metrics`
 - `limen.metrics.continuous_metrics`
 
-If you want predictions to be available through `uel.preds` and `Log`, include:
+For predictions available through `uel.preds` and `Log`, include:
 
 ```python
 round_results['_preds'] = preds
 ```
 
-If your prep stage fits an object that should be preserved, put it into the data dict under:
+Fitted prep-stage objects that should be preserved belong in the data dict under:
 
 ```python
 data_dict['_scaler'] = fitted_scaler
 ```
 
-## Foundational Vs Custom
+## Foundational versus custom
 
 Limen ships foundational SFDs under `limen.sfd.foundational_sfd`. These are reference implementations that show the preferred style for shared Limen workflows.
 
-Custom SFDs are your own experiment modules. They can use the same manifest system, or they can take the custom `prep()` and `model()` path when the workflow demands it.
+Custom SFDs are project experiment modules. They can use the same manifest system or the custom `prep()` and `model()` path.
 
-## Foundational SFDs Versus Reference Architecture
+## Foundational SFDs versus reference architecture
 
 There is one more design split that matters in practice:
 
@@ -204,10 +204,10 @@ On a live local smoke pass in this repo:
 
 Use [Built-In SFDs](Built-In-SFDs.md) for the current shipped catalog and [Reference Architecture](Reference-Architecture.md) for the model layer underneath it.
 
-## Read Next
+## Read next
 
 - Continue to [Built-In SFDs](Built-In-SFDs.md) for the shipped foundational decoder catalog.
-- Continue to [Experiment Manifest](Experiment-Manifest.md) for the full declarative pipeline used by most SFDs.
+- Continue to [Experiment Manifest](Experiment-Manifest.md) for the full declarative pipeline used by standard SFDs.
 - Continue to [Universal Experiment Loop](Universal-Experiment-Loop.md) to run an SFD.
-- Continue to [Reference Architecture](Reference-Architecture.md) if you are authoring model implementations rather than only packaged decoders.
+- Continue to [Reference Architecture](Reference-Architecture.md) for model implementation authoring beyond packaged decoders.
 - Use [Indicators](Indicators.md), [Features](Features.md), [Transforms](Transforms.md), and [Scalers](Scalers.md) as the reference layer while authoring new SFDs.

--- a/docs/Standard-Metrics-Library.md
+++ b/docs/Standard-Metrics-Library.md
@@ -31,13 +31,11 @@ Why this matters:
 - `balanced_metric` is re-exported as a callable
 - `limen.metrics` re-exports `binary_metrics`, `multiclass_metrics`, `continuous_metrics`, and `safe_ovr_auc` as modules
 
-So if you write:
+The package-root import returns the module, not the function:
 
 ```python
 from limen.metrics import binary_metrics
 ```
-
-you are importing the module, not the function.
 
 This low-level metrics layer also sits underneath [Reference Architecture](Reference-Architecture.md). The class-based models add confusion and backtest fields later; these helpers stay at the smaller task-metric level.
 
@@ -59,7 +57,7 @@ Returns a dictionary with:
 - `auc`
 - `accuracy`
 
-On a live local `LogRegBinary.evaluate(..., inline_metrics=False)` run in this repo, this task-metric layer was exactly:
+On a live local `LogRegBinary.evaluate(data, inline_metrics=False)` run in this repo, this task-metric layer was exactly:
 
 - `accuracy`
 - `auc`
@@ -147,14 +145,16 @@ If no valid class-vs-rest comparisons can be made, it returns `NaN`.
 
 ## Where These Helpers Fit
 
-A typical reference-architecture model function looks like:
+A reference-architecture model function has this shape:
 
 ```python
+import numpy as np
+
 from limen.metrics.binary_metrics import binary_metrics
 
-def model(data, ...):
-    preds = ...
-    probs = ...
+def model(data):
+    preds = np.zeros(len(data['y_test']), dtype=int)
+    probs = np.zeros(len(data['y_test']), dtype=float)
 
     results = binary_metrics(data, preds, probs)
     results['_preds'] = preds

--- a/docs/Targets.md
+++ b/docs/Targets.md
@@ -382,8 +382,7 @@ class MyTarget:
 
     def transform(self, data: pl.DataFrame, **transform_params) -> pl.DataFrame:
         return data.with_columns(
-            # ... compute label ...
-            .alias(self.target_name)
+            (pl.col('close').shift(-1) > pl.col('close')).cast(pl.Int8).alias(self.target_name)
         )
 ```
 

--- a/docs/TechnicalDebt.md
+++ b/docs/TechnicalDebt.md
@@ -4,7 +4,7 @@ Known technical debt in shipped Limen code. Each item includes origin PR, severi
 
 ## Register Rules
 
-Use this page only for debt that is accepted and intentionally carried. Do not use it as a general TODO list.
+Use this page only for debt that is accepted and intentionally carried. Do not use it as a general task backlog.
 
 Each entry should include:
 

--- a/docs/Trainer.md
+++ b/docs/Trainer.md
@@ -1,12 +1,12 @@
 # Trainer
 
-`Trainer` is Limen's promotion layer for finished experiment rounds. It takes a completed artifact-rich experiment directory, reconstructs the manifest and round parameters, validates selected permutations, and retrains them into reusable `Sensor` objects.
+`Trainer` is Limen's promotion layer for finished experiment rounds. It takes a completed artifact-backed experiment directory, reconstructs the manifest and round parameters, validates selected permutations, and retrains them into reusable `Sensor` objects.
 
-This is the bridge between "a good row in an experiment" and "a trained model object I can carry forward."
+Trainer bridges a selected experiment row and a trained model object for downstream inference.
 
-## What Trainer Needs
+## What Trainer needs
 
-Trainer works only with experiments that were run through the artifact-rich UEL path and wrote an `experiment_dir`.
+Trainer works only with experiments that were run through the artifact-backed UEL path and wrote an `experiment_dir`.
 
 At minimum, the directory must contain:
 
@@ -17,11 +17,11 @@ If `results.csv` is also present, Trainer validates the retrained metrics agains
 
 ## Prerequisites
 
-- the experiment must have been created with `experiment_dir=...`
+- the experiment must have been created with `experiment_dir='experiments/logreg-first'`
 - the experiment must be YAML-based (created via `limen run`)
 - the SFD must be a manifest-driven ML architecture (rule-based architectures are not supported)
 
-## Typical Workflow
+## Workflow
 
 Start from an existing experiment directory:
 
@@ -45,12 +45,12 @@ bar_pred = sensor.predict(raw_klines)
 In this workflow:
 
 - `Trainer` reconstructs the manifest and round metadata
-- `train([ ... ])` validates and retrains the selected rounds
+- `trainer.train(top_ids)` validates and retrains the selected rounds
 - each returned `Sensor` wraps one trained `ReferenceModel`
 
 ## Why Trainer Exists
 
-Experiment runs are usually done on train/validation/test splits. Promotion is different: once a round is selected, you usually want to retrain it on all available data before carrying it downstream.
+Experiment runs normally use train/validation/test splits. Promotion retrains a selected round on all available data before downstream use.
 
 Trainer handles that transition cleanly by:
 
@@ -58,16 +58,16 @@ Trainer handles that transition cleanly by:
 - validating that the pipeline still reproduces the logged round metrics
 - wrapping the validated model in a `Sensor` ready for inference
 
-## Training and Validation
+## Training and validation
 
 Trainer reruns:
 
-- `manifest.prepare_data(...)`
-- `manifest.run_model(...)`
+- `manifest.prepare_data(data, round_params)`
+- `manifest.run_model(prepared, round_params)`
 
 with the original round parameters and wraps the resulting model in a `Sensor`. If `results.csv` is present, it also compares the resulting metrics against the original experiment log.
 
-If the model is deterministic, validation expects an exact match within a very small float tolerance. If the model is stochastic, Trainer uses a looser scaled tolerance.
+Deterministic models require near-exact metric matches. Stochastic models use a scaled tolerance.
 
 If validation fails, Trainer raises `ReconstructionError`.
 
@@ -82,7 +82,7 @@ except ReconstructionError as e:
 
 This is Limen's guard against pipeline drift.
 
-## Deterministic Vs Stochastic Models
+## Deterministic versus stochastic models
 
 Trainer uses the model class's `deterministic` attribute to choose the validation tolerance.
 
@@ -93,7 +93,7 @@ Trainer uses the model class's `deterministic` attribute to choose the validatio
 
 This is why promotion is more reliable for deterministic reference models than for intentionally stochastic ones.
 
-## Trainer And The Reference-Architecture Contract
+## Trainer and the reference-architecture contract
 
 Trainer does not promote arbitrary model objects. It resolves exactly one `ReferenceModel` subclass from the original model module and uses that class for retraining.
 
@@ -113,7 +113,7 @@ That means the promotion stack depends on the [Reference Architecture](Reference
 | `experiment_dir` | path to the completed experiment directory |
 | `data` | optional dataframe override; if omitted, Trainer fetches data from the reconstructed manifest |
 
-Use `data=` when you already have the exact dataframe you want Trainer to use. Otherwise Trainer falls back to `manifest.fetch_data()`.
+Use `data=` with an exact dataframe override. Otherwise Trainer falls back to `manifest.fetch_data()`.
 
 ## `train(permutation_ids)`
 
@@ -145,19 +145,19 @@ Each sensor exposes:
 - `manifest_id` — SHA-256 content hash of the YAML manifest, carried from `metadata.json` for traceability
 - `round_params` — parameter values used for this permutation
 
-### Example
+### Sensor example
 
 ```python
 sensor = sensors[0]
 
-print(sensor.permutation_id)   # 'sha256:a3f1...'
-print(sensor.manifest_id)      # 'sha256:7c2e...'
+print(sensor.permutation_id)   # 'sha256:a3f1c9'
+print(sensor.manifest_id)      # 'sha256:7c2e41'
 print(sensor.round_params)
 
 bar_pred = sensor.predict(raw_klines)
 ```
 
-Sensors are also callable — `__call__` aliases `predict_all` and returns `list[BarPrediction]`, one entry per bar. Use this in replay loops:
+Sensors are also callable. `__call__` aliases `predict_all` and returns `list[BarPrediction]`, one entry per bar:
 
 ```python
 all_preds = sensor(raw_klines)  # list[BarPrediction]
@@ -198,7 +198,7 @@ On unexpected exceptions the method returns a list of `reason='sensor-error'` en
 
 All reference models need only `x_test` for inference. Calibrated models (those trained with `use_calibration: true`) store the fitted calibrator internally during the training evaluation step; subsequent `predict()` calls reuse it without needing `x_val` or `y_val`. The caller never needs to supply validation data at inference time.
 
-## What Trainer Reads From Disk
+## What Trainer reads from disk
 
 Trainer uses:
 
@@ -206,17 +206,17 @@ Trainer uses:
 - `round_data.jsonl` — loads `round_params` for each permutation
 - `results.csv` — when available, validates retrained metrics against the original experiment log
 
-## Scope Note
+## Scope note
 
-Trainer depends on the artifact-rich UEL path, which in turn depends on a concrete `SearchStrategy`. Limen ships built-in strategies (`GridStrategy`, `RandomStrategy`) and the `SearchStrategy` abstraction for writing your own.
+Trainer depends on the artifact-backed UEL path, which in turn depends on a concrete `SearchStrategy`. Limen ships built-in strategies (`GridStrategy`, `RandomStrategy`) and the `SearchStrategy` abstraction for custom strategies.
 
-So the clean mental model is:
+The operating model is:
 
-- UEL artifact-rich runs create the promotion-ready experiment directory
+- UEL artifact-backed runs create the promotion-ready experiment directory
 - Trainer turns selected rounds from that directory into sensors
 
-## Read Next
+## Read next
 
 - Continue to [Reference Architecture](Reference-Architecture.md) for the class-based model contract that Trainer reconstructs and retrains.
-- Continue to [Cohort](Cohort.md) if you want to bind selected sensors into an ensemble inference surface.
-- Continue to [Universal Experiment Loop](Universal-Experiment-Loop.md) if you need the run layer that produces `experiment_dir`.
+- Continue to [Cohort](Cohort.md) to bind selected sensors into an ensemble inference surface.
+- Continue to [Universal Experiment Loop](Universal-Experiment-Loop.md) for the run layer that produces `experiment_dir`.

--- a/docs/Transforms.md
+++ b/docs/Transforms.md
@@ -1,22 +1,22 @@
 # Transforms
 
-Transforms in Limen are lightweight helpers used during data preparation or target construction. They are not the same thing as train-fitted scalers. For probability calibration and threshold optimization, see `limen.calibration`.
+Transforms in Limen are stateless helpers used during data preparation or target construction. They are not the same thing as train-fitted scalers. For probability calibration and threshold optimization, see `limen.calibration`.
 
-Use this page when you need to shape a target, clip or normalize a frame in a stateless way. For train-only fitted preprocessing, see [Scalers](Scalers.md).
+This page covers stateless target shaping, clipping, and frame normalization. For train-only fitted preprocessing, see [Scalers](Scalers.md).
 
-## DataFrame Transforms
+## DataFrame transforms
 
-These helpers operate on the frame passed into them. They do not carry learned state across splits. If you call them separately on train, validation, and test, each call uses the statistics of the frame it received.
+These helpers operate on the frame passed into them. They do not carry learned state across splits. Separate calls on train, validation, and test use the statistics of the frame passed to that call.
 
 | Function | Behavior | Notes |
 |---|---|---|
 | `mad_transform(df, time_col='datetime')` | rescales numeric columns by median absolute deviation | Leaves the time column untouched. |
-| `winsorize_transform(df, time_col='datetime')` | clips numeric columns to fixed 1% and 99% quantiles | Good when you want to tame outliers without dropping rows. |
+| `winsorize_transform(df, time_col='datetime')` | clips numeric columns to fixed 1% and 99% quantiles | Preserves rows while capping outliers. |
 | `quantile_trim_transform(df, time_col='datetime')` | removes rows outside fixed 0.5% and 99.5% bounds across numeric columns | More aggressive than winsorization because rows can disappear. |
 | `zscore_transform(df, time_col='datetime')` | standardizes numeric columns to mean zero and unit variance | Stateless per call, unlike a train-fitted scaler. |
 | `shift_column_transform(data, shift, column)` | shifts one column in place | Common in target construction. Negative values shift forward in time. |
 
-## Function Reference
+## Function reference
 
 ### `mad_transform(df, *, time_col='datetime')`
 
@@ -77,11 +77,11 @@ Return behavior:
 - nulls are introduced at the shifted boundary
 - the target column must exist in `data`
 
-## Manifest Usage
+## Manifest usage
 
-Transforms usually appear in manifest target construction or as callable helpers inside a custom SFD prep path. The important split-safety rule is that stateless transforms do not remember train statistics. If validation and test must use train-fitted parameters, use [Scalers](Scalers.md) or a target class that fits on train in `__init__`.
+Transforms appear in manifest target construction or as callable helpers inside a custom SFD prep path. The important split-safety rule is that stateless transforms do not remember train statistics. If validation and test must use train-fitted parameters, use [Scalers](Scalers.md) or a target class that fits on train in `__init__`.
 
-## Target-Building Example
+## Target-building example
 
 ```python
 from limen.targets import QuantileBinaryTarget
@@ -98,15 +98,15 @@ The important detail is that `QuantileBinaryTarget.__init__` computes the cutoff
 
 ## Boundaries
 
-- Use a transform when the operation is lightweight and local to the frame or prediction arrays you already have.
+- Use a transform when the operation is stateless and local to the frame or prediction arrays.
 - Use a scaler when the operation must be fitted on train and then reused unchanged on validation and test.
-- If you need split-safe learned parameters inside a target, compute them through the manifest target builder rather than hiding the fitting inside the transform itself.
+- Compute split-safe learned parameters through the manifest target builder rather than hiding the fitting inside the transform itself.
 - For probability calibration and threshold selection after model training, use `limen.calibration` and the manifest's `with_calibration()` builder.
 - Use `quantile_trim_transform` only when row removal is acceptable for the downstream split. If preserving row alignment matters, prefer `winsorize_transform`.
-- Keep `time_col` explicit when your time column is not named `datetime`; otherwise it will be transformed like any other numeric column.
+- Keep `time_col` explicit when the time column is not named `datetime`; otherwise it will be transformed like any other numeric column.
 
-## Read Next
+## Read next
 
 - [Scalers](Scalers.md) for train-fitted preprocessing
-- [Features](Features.md) for target and regime helpers that often pair with transforms
+- [Features](Features.md) for target and regime helpers paired with transforms
 - [Experiment Manifest](Experiment-Manifest.md) for where transforms live in the split-first execution order

--- a/docs/Universal-Experiment-Loop.md
+++ b/docs/Universal-Experiment-Loop.md
@@ -1,28 +1,28 @@
-# Universal Experiment Loop
+# Universal experiment loop
 
 The Universal Experiment Loop (UEL) is Limen's experiment runner. It takes an SFD, executes parameter combinations, streams a CSV log, and then exposes post-run analysis surfaces such as confusion metrics and backtest results.
 
-This is the page to read when you want to answer four practical questions:
+This page covers:
 
 - how to run a first experiment
 - what `UniversalExperimentLoop` actually stores after a run
-- when to use the simple run path versus the advanced artifact-rich path
+- when to use the standard run path versus the advanced artifact-backed path
 - which run-time rules matter for manifest-driven and custom SFDs
 
-## Two Execution Modes
+## Two execution modes
 
 UEL currently has two execution modes.
 
-| Mode | How you enter it | Best for | What you get |
+| Mode | Entry path | Fits | Outputs |
 |---|---|---|---|
-| standard run path | instantiate with `sfd=` and optionally `data=`, then call `run()` without a `search_strategy` | most public examples and straightforward sweeps | in-memory UEL artifacts plus a streaming CSV at `<experiment_name>.csv`, or `<experiment_dir>/<experiment_name>.csv` when `experiment_dir` is set |
-| MSQ / artifact-rich path | instantiate with a concrete `search_strategy`, optionally `experiment_dir`, then call `run()` | advanced search flows, checkpointing, resumability, trainer workflows | `results.csv`, `round_data.jsonl`, checkpoints, audit trail, metadata, and in-memory UEL artifacts |
+| standard run path | instantiate with `sfd=` and optionally `data=`, then call `run()` without a `search_strategy` | public examples and direct sweeps | in-memory UEL artifacts plus a streaming CSV at `<experiment_name>.csv`, or `<experiment_dir>/<experiment_name>.csv` when `experiment_dir` is set |
+| MSQ / artifact-backed path | instantiate with a concrete `search_strategy`, optionally `experiment_dir`, then call `run()` | advanced search flows, checkpointing, resumability, trainer workflows | `results.csv`, `round_data.jsonl`, checkpoints, audit trail, metadata, and in-memory UEL artifacts |
 
-The standard run path is the right starting point for most readers. The advanced path is real and supported, but it is an extension-oriented surface built around `SearchStrategy`.
+The standard run path is the starting point for public examples and direct sweeps. The advanced path is supported and extension-oriented through `SearchStrategy`.
 
-## First Real Run
+## First real run
 
-This is the most reliable local example because it uses the file-backed spot-kline path with explicit `kline_size` and `row_count_limit`.
+This local example uses the file-backed spot-kline path with explicit `kline_size` and `row_count_limit`.
 
 ```python
 import limen
@@ -44,7 +44,7 @@ uel.run(
 )
 ```
 
-After the run you can inspect:
+After the run, these attributes are available:
 
 ```python
 uel.experiment_log
@@ -59,7 +59,7 @@ On a live local run over that file-backed input, that produced:
 - `uel.experiment_backtest_results` with one row per round
 - `uel.preds`, `uel.round_params`, and `uel._alignment` for round-level reconstruction
 
-## Constructor Contract
+## Constructor contract
 
 ```python
 uel = limen.UniversalExperimentLoop(
@@ -83,11 +83,11 @@ uel = limen.UniversalExperimentLoop(
 
 ### Data behavior
 
-- If the SFD exposes `manifest()` and you do not pass `data=`, UEL fetches data from the manifest.
+- If the SFD exposes `manifest()` and `data=` is omitted, UEL fetches data from the manifest.
 - If the SFD is custom and has no manifest, `data=` is required.
 - For manifest-driven SFDs, the data source used is `fetch_data()` by default; pass `test_mode=True` to use the test data source.
 
-## `run()` Contract
+## `run()` contract
 
 ```python
 uel.run(
@@ -121,13 +121,13 @@ If the SFD uses `manifest()`:
 
 If the SFD uses custom `prep()` and `model()`:
 
-- `data=` must be provided when you instantiate UEL
+- `data=` must be provided when UEL is instantiated
 - `prep_each_round` can be `True` or `False`, depending on whether prep depends on round params
 - `params=`, `prep=`, and `model=` overrides are available on the standard path
 
-## What UEL Stores After A Run
+## What UEL stores after a run
 
-The most important attributes are:
+Primary attributes are:
 
 | Attribute | Meaning |
 |---|---|
@@ -154,15 +154,15 @@ This is what lets downstream analysis stay aligned with the actual test window s
 
 ### Deeper post-run analysis
 
-UEL constructs a `Log` instance automatically at the end of a successful run. That gives you access to methods such as:
+UEL constructs a `Log` instance automatically at the end of a successful run. That exposes methods such as:
 
 - `uel._log.permutation_prediction_performance(round_id=0)`
 - `uel._log.permutation_confusion_metrics('price_change', round_id=0)`
 - `uel.experiment_parameter_correlation('auc')`
 
-## Standard Path Versus Artifact-Rich Path
+## Standard path versus artifact-backed path
 
-### Standard Path
+### Standard path
 
 The standard path writes a streaming CSV at:
 
@@ -182,12 +182,12 @@ This is the path to use for:
 
 - first experiments
 - docs examples
-- quick local research loops
-- simple parameter sweeps
+- direct local research loops
+- direct parameter sweeps
 
-### Artifact-Rich Path
+### Artifact-backed path
 
-If you instantiate UEL with a concrete `search_strategy` and an `experiment_dir`, Limen stores structured artifacts there. This path uses `results.csv` as the round log filename rather than `<experiment_name>.csv`.
+When UEL is instantiated with a concrete `search_strategy` and an `experiment_dir`, Limen stores structured artifacts there. This path uses `results.csv` as the round log filename rather than `<experiment_name>.csv`.
 
 | File | Meaning |
 |---|---|
@@ -195,18 +195,18 @@ If you instantiate UEL with a concrete `search_strategy` and an `experiment_dir`
 | `round_data.jsonl` | round params, predictions, and alignment metadata |
 | `checkpoint.json` | checkpoint state for resumption |
 | `audit.jsonl` | feedback-controller audit trail |
-| `interventions.json` | optional external intervention file polled by the feedback controller if you create it |
+| `interventions.json` | optional external intervention file polled by the feedback controller when the file exists |
 | `metadata.json` | experiment metadata used by `Trainer` |
 
 This path is what powers checkpointing, resumability, and the [Trainer](Trainer.md) workflow.
 
 ### Important scope note
 
-Limen ships built-in strategies (`GridStrategy`, `RandomStrategy`) and the `SearchStrategy` abstraction for writing your own. The advanced path is available now with the built-in strategies or a custom implementation from your codebase.
+Limen ships built-in strategies (`GridStrategy`, `RandomStrategy`) and the `SearchStrategy` abstraction for custom strategies. The advanced path is available with built-in strategies or a custom implementation from the caller's codebase.
 
-## One Real Advanced Run
+## One real advanced run
 
-The UEL-facing part of an advanced run looks like this once you already have a concrete `SearchStrategy`:
+The UEL-facing part of an advanced run looks like this with a concrete `SearchStrategy`:
 
 ```python
 import limen
@@ -242,9 +242,9 @@ On a live local run in this repo, that advanced run:
 - wrote `1` entry to `audit.jsonl`
 - saved a checkpoint after round `3`
 
-That behavior came from a reducer-triggered trim during the feedback cycle, not from a simple early stop.
+That behavior came from a reducer-triggered trim during the feedback cycle, not an early stop.
 
-## Resume In Practice
+## Resume in practice
 
 Resumption belongs only to the advanced path:
 
@@ -271,22 +271,22 @@ For the full advanced-search contract, continue to [Advanced Search](Advanced-Se
 
 ### Manifest-driven runs require `prep_each_round=True`
 
-If you run a manifest-driven SFD with `prep_each_round=False`, UEL currently raises the exact runtime string `prep_each_round must be True for manifest-driven SFMs`. The `SFM` wording there is legacy runtime text, not current docs terminology. Set `prep_each_round=True`.
+A manifest-driven SFD with `prep_each_round=False` raises the exact runtime string `prep_each_round must be True for manifest-driven SFMs`. The `SFM` wording is legacy runtime text, not current docs terminology. Set `prep_each_round=True`.
 
 ### Manifest-driven runs cannot override `prep` or `model`
 
-If you pass `prep=` or `model=` to `run()` for a manifest-driven SFD, UEL currently raises `Cannot override prep/model when SFM has manifest`. That `SFM` wording is also legacy runtime text. Put the logic into the manifest instead, or switch to the custom SFD path.
+Passing `prep=` or `model=` to `run()` for a manifest-driven SFD raises `Cannot override prep/model when SFM has manifest`. That `SFM` wording is legacy runtime text. Put the logic into the manifest, or switch to the custom SFD path.
 
 ### Custom SFDs require explicit `data=`
 
-If you instantiate UEL with a custom SFD and omit `data=`, UEL raises `data parameter required for custom SFDs using custom functions approach`.
+A custom SFD with omitted `data=` raises `data parameter required for custom SFDs using custom functions approach`.
 
 ### Resuming requires a search strategy
 
-Resumption belongs to the advanced path. If you call `run(..., resume=True)` without a search strategy, UEL raises `resume=True is only supported with a search_strategy`.
+Resumption belongs to the advanced path. Calling `run(resume=True)` without a search strategy raises `resume=True is only supported with a search_strategy`.
 
-## Read Next
+## Read next
 
 - Continue to [Log](Log.md) to understand the analysis surfaces built on top of UEL results.
-- Continue to [Experiment Manifest](Experiment-Manifest.md) if you are building a manifest-driven SFD.
-- Continue to [Trainer](Trainer.md) if you are using the artifact-rich path and want to retrain finished rounds into sensors.
+- Continue to [Experiment Manifest](Experiment-Manifest.md) for manifest-driven SFD construction.
+- Continue to [Trainer](Trainer.md) for artifact-backed retraining of finished rounds into sensors.

--- a/docs/Utilities.md
+++ b/docs/Utilities.md
@@ -2,18 +2,18 @@
 
 Utilities are the smaller helper surfaces that support Limen workflows without defining one primary subsystem of their own.
 
-They are useful, but they are not the main story of the package. If you are new to Limen, learn [Universal Experiment Loop](Universal-Experiment-Loop.md), [Experiment Manifest](Experiment-Manifest.md), and [Log](Log.md) first.
+They support the package, but they are not the main workflow. New Limen readers should start with [Universal Experiment Loop](Universal-Experiment-Loop.md), [Experiment Manifest](Experiment-Manifest.md), and [Log](Log.md).
 
-## Current Public Utility Surface
+## Current public utility surface
 
-| Helper | Use it when |
+| Helper | Use case |
 |---|---|
-| `ParamSpace` | you are on the legacy standard UEL path and need sampled parameter combinations |
-| `data_dict_to_numpy` | you want numpy arrays from the standard Limen `data_dict` |
-| `adf_test` and `AdfResult` | you want a simple stationarity check for a series or for helpers such as `find_min_d` |
-| `confidence_filtering_system` | you want validation-calibrated confidence filtering across multiple models |
-| `split_by_dates` | you want absolute-datetime train / val / test splits (the helper backing `Manifest.set_split_dates`) |
-| reporting helpers | you want simple formatted text blocks |
+| `ParamSpace` | legacy standard UEL path requiring sampled parameter combinations |
+| `data_dict_to_numpy` | numpy arrays from the standard Limen `data_dict` |
+| `adf_test` and `AdfResult` | stationarity check for a series or for helpers such as `find_min_d` |
+| `confidence_filtering_system` | validation-calibrated confidence filtering across multiple models |
+| `split_by_dates` | absolute-datetime train / val / test splits (the helper backing `Manifest.set_split_dates`) |
+| reporting helpers | formatted text blocks |
 
 ## `ParamSpace`
 
@@ -35,7 +35,7 @@ On a live local run in this repo, that parameter space had:
 
 Then repeated `generate(random_search=False)` calls returned the remaining sampled combinations in order from the internal sampled pool, not from the full original grid.
 
-Use `ParamSpace` only when you are intentionally on the legacy UEL path. The advanced path uses [Advanced Search](Advanced-Search.md) primitives instead.
+Use `ParamSpace` only on the legacy UEL path. The advanced path uses [Advanced Search](Advanced-Search.md) primitives instead.
 
 ## `data_dict_to_numpy`
 
@@ -54,7 +54,7 @@ On a live local manifest-prepared `data_dict` in this repo, it converted:
 - `x_val` to shape `(428, 24)`
 - `x_test` to shape `(884, 24)`
 
-This helper is most useful inside sklearn-style or numpy-first model code.
+This helper supports sklearn-style or numpy-first model code.
 
 ## `adf_test`
 
@@ -93,7 +93,7 @@ It returns:
 
 In a live synthetic-model run in this repo with `target_confidence=0.8`, it returned:
 
-- coverage of about `0.867`
+- coverage value `0.867`
 - a threshold near zero on that particular synthetic setup
 - a results frame with columns:
   - `datetime`
@@ -132,7 +132,7 @@ Behavior rules:
 
 Prefer `Manifest.set_split_dates` inside the experiment pipeline — it pairs the splitter with the manifest's ordering validation and `with_params_override` clearance contract. Use `split_by_dates` directly when the manifest pipeline is not in play.
 
-## Reporting Helpers
+## Reporting helpers
 
 The reporting helpers are small text-formatting functions:
 
@@ -140,10 +140,10 @@ The reporting helpers are small text-formatting functions:
 - `format_report_section`
 - `format_report_footer`
 
-These are lightweight utilities, not a canonical reporting framework.
+These are text-formatting utilities, not a canonical reporting framework.
 
-## Read Next
+## Read next
 
 - Continue to [Universal Experiment Loop](Universal-Experiment-Loop.md) for the legacy path that still uses `ParamSpace`.
-- Continue to [Advanced Search](Advanced-Search.md) for the newer search abstractions that replace `ParamSpace` in artifact-rich runs.
-- Continue to [Reference Architecture](Reference-Architecture.md) if you are using `data_dict_to_numpy()` inside model code.
+- Continue to [Advanced Search](Advanced-Search.md) for the newer search abstractions that replace `ParamSpace` in artifact-backed runs.
+- Continue to [Reference Architecture](Reference-Architecture.md) for `data_dict_to_numpy()` usage inside model code.

--- a/limen/backtest/README.md
+++ b/limen/backtest/README.md
@@ -15,10 +15,10 @@ Does **not** own signal generation, experiment logging, or portfolio bookkeeping
 
 ## Key entry points
 
-| Entry point | Use it when | Notes |
+| Entry point | Use case | Notes |
 |-------------|-------------|-------|
-| `backtest_snapshot` | You want the fast, vectorized evaluation used across many rounds | Import from `limen.backtest.backtest_snapshot` |
-| `long_flat_strategy` | You want the default execution model, or a template for a new strategy | Returns an `ExecutionResult`; import from `limen.backtest.long_flat_strategy` |
+| `backtest_snapshot` | Vectorized evaluation across rounds | Import from `limen.backtest.backtest_snapshot` |
+| `long_flat_strategy` | Default execution model, or a template for a new strategy | Returns an `ExecutionResult`; import from `limen.backtest.long_flat_strategy` |
 
 ## Adjacent modules
 
@@ -36,7 +36,7 @@ backtest/
 ## Things to know
 
 - The package root currently does not re-export the backtest helpers, so import from the module paths directly.
-- `backtest_snapshot()` is the common analysis path for experiment sweeps because it is simple and fast.
+- `backtest_snapshot()` is the standard analysis path for vectorized experiment-sweep evaluation.
 - Snapshot outputs are reported in percent units, while fee and slippage inputs are specified in basis points.
 
 ## Read next

--- a/limen/calibration/README.md
+++ b/limen/calibration/README.md
@@ -15,13 +15,13 @@ Does **not** own target construction, scaler fitting, model training, or downstr
 
 ## Key entry points
 
-| Entry point | Use it when | Notes |
+| Entry point | Use case | Notes |
 | --- | --- | --- |
-| `CalibratorProtocol`, `ThresholdOptimizerProtocol` | You need the callable contracts for custom calibration or threshold functions | Used by manifest calibration wiring and pipeline helpers. |
-| `fit_calibrator` | You need to fit the configured calibrator and threshold on validation data | Returns the fitted predictor, selected threshold, and validation score. |
-| `apply_calibrated_predict` | You need to apply calibration and thresholding to test predictions | Returns `_preds`, `_probs`, `optimal_threshold`, and `val_score`. |
-| `sklearn_probability_calibrator` | You need scikit-learn probability calibration | Supports isotonic and sigmoid calibration. |
-| `grid_threshold_optimizer` | You need a threshold optimizer over calibrated or raw probabilities | Produces the decision cutoff used for binary predictions. |
+| `CalibratorProtocol`, `ThresholdOptimizerProtocol` | Callable contracts for custom calibration or threshold functions | Used by manifest calibration wiring and pipeline helpers. |
+| `fit_calibrator` | Fit the configured calibrator and threshold on validation data | Returns the fitted predictor, selected threshold, and validation score. |
+| `apply_calibrated_predict` | Apply calibration and thresholding to test predictions | Returns `_preds`, `_probs`, `optimal_threshold`, and `val_score`. |
+| `sklearn_probability_calibrator` | Scikit-learn probability calibration | Supports isotonic and sigmoid calibration. |
+| `grid_threshold_optimizer` | Threshold optimizer over calibrated or raw probabilities | Produces the decision cutoff used for binary predictions. |
 
 ## Adjacent modules
 

--- a/limen/cli/README.md
+++ b/limen/cli/README.md
@@ -15,16 +15,16 @@ Does **not** own manifest semantics, experiment execution internals, model behav
 
 ## Key entry points
 
-| Entry point | Use it when | Notes |
+| Entry point | Use case | Notes |
 | --- | --- | --- |
-| `limen.cli.main:cli` | You need the Click command group exported by the package script | Registered as the `limen` console script. |
-| `commands/validate.py` | You need YAML validation from the shell | Uses `limen.yaml` validation. |
-| `commands/profile.py` | You need static permutation profiling for YAML manifests | Runtime sampling is skipped for validated CLI YAML. |
-| `commands/run.py` | You need to execute a YAML experiment | Compiles YAML into a manifest and runs UEL. |
-| `commands/resume.py` | You need to continue a checkpointed artifact-rich run | Used through `limen run --resume`. |
-| `commands/init.py` and `commands/list_templates.py` | You need bundled template discovery or scaffolding | Reads `limen/yaml/templates`. |
-| `commands/commit.py` and `commands/ls.py` | You need committed manifest storage | Writes project-local `manifests/committed` state. |
-| `commands/new.py` | You need a new project scaffold | Clones the official project template. |
+| `limen.cli.main:cli` | Click command group exported by the package script | Registered as the `limen` console script. |
+| `commands/validate.py` | YAML validation from the shell | Uses `limen.yaml` validation. |
+| `commands/profile.py` | Static permutation profiling for YAML manifests | Runtime sampling is skipped for validated CLI YAML. |
+| `commands/run.py` | Execute a YAML experiment | Compiles YAML into a manifest and runs UEL. |
+| `commands/resume.py` | Continue a checkpointed artifact-backed run | Used through `limen run --resume`. |
+| `commands/init.py` and `commands/list_templates.py` | Bundled template discovery or scaffolding | Reads `limen/yaml/templates`. |
+| `commands/commit.py` and `commands/ls.py` | Committed manifest storage | Writes project-local `manifests/committed` state. |
+| `commands/new.py` | New project scaffold | Clones the official project template. |
 
 ## Adjacent modules
 
@@ -53,7 +53,7 @@ cli/
 ## Things to know
 
 - `limen profile` is static for validated CLI YAML because YAML manifests reject `test_data_source`.
-- `limen run` accepts both direct YAML files and committed `manifest://sha256:...` URIs.
+- `limen run` accepts both direct YAML files and committed `manifest://sha256:` URIs.
 - `limen commit` writes the project manifest store before attempting the git commit.
 - Command code should stay thin; YAML semantics belong in `limen.yaml` and execution semantics belong in `limen.experiment`.
 

--- a/limen/cohort/README.md
+++ b/limen/cohort/README.md
@@ -22,13 +22,13 @@ It does **not** own:
 
 ## Key entry points
 
-| Entry point                       | Use it when                                                                             | Notes                                                          |
+| Entry point                       | Use case | Notes                                                          |
 | --------------------------------- | --------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
-| `Cohort`                        | You want to aggregate selected decoders from one completed experiment at inference time | Supports probability-weighted and majority-vote fallback modes |
-| `limen.cohort.sfc.all.select`             | You want the default "use every round" selector                         | Preserves existing omitted-`permutation_ids` behavior          |
-| `limen.cohort.sfc.top_n.select`           | You want a simple results-column ranker                                 | Requires `results.csv`                                         |
-| `limen.cohort.sfc.backtest_pareto.select` | You want trading-metric Pareto selection                                | Uses backtest return/risk columns                              |
-| `limen.cohort.sfc.diverse_metrics.select` | You want metric-diverse member selection                                | Uses PCA/KMeans medoids over metric columns                    |
+| `Cohort`                        | Aggregate selected decoders from one completed experiment at inference time | Supports probability-weighted and majority-vote fallback modes |
+| `limen.cohort.sfc.all.select`             | Default "use every round" selector | Preserves existing omitted-`permutation_ids` behavior          |
+| `limen.cohort.sfc.top_n.select`           | Results-column ranker | Requires `results.csv`                                         |
+| `limen.cohort.sfc.backtest_pareto.select` | Trading-metric Pareto selection | Uses backtest return/risk columns                              |
+| `limen.cohort.sfc.diverse_metrics.select` | Metric-diverse member selection | Uses PCA/KMeans medoids over metric columns                    |
 
 ## Package map
 
@@ -37,9 +37,9 @@ cohort/
 ├── cohort.py                # Cohort constructor + aggregation logic
 └── sfc/                     # Single-file cohort strategies
     ├── all.py               # select(context) -> ids
-    ├── top_n.py             # select(context, *, column, n, ...) -> ids
-    ├── backtest_pareto.py   # select(context, *, target_count, ...) -> ids
-    └── diverse_metrics.py   # select(context, *, target_count, ...) -> ids
+    ├── top_n.py             # select(context, *, column, n) -> ids
+    ├── backtest_pareto.py   # select(context, *, target_count) -> ids
+    └── diverse_metrics.py   # select(context, *, target_count) -> ids
 ```
 
 ## Cohort quick behavior
@@ -50,14 +50,14 @@ cohort/
 - Infer aggregation mode from architecture capability:
   - `probability_weighted` when probability output is supported
   - `majority_vote` fallback otherwise
-- `predict(...)` returns ndarray/tuple contract
-- `__call__(...)` returns decoder-compatible dict contract
+- `predict(raw_klines)` returns ndarray/tuple contract
+- `__call__(raw_klines)` returns decoder-compatible dict contract
 
 See [Cohort](../../docs/Cohort.md) for full contract and examples.
 
 ## Selector quick behavior
 
-- Selectors are one-file strategies with one public `select(...)` function
+- Selectors are one-file strategies with one public `select(context)` function
 - Selectors receive a context dict and return permutation IDs only
 - Cohort owns all validation after selector execution
 - Built-ins cover all-round, single-column rank, backtest Pareto, and metric diversity selection

--- a/limen/data/README.md
+++ b/limen/data/README.md
@@ -14,12 +14,12 @@ Does **not** own indicators, higher-level features, manifests, or model training
 
 ## Key entry points
 
-| Entry point | Use it when | Notes |
+| Entry point | Use case | Notes |
 |-------------|-------------|-------|
-| `HistoricalData` | You need file-backed BTCUSDT spot klines or raw file ingestion | The main public class exported by `limen.data` |
-| `compute_data_bars()` | You want to aggregate kline rows into threshold bars before feature engineering | Used by manifests through `set_bar_formation()` |
-| `split_sequential()` | You need ordered train/validation/test windows | Used by manifest-driven prep |
-| `split_data_to_prep_output()` | You need the standard `data_dict` structure | Converts split frames into model-ready keys like `x_train` and `y_test` |
+| `HistoricalData` | File-backed BTCUSDT spot klines or raw file ingestion | The main public class exported by `limen.data` |
+| `compute_data_bars()` | Aggregate kline rows into threshold bars before feature engineering | Used by manifests through `set_bar_formation()` |
+| `split_sequential()` | Ordered train/validation/test windows | Used by manifest-driven prep |
+| `split_data_to_prep_output()` | Standard `data_dict` structure | Converts split frames into model-ready keys like `x_train` and `y_test` |
 
 ## Adjacent modules
 

--- a/limen/experiment/README.md
+++ b/limen/experiment/README.md
@@ -17,13 +17,13 @@ Does **not** own model architectures, indicators, features, or raw metric helper
 
 ## Key entry points
 
-| Entry point | Use it when | Notes |
+| Entry point | Use case | Notes |
 |-------------|-------------|-------|
-| `Manifest` | You want a declarative experiment pipeline | Exported at the package root |
-| `UniversalExperimentLoop` | You want to run an SFD across many permutations | Exported at the package root |
-| `Trainer` | You want to rebuild winning rounds into reusable inference artifacts | Exported at the package root |
-| `Sensor` | You want a portable inference object produced by `Trainer` | Exported at the package root |
-| `ReconstructionError` | You need to handle failed manifest reconstruction during training | Exported at the package root |
+| `Manifest` | Declarative experiment pipeline | Exported at the package root |
+| `UniversalExperimentLoop` | Run an SFD across parameter permutations | Exported at the package root |
+| `Trainer` | Rebuild winning rounds into reusable inference artifacts | Exported at the package root |
+| `Sensor` | Portable inference object produced by `Trainer` | Exported at the package root |
+| `ReconstructionError` | Handle failed manifest reconstruction during training | Exported at the package root |
 
 ## Adjacent modules
 

--- a/limen/features/README.md
+++ b/limen/features/README.md
@@ -15,27 +15,27 @@ Does **not** own raw technical indicators, feature scaling, or model fitting.
 
 ## Key entry points
 
-| Entry point | Use it when | Notes |
+| Entry point | Use case | Notes |
 |-------------|-------------|-------|
-| `limen.features.*` exports | You want feature functions inside a manifest or custom prep pipeline | The package root re-exports the public feature surface |
-| `lag_column`, `lag_columns`, `lag_range`, `lag_range_cols` | You want lagged versions of existing columns | Useful for both raw and derived features |
-| `calendar_time_features`, `cyclical_time_features` | You want calendar context or cyclical encodings from `datetime` | Time-of-bar features for schedules, regimes, and model inputs |
-| `parkinson_volatility`, `garman_klass_volatility`, `rogers_satchell_volatility`, `yang_zhang_volatility` | You want range-based volatility estimates from OHLC bars | Useful when close-to-close volatility is too coarse |
-| `dollar_volume`, `amihud_illiquidity`, `return_per_dollar_volume`, `range_per_dollar_volume`, `illiquidity_shock` | You want simple liquidity and impact proxies from OHLCV data | Keeps bar-derived liquidity features separate from trade-level microstructure |
-| `maker_*`, `trade_*`, `liquidity_*`, `taker_imbalance_ratio` | You want maker/taker and LOB-liquidity features emitted by native klines | Uses columns from `get_spot_klines` and `get_spot_dollar_klines` |
-| `rolling_zscore` | You want one primitive for rolling z-score features | Supports `identity`, `log1p`, and `abs` transforms |
-| `wick_proportion`, `stochastic_k_abs`, `distance_from_ma`, `close_ma_distance_atr`, `kaufman_efficiency_ratio` | You want structural rolling OHLCV features | Adds bar-structure, distance, and path-efficiency context |
-| `realized_semivariance`, `realized_skewness`, `realized_kurtosis`, `jump_variation_proxy`, `tail_event_intensity`, `volatility_of_volatility` | You want asymmetry, jump, and tail context around recent returns | These are useful risk-state features, not just volatility levels |
-| `relative_volume_seasonality`, `relative_range_seasonality`, `relative_volatility_seasonality` | You want current bar behavior normalized against hour-of-week baselines | Helps detect unusually active or quiet bars in a 24/7 market |
-| `body_to_range`, `wick_imbalance`, `range_overlap`, `rejection_intensity`, `absorption_intensity` | You want candle anatomy and auction-style context from plain bars | Focuses on rejection, overlap, and body-versus-wick structure |
-| `trend_coherence`, `volatility_term_structure` | You want short/medium/long horizon agreement features | Summarizes cross-timescale alignment without a large feature bundle |
-| `conserved_flux_renormalization` | You want trade-derived multi-scale flux diagnostics | Requires trade-level input rather than plain OHLCV bars |
+| `limen.features.*` exports | Feature functions inside a manifest or custom prep pipeline | The package root re-exports the public feature surface |
+| `lag_column`, `lag_columns`, `lag_range`, `lag_range_cols` | Lagged versions of existing columns | Works for raw and derived features |
+| `calendar_time_features`, `cyclical_time_features` | Calendar context or cyclical encodings from `datetime` | Time-of-bar features for schedules, regimes, and model inputs |
+| `parkinson_volatility`, `garman_klass_volatility`, `rogers_satchell_volatility`, `yang_zhang_volatility` | Range-based volatility estimates from OHLC bars | Captures range information beyond close-to-close volatility |
+| `dollar_volume`, `amihud_illiquidity`, `return_per_dollar_volume`, `range_per_dollar_volume`, `illiquidity_shock` | Liquidity and impact proxies from OHLCV data | Keeps bar-derived liquidity features separate from trade-level microstructure |
+| `maker_*`, `trade_*`, `liquidity_*`, `taker_imbalance_ratio` | Maker/taker and LOB-liquidity features emitted by native klines | Uses columns from `get_spot_klines` and `get_spot_dollar_klines` |
+| `rolling_zscore` | One primitive for rolling z-score features | Supports `identity`, `log1p`, and `abs` transforms |
+| `wick_proportion`, `stochastic_k_abs`, `distance_from_ma`, `close_ma_distance_atr`, `kaufman_efficiency_ratio` | Structural rolling OHLCV features | Adds bar-structure, distance, and path-efficiency context |
+| `realized_semivariance`, `realized_skewness`, `realized_kurtosis`, `jump_variation_proxy`, `tail_event_intensity`, `volatility_of_volatility` | Asymmetry, jump, and tail context near recent returns | Risk-state features beyond volatility levels |
+| `relative_volume_seasonality`, `relative_range_seasonality`, `relative_volatility_seasonality` | Current bar behavior normalized against hour-of-week baselines | Detects activity and range deviations in a 24/7 market |
+| `body_to_range`, `wick_imbalance`, `range_overlap`, `rejection_intensity`, `absorption_intensity` | Candle anatomy and auction-style context from plain bars | Focuses on rejection, overlap, and body-versus-wick structure |
+| `trend_coherence`, `volatility_term_structure` | Short/medium/long horizon agreement features | Summarizes cross-timescale alignment without a large feature bundle |
+| `conserved_flux_renormalization` | Trade-derived multi-scale flux diagnostics | Requires trade-level input rather than plain OHLCV bars |
 
 ## Adjacent modules
 
-- `limen.indicators` usually runs first and produces columns that many features depend on.
+- `limen.indicators` runs first when features depend on indicator columns.
 - `limen.transforms` is commonly used alongside feature generation when building targets.
-- `limen.experiment.Manifest` wires features into the prep pipeline through `.add_feature(...)`.
+- `limen.experiment.Manifest` wires features into the prep pipeline through `.add_feature(vwap)`.
 
 ## Quick orientation
 

--- a/limen/indicators/README.md
+++ b/limen/indicators/README.md
@@ -14,38 +14,38 @@ Does **not** own higher-level feature engineering, target creation, or model tra
 
 ## Key entry points
 
-| Entry point | Use it when | Notes |
+| Entry point | Use case | Notes |
 |-------------|-------------|-------|
-| `limen.indicators.*` exports | You want indicators in a manifest or custom prep pipeline | The package root re-exports the public indicator surface |
-| `sma`, `ema`, `wilder_rsi`, `atr` | You need common directional and volatility baselines | Frequently used in foundational SFDs |
-| `bbands`, `bollinger_bands`, `bollinger_position` | You want band-based regime or position signals | Useful before higher-level feature construction |
-| `macd`, `ppo`, `roc`, `stoch`, `stochrsi` | You need momentum and oscillator families | Most emit multiple columns or parameterized output names |
-| Candlestick helpers like `cdldoji` | You want pattern flags aligned with TA-Lib semantics | Exported at the package root alongside the rest of the library |
+| `limen.indicators.*` exports | Indicators in a manifest or custom prep pipeline | The package root re-exports the public indicator surface |
+| `sma`, `ema`, `wilder_rsi`, `atr` | Common directional and volatility baselines | Frequently used in foundational SFDs |
+| `bbands`, `bollinger_bands`, `bollinger_position` | Band-based regime or position signals | Inputs for higher-level feature construction |
+| `macd`, `ppo`, `roc`, `stoch`, `stochrsi` | Momentum and oscillator families | Most emit multiple columns or parameterized output names |
+| Candlestick helpers like `cdldoji` | Pattern flags aligned with TA-Lib semantics | Exported at the package root alongside the rest of the library |
 
 ## Adjacent modules
 
-- `limen.features` typically consumes indicator columns and turns them into more opinionated model inputs.
-- `limen.experiment.Manifest` wires indicators into the prep pipeline through `.add_indicator(...)`.
+- `limen.features` consumes indicator columns and turns them into more opinionated model inputs.
+- `limen.experiment.Manifest` wires indicators into the prep pipeline through `.add_indicator(roc)`.
 - `limen.data` supplies the OHLCV frames that most indicators expect.
 
 ## Quick orientation
 
 ```text
 indicators/
-├── ma, sma, ema, wma, tema, trima, t3 ...   # Moving averages and trend baselines
-├── rsi, wilder_rsi, cmo, willr, ultosc ...  # Momentum and oscillator families
-├── atr, natr, trange, stddev, var ...       # Volatility and range measures
-├── bbands, bollinger_bands, midpoint ...    # Band and price-position helpers
-├── macd, macdfix, macdext, ppo ...          # Multi-column momentum helpers
+├── ma, sma, ema, wma, tema, trima, t3       # Moving averages and trend baselines
+├── rsi, wilder_rsi, cmo, willr, ultosc      # Momentum and oscillator families
+├── atr, natr, trange, stddev, var           # Volatility and range measures
+├── bbands, bollinger_bands, midpoint        # Band and price-position helpers
+├── macd, macdfix, macdext, ppo              # Multi-column momentum helpers
 └── cdl*.py                                  # Candlestick pattern detections
 ```
 
 ## Things to know
 
-- Most indicator functions accept a `pl.LazyFrame` and return that frame with one or more appended columns.
+- Indicator functions accept a `pl.LazyFrame` and return that frame with one or more appended columns.
 - Leading `null` rows are expected for rolling calculations. Manifest-driven prep drops them after the feature and indicator stage.
 - The public reference should be treated as the canonical list of exported helpers and output-column conventions.
-- Many indicators aim for TA-Lib parity, so naming and behavior are intentionally close to that surface where applicable.
+- TA-Lib-aligned indicators keep naming and behavior close to that surface where applicable.
 
 ## Read next
 

--- a/limen/log/README.md
+++ b/limen/log/README.md
@@ -15,14 +15,14 @@ Does **not** own experiment execution, model training, or artifact persistence d
 
 ## Key entry points
 
-| Entry point | Use it when | Notes |
+| Entry point | Use case | Notes |
 |-------------|-------------|-------|
-| `Log` | You want the main post-run analysis object | Import from `limen.log.log` |
-| `permutation_prediction_performance` | You want aligned predictions, actuals, and price columns for one round | Available as a `Log` method |
-| `permutation_confusion_metrics` | You want one-round classification diagnostics | Available as a `Log` method |
-| `experiment_confusion_metrics` | You want one table across all permutations | Available as a `Log` method and re-exported helper |
-| `experiment_backtest_results` | You want snapshot backtests across all rounds | Uses `limen.backtest` downstream |
-| `experiment_parameter_correlation` | You want to inspect which parameters move with a chosen metric | Useful for sweep interpretation |
+| `Log` | Main post-run analysis object | Import from `limen.log.log` |
+| `permutation_prediction_performance` | Aligned predictions, actuals, and price columns for one round | Available as a `Log` method |
+| `permutation_confusion_metrics` | One-round classification diagnostics | Available as a `Log` method |
+| `experiment_confusion_metrics` | One table across all permutations | Available as a `Log` method and re-exported helper |
+| `experiment_backtest_results` | Snapshot backtests across all rounds | Uses `limen.backtest` downstream |
+| `experiment_parameter_correlation` | Inspect which parameters move with a chosen metric | Supports sweep interpretation |
 
 ## Adjacent modules
 
@@ -45,10 +45,10 @@ log/
 
 ## Things to know
 
-- `Log(file_path=...)` is useful, but it does not expose every method that a live UEL-backed `Log` can support.
+- `Log(file_path='my_experiment.csv')` supports CSV-log cleanup but does not expose every method that a live UEL-backed `Log` can support.
 - Manifest-aware logs reconstruct the test window with the same bar-formation logic used during the run.
 - The package root re-exports helper functions, but the `Log` class itself lives in `limen.log.log`.
-- A good mental model is that `Log` is the bridge between raw experiment output and higher-level selection decisions.
+- `Log` bridges raw experiment output and higher-level selection decisions.
 
 ## Read next
 

--- a/limen/metrics/README.md
+++ b/limen/metrics/README.md
@@ -13,13 +13,13 @@ Does **not** own model fitting, prediction generation, experiment logging, or ba
 
 ## Key entry points
 
-| Entry point | Use it when | Notes |
+| Entry point | Use case | Notes |
 |-------------|-------------|-------|
-| `binary_metrics` | You need binary-classification metrics from predictions and probabilities | Import from `limen.metrics.binary_metrics` for the function form |
-| `multiclass_metrics` | You need macro or weighted metrics for multiclass problems | Import from `limen.metrics.multiclass_metrics` |
-| `continuous_metrics` | You need regression metrics like MAE, RMSE, and R2 | Import from `limen.metrics.continuous_metrics` |
-| `safe_ovr_auc` | You need OvR AUC without blowing up on missing-class edge cases | Import from `limen.metrics.safe_ovr_auc` |
-| `balanced_metric` | You want a single optimization target for balanced binary prediction quality | Exported directly from the package root |
+| `binary_metrics` | Binary-classification metrics from predictions and probabilities | Import from `limen.metrics.binary_metrics` for the function form |
+| `multiclass_metrics` | Macro or weighted metrics for multiclass problems | Import from `limen.metrics.multiclass_metrics` |
+| `continuous_metrics` | Regression metrics like MAE, RMSE, and R2 | Import from `limen.metrics.continuous_metrics` |
+| `safe_ovr_auc` | OvR AUC without blowing up on missing-class edge cases | Import from `limen.metrics.safe_ovr_auc` |
+| `balanced_metric` | Single optimization target for balanced binary prediction quality | Exported directly from the package root |
 
 ## Adjacent modules
 

--- a/limen/scalers/README.md
+++ b/limen/scalers/README.md
@@ -14,15 +14,15 @@ Does **not** own raw feature creation or the experiment loop itself.
 
 ## Key entry points
 
-| Entry point | Use it when | Notes |
+| Entry point | Use case | Notes |
 |-------------|-------------|-------|
-| `LinearScaler` | You want rule-based scaling over mixed market-data columns | Exported at the package root |
-| `LogRegScaler` | You want the standard scaler used by logistic-regression SFDs | Exported at the package root |
-| `RobustScaler` | You want median and IQR scaling for outlier-heavy data | Exported at the package root |
-| `CausalRollingRobustScaler` | You want robust scaling that adapts to drift, with no look-ahead | Exported at the package root |
-| `RankGaussScaler` | You want rank-based Gaussianization | Exported at the package root |
-| `SCALER_REGISTRY` | You want to resolve scalers by manifest parameter name | Used by `set_scaler_from_params()` |
-| `build_rules`, `inverse_transform` | You need to customize or interpret `LinearScaler` behavior | Available from the module-level implementations |
+| `LinearScaler` | Rule-based scaling over mixed market-data columns | Exported at the package root |
+| `LogRegScaler` | Standard scaler used by logistic-regression SFDs | Exported at the package root |
+| `RobustScaler` | Median and IQR scaling for outlier-heavy data | Exported at the package root |
+| `CausalRollingRobustScaler` | Robust scaling that adapts to drift, with no look-ahead | Exported at the package root |
+| `RankGaussScaler` | Rank-based Gaussianization | Exported at the package root |
+| `SCALER_REGISTRY` | Resolve scalers by manifest parameter name | Used by `set_scaler_from_params()` |
+| `build_rules`, `inverse_transform` | Customize or interpret `LinearScaler` behavior | Available from the module-level implementations |
 
 ## Adjacent modules
 

--- a/limen/sfd/README.md
+++ b/limen/sfd/README.md
@@ -17,13 +17,13 @@ Does **not** own experiment execution, data retrieval, or the lower-level indica
 
 ## Key entry points
 
-| Entry point | Use it when | Notes |
+| Entry point | Use case | Notes |
 |-------------|-------------|-------|
-| `logreg_binary` | You want the standard manifest-driven binary-classification SFD | Exported at the package root |
-| `random_binary` | You want a baseline classifier for comparison | Exported at the package root |
-| `xgboost_regressor` | You want a regression-style SFD | Exported at the package root |
-| `foundational_sfd` | You want the full catalog of packaged SFDs | Subpackage with production-oriented SFD modules |
-| `reference_architecture` | You want model-function templates without the packaged data pipeline | Starting point for custom SFD work |
+| `logreg_binary` | Standard manifest-driven binary-classification SFD | Exported at the package root |
+| `random_binary` | Baseline classifier for comparison | Exported at the package root |
+| `xgboost_regressor` | Regression-style SFD | Exported at the package root |
+| `foundational_sfd` | Full catalog of packaged SFDs | Subpackage with production-oriented SFD modules |
+| `reference_architecture` | Model-function templates without the packaged data pipeline | Starting point for custom SFD work |
 
 ## Adjacent modules
 
@@ -49,7 +49,7 @@ sfd/
 
 ## Things to know
 
-- A foundational SFD typically owns the experiment shape, while the matching reference architecture owns the model training logic.
+- A foundational SFD owns the experiment shape, while the matching reference architecture owns the model training logic.
 - `tabpfn_binary` is optional and remains unavailable when `tabpfn` is not installed.
 - The simplest path to a new SFD is to copy an existing foundational SFD, adjust `params()`, and modify the manifest chain.
 - SFD modules are expected to stay cheap and stateless at import and manifest-construction time.

--- a/limen/targets/README.md
+++ b/limen/targets/README.md
@@ -15,17 +15,17 @@ Does **not** own feature engineering, model fitting, calibration, or execution s
 
 ## Key entry points
 
-| Entry point | Use it when | Notes |
+| Entry point | Use case | Notes |
 | --- | --- | --- |
-| `QuantileBinaryTarget` | You need labels from a train-fitted quantile cutoff | Fits the cutoff on train only. |
-| `ThresholdBinaryTarget` | You need labels from a fixed threshold | Useful for explicit return thresholds. |
-| `TradelineLongBinaryTarget` | You need a long-entry label from price-line context | Pairs with line-based feature helpers. |
-| `NextReturnTarget`, `VolNormalizedReturnTarget`, `ForwardVolNormalizedReturnTarget` | You need continuous forward-return style targets | Common for regression or ranking experiments. |
-| `NextBarUpTarget`, `NextBarDownTarget` | You need one-bar direction labels | Lightweight classification baselines. |
-| `ForwardBreakoutTarget`, `EmaBreakoutTarget` | You need breakout-oriented labels | Uses forward path or EMA context. |
-| `TripleBarrierTarget` | You need a path-aware barrier label | Requires enough rows for `max_horizon` and the volatility warmup. |
-| `RiskRewardRatioTarget`, `ExitQualityTarget` | You need outcome labels from upstream trade-path columns | Require the expected input columns to exist on every split. |
-| `RandomBinaryTarget`, `IdentityTarget` | You need controls or already-present target columns | Useful for tests, baselines, and externally labelled data. |
+| `QuantileBinaryTarget` | Labels from a train-fitted quantile cutoff | Fits the cutoff on train only. |
+| `ThresholdBinaryTarget` | Labels from a fixed threshold | Supports explicit return thresholds. |
+| `TradelineLongBinaryTarget` | Long-entry label from price-line context | Pairs with line-based feature helpers. |
+| `NextReturnTarget`, `VolNormalizedReturnTarget`, `ForwardVolNormalizedReturnTarget` | Continuous forward-return style targets | Common for regression or ranking experiments. |
+| `NextBarUpTarget`, `NextBarDownTarget` | One-bar direction labels | Classification baselines. |
+| `ForwardBreakoutTarget`, `EmaBreakoutTarget` | Breakout-oriented labels | Uses forward path or EMA context. |
+| `TripleBarrierTarget` | Path-aware barrier label | Requires enough rows for `max_horizon` and the volatility warmup. |
+| `RiskRewardRatioTarget`, `ExitQualityTarget` | Outcome labels from upstream trade-path columns | Require the expected input columns to exist on every split. |
+| `RandomBinaryTarget`, `IdentityTarget` | Controls or already-present target columns | Supports tests, baselines, and externally labelled data. |
 
 ## Adjacent modules
 

--- a/limen/transforms/README.md
+++ b/limen/transforms/README.md
@@ -1,6 +1,6 @@
 # `limen.transforms`
 
-> Hold lightweight transform helpers for target construction and data cleanup.
+> Hold stateless transform helpers for target construction and data cleanup.
 
 ## Canonical docs
 
@@ -13,11 +13,11 @@ Owns stateless DataFrame transforms. Does **not** own fitted feature scaling, hi
 
 ## Key entry points
 
-| Entry point | Use it when | Notes |
+| Entry point | Use case | Notes |
 |-------------|-------------|-------|
-| `shift_column_transform` | You need a forward-looking target column | Common inside manifest target blocks |
-| `zscore_transform` | You want a simple frame-wide normalization step | Stateless and fast |
-| `winsorize_transform`, `mad_transform`, `quantile_trim_transform` | You want lightweight clipping or row filtering before modeling | These do not carry their own train-only state |
+| `shift_column_transform` | Forward-looking target column | Common inside manifest target blocks |
+| `zscore_transform` | Frame-wide normalization step | Stateless per call |
+| `winsorize_transform`, `mad_transform`, `quantile_trim_transform` | Clipping or row filtering before modeling | These do not carry their own train-only state |
 
 ## Adjacent modules
 
@@ -40,7 +40,7 @@ transforms/
 ## Things to know
 
 - All helpers in this package are intentionally stateless per call.
-- If you need fit-on-train and apply-to-all semantics, use a manifest fit parameter or a scaler rather than assuming a transform will remember state.
+- For fit-on-train and apply-to-all semantics, use a manifest fit parameter or a scaler rather than assuming a transform will remember state.
 - `shift_column_transform` with `shift=-1` creates a future-looking label and therefore introduces a trailing null row that later prep stages drop.
 
 ## Read next

--- a/limen/utils/README.md
+++ b/limen/utils/README.md
@@ -16,12 +16,12 @@ Does **not** own the canonical experiment, feature, metric, or backtest surfaces
 
 ## Key entry points
 
-| Entry point | Use it when | Notes |
+| Entry point | Use case | Notes |
 |-------------|-------------|-------|
-| `ParamSpace` | You are on the legacy basic `UEL.run()` path and need permutation sampling | Advanced runs use `SearchStrategy` and `ParamDomain` instead |
-| `data_dict_to_numpy` | You want numpy arrays from the standard Limen `data_dict` | Common inside sklearn-style model functions |
-| `confidence_filtering_system` | You want post-prediction filtering based on model agreement | An optional downstream helper, not part of the main UEL contract |
-| Reporting helpers | You want formatted text summaries | Utility surface, not a canonical reporting framework |
+| `ParamSpace` | Legacy basic `UEL.run()` path and need permutation sampling | Advanced runs use `SearchStrategy` and `ParamDomain` instead |
+| `data_dict_to_numpy` | Numpy arrays from the standard Limen `data_dict` | Common inside sklearn-style model functions |
+| `confidence_filtering_system` | Post-prediction filtering based on model agreement | An optional downstream helper, not part of the main UEL contract |
+| Reporting helpers | Formatted text summaries | Utility surface, not a canonical reporting framework |
 
 ## Adjacent modules
 
@@ -41,9 +41,9 @@ utils/
 
 ## Things to know
 
-- This package is intentionally mixed. If a helper grows into a coherent subsystem, it should usually move out of `utils`.
+- This package is intentionally mixed. If a helper grows into a coherent subsystem, move it out of `utils`.
 - `ParamSpace` is the legacy path, not the long-term abstraction for advanced search.
-- `data_dict_to_numpy` assumes the standard Limen split schema and is most useful inside model code.
+- `data_dict_to_numpy` assumes the standard Limen split schema and supports model code.
 
 ## Read next
 

--- a/limen/yaml/README.md
+++ b/limen/yaml/README.md
@@ -15,22 +15,22 @@ Does **not** own Click command routing, UEL execution, model implementations, or
 
 ## Key entry points
 
-| Entry point | Use it when | Notes |
+| Entry point | Use case | Notes |
 | --- | --- | --- |
-| `parser.py` | You need to read YAML into structured config | Handles file parsing before validation. |
-| `schema.py` | You need the authoritative YAML field sets and allowed values | Defines schema version `1.0`, modes, manifest types, output formats, and search strategies. |
-| `validator.py` | You need to validate structure and supported field names | Used by CLI validation and run paths. |
-| `resolver.py` | You need to resolve `limen.*` dotted references | Bridges YAML text to Python callables/classes. |
-| `compiler.py` | You need to compile YAML config into executable Limen objects | Produces manifest and UEL-ready configuration. |
-| `profiler.py` | You need permutation and runtime estimates | Powers `limen profile`. |
-| `store.py` | You need committed-manifest storage and `manifest://` lookup | Used by `limen commit`, `limen ls`, and `limen run manifest://...`. |
-| `templates/` | You need shipped starting YAML files | Used by `limen init` and `limen list-templates`. |
+| `parser.py` | Read YAML into structured config | Handles file parsing before validation. |
+| `schema.py` | Authoritative YAML field sets and allowed values | Defines schema version `1.0`, modes, manifest types, output formats, and search strategies. |
+| `validator.py` | Validate structure and supported field names | Used by CLI validation and run paths. |
+| `resolver.py` | Resolve `limen.*` dotted references | Bridges YAML text to Python callables/classes. |
+| `compiler.py` | Compile YAML config into executable Limen objects | Produces manifest and UEL-ready configuration. |
+| `profiler.py` | Permutation and runtime estimates | Powers `limen profile`. |
+| `store.py` | Committed-manifest storage and `manifest://` lookup | Used by `limen commit`, `limen ls`, and `limen run manifest://sha256:`. |
+| `templates/` | Shipped starting YAML files | Used by `limen init` and `limen list-templates`. |
 
 ## Adjacent modules
 
 - `limen.cli` exposes this package through shell commands.
 - `limen.experiment.manifest_core` is the Python object model that compiled YAML targets.
-- `limen.sfd.foundational_sfd` mirrors several YAML templates as packaged SFDs.
+- `limen.sfd.foundational_sfd` mirrors YAML templates as packaged SFDs.
 
 ## Quick orientation
 


### PR DESCRIPTION
## Summary
- remove second-person voice, rhetorical questions, vague praise, and unsupported approximation markers across canonical docs and package READMEs
- replace fake-looking ellipses and placeholder snippets with concrete examples or explicit prose
- align headings and routing copy with the Vaquum voice addendum while preserving the existing docs structure

## Checks
- content scan: 0 second-person, vague-praise, approximation, rhetorical punctuation, placeholder, and ellipsis hits
- git diff --check
- npm run check