### PR TITLE
docs: align backtest sample with design system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1132,3 +1132,7 @@ Note: add all new changelog entries to the bottom of this file.
 ## v3.30.1 on 14th of June, 2026
 
 - Complete the canonical docs surface: route every public docs page and package README through the docs-site assembly map, add missing CLI and package orientation pages, and expand canonical references for CLI, transforms, release/version local scope, pruning terminology, and technical-debt register rules.
+
+## v3.30.2 on 14th of June, 2026
+
+- Add a design-system-aligned Backtest docs sample: claim-first structure, scoped IBM Plex typography, quieter reference-table type, and dark-mode-safe sample styling.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1135,4 +1135,4 @@ Note: add all new changelog entries to the bottom of this file.
 
 ## v3.30.2 on 14th of June, 2026
 
-- Add a design-system-aligned Backtest docs sample: claim-first structure, scoped IBM Plex typography, quieter reference-table type, and dark-mode-safe sample styling.
+- Add a design-system-aligned docs surface: global IBM Plex typography, fixed editorial scale, quiet navigation, booktabs-style tables, square code and media frames, light/dark palette parity, and the Backtest page as the first canonical content sample.

--- a/docs-site/src/css/custom.css
+++ b/docs-site/src/css/custom.css
@@ -1,193 +1,183 @@
 @import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600&family=IBM+Plex+Mono:wght@400;500&display=swap');
 
 :root {
-  --vaquum-cyan: #c4e8f4;
-  --vaquum-pink-100: #fce2eb;
-  --vaquum-pink-300: #eaa3c8;
-  --vaquum-pink-500: #dc65a6;
-  --vaquum-coral: #f16068;
-  --vaquum-lilac: #bcabd3;
-  --vaquum-lime: #ddd941;
-  --vaquum-black: #121212;
-  --vaquum-ink: #231f20;
-  --vaquum-gray-700: #444444;
-  --vaquum-gray-500: #808080;
-  --vaquum-gray-300: #d3d3d3;
-  --vaquum-gray-100: #f3f3f3;
-  --vaquum-gray-50: #f8f8f8;
+  --vaquum-ink-deep: #121212;
+  --vaquum-ink: #231F20;
+  --vaquum-ink-soft: #444444;
+  --vaquum-ink-mute: #808080;
+  --vaquum-rule: #D3D3D3;
+  --vaquum-paper-2: #F3F3F3;
+  --vaquum-paper: #F8F8F8;
+  --vaquum-accent: #DC65A6;
+  --vaquum-accent-soft: #EAA3C8;
+  --vaquum-coral: #F16068;
+  --vaquum-lime: #DDD941;
+  --vaquum-cyan: #C4E8F4;
+  --vaquum-sans: 'IBM Plex Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+  --vaquum-mono: 'IBM Plex Mono', ui-monospace, 'SF Mono', Menlo, Consolas, 'Liberation Mono', monospace;
 
-  --ifm-color-primary: #dc65a6;
-  --ifm-color-primary-dark: #d44f98;
-  --ifm-color-primary-darker: #cf438f;
-  --ifm-color-primary-darkest: #b42f76;
-  --ifm-color-primary-light: #e17bb4;
-  --ifm-color-primary-lighter: #e488bc;
-  --ifm-color-primary-lightest: #ebaacb;
-  --ifm-color-success: #ddd941;
-  --ifm-color-info: #c4e8f4;
-  --ifm-background-color: var(--vaquum-gray-50);
-  --ifm-background-surface-color: rgba(248, 248, 248, 0.92);
-  --ifm-navbar-background-color: rgba(248, 248, 248, 0.9);
+  --ifm-color-primary: var(--vaquum-accent);
+  --ifm-color-primary-dark: var(--vaquum-accent);
+  --ifm-color-primary-darker: var(--vaquum-accent);
+  --ifm-color-primary-darkest: var(--vaquum-accent);
+  --ifm-color-primary-light: var(--vaquum-accent-soft);
+  --ifm-color-primary-lighter: var(--vaquum-accent-soft);
+  --ifm-color-primary-lightest: #FCE2EB;
+  --ifm-color-success: var(--vaquum-lime);
+  --ifm-color-info: var(--vaquum-cyan);
+  --ifm-background-color: var(--vaquum-paper);
+  --ifm-background-surface-color: var(--vaquum-paper);
+  --ifm-navbar-background-color: var(--vaquum-paper);
   --ifm-footer-background-color: var(--vaquum-ink);
   --ifm-font-color-base: var(--vaquum-ink);
-  --ifm-heading-color: var(--vaquum-black);
-  --ifm-link-color: var(--vaquum-pink-500);
-  --ifm-link-hover-color: var(--vaquum-coral);
-  --ifm-code-font-size: 94%;
-  --ifm-font-family-base: "IBM Plex Sans", "Segoe UI", sans-serif;
-  --ifm-font-family-monospace: "IBM Plex Mono", "SFMono-Regular", monospace;
-  --ifm-heading-font-family: "IBM Plex Sans", "Segoe UI", sans-serif;
+  --ifm-heading-color: var(--vaquum-ink-deep);
+  --ifm-link-color: var(--vaquum-ink);
+  --ifm-link-hover-color: var(--vaquum-accent);
+  --ifm-code-background: var(--vaquum-paper-2);
+  --ifm-code-font-size: 14.5px;
+  --ifm-font-family-base: var(--vaquum-sans);
+  --ifm-font-family-monospace: var(--vaquum-mono);
+  --ifm-heading-font-family: var(--vaquum-sans);
   --ifm-heading-font-weight: 600;
-  --ifm-line-height-base: 1.65;
-  --ifm-menu-color: var(--vaquum-gray-700);
-  --ifm-menu-color-active: var(--vaquum-black);
-  --ifm-menu-color-background-active: rgba(196, 232, 244, 0.45);
-  --ifm-breadcrumb-color-active: var(--vaquum-black);
-  --ifm-toc-border-color: rgba(35, 31, 32, 0.12);
-  --ifm-global-shadow-lw: 0 12px 30px rgba(18, 18, 18, 0.06);
-  --ifm-global-shadow-md: 0 24px 60px rgba(18, 18, 18, 0.1);
+  --ifm-line-height-base: 1.55;
+  --ifm-menu-color: var(--vaquum-ink-soft);
+  --ifm-menu-color-active: var(--vaquum-ink-deep);
+  --ifm-menu-color-background-active: var(--vaquum-paper-2);
+  --ifm-menu-color-background-hover: var(--vaquum-paper-2);
+  --ifm-breadcrumb-color-active: var(--vaquum-ink-deep);
+  --ifm-toc-border-color: var(--vaquum-rule);
+  --ifm-global-radius: 0;
+  --ifm-global-shadow-lw: none;
+  --ifm-global-shadow-md: none;
   --doc-sidebar-width: 320px;
 }
 
-html {
-  background:
-    radial-gradient(circle at top left, rgba(196, 232, 244, 0.7), transparent 28rem),
-    radial-gradient(circle at top right, rgba(252, 226, 235, 0.85), transparent 22rem),
-    linear-gradient(180deg, var(--vaquum-gray-50) 0%, var(--vaquum-gray-100) 100%);
+html[data-theme='dark'] {
+  --vaquum-ink-deep: #F8F8F8;
+  --vaquum-ink: #F3F3F3;
+  --vaquum-ink-soft: #D3D3D3;
+  --vaquum-ink-mute: #808080;
+  --vaquum-rule: #444444;
+  --vaquum-paper-2: #231F20;
+  --vaquum-paper: #121212;
+  --vaquum-accent: #EAA3C8;
+  --vaquum-accent-soft: #FCE2EB;
+
+  --ifm-color-primary: var(--vaquum-accent);
+  --ifm-color-primary-dark: var(--vaquum-accent);
+  --ifm-color-primary-darker: var(--vaquum-accent);
+  --ifm-color-primary-darkest: var(--vaquum-accent);
+  --ifm-color-primary-light: var(--vaquum-accent-soft);
+  --ifm-color-primary-lighter: var(--vaquum-accent-soft);
+  --ifm-color-primary-lightest: var(--vaquum-accent-soft);
+  --ifm-background-color: var(--vaquum-paper);
+  --ifm-background-surface-color: var(--vaquum-paper);
+  --ifm-navbar-background-color: var(--vaquum-paper);
+  --ifm-footer-background-color: var(--vaquum-paper);
+  --ifm-font-color-base: var(--vaquum-ink);
+  --ifm-heading-color: var(--vaquum-ink-deep);
+  --ifm-link-color: var(--vaquum-ink);
+  --ifm-link-hover-color: var(--vaquum-accent);
+  --ifm-code-background: var(--vaquum-paper-2);
+  --ifm-menu-color: var(--vaquum-ink-soft);
+  --ifm-menu-color-active: var(--vaquum-ink-deep);
+  --ifm-menu-color-background-active: var(--vaquum-paper-2);
+  --ifm-menu-color-background-hover: var(--vaquum-paper-2);
+  --ifm-breadcrumb-color-active: var(--vaquum-ink-deep);
+  --ifm-toc-border-color: var(--vaquum-rule);
+}
+
+html,
+body {
+  background: var(--vaquum-paper);
 }
 
 body {
-  background: transparent;
+  color: var(--vaquum-ink);
+  font-family: var(--vaquum-sans);
+  font-feature-settings: 'kern' 1, 'liga' 1, 'calt' 1;
+  font-size: 17px;
+  font-variant-numeric: lining-nums;
+  letter-spacing: 0;
+  line-height: 1.55;
 }
 
-html[data-theme='dark'] {
-  --ifm-color-primary: #eaa3c8;
-  --ifm-color-primary-dark: #e38dbb;
-  --ifm-color-primary-darker: #df81b4;
-  --ifm-color-primary-darkest: #d05a9d;
-  --ifm-color-primary-light: #f1b9d5;
-  --ifm-color-primary-lighter: #f3c5dc;
-  --ifm-color-primary-lightest: #f8deea;
-  --ifm-background-color: #181516;
-  --ifm-background-surface-color: rgba(35, 31, 32, 0.88);
-  --ifm-navbar-background-color: rgba(18, 18, 18, 0.86);
-  --ifm-footer-background-color: #121212;
-  --ifm-font-color-base: #f3f3f3;
-  --ifm-heading-color: #f8f8f8;
-  --ifm-link-color: #fce2eb;
-  --ifm-link-hover-color: #ddd941;
-  --ifm-menu-color: #d3d3d3;
-  --ifm-menu-color-active: #f8f8f8;
-  --ifm-menu-color-background-active: rgba(220, 101, 166, 0.18);
-  --ifm-toc-border-color: rgba(248, 248, 248, 0.12);
-  background:
-    radial-gradient(circle at top left, rgba(220, 101, 166, 0.2), transparent 28rem),
-    radial-gradient(circle at top right, rgba(196, 232, 244, 0.16), transparent 22rem),
-    linear-gradient(180deg, #181516 0%, #121212 100%);
-}
-
-.navbar {
-  backdrop-filter: blur(14px);
-  border-bottom: 1px solid rgba(35, 31, 32, 0.08);
-}
-
-.footer {
-  border-top: 1px solid rgba(248, 248, 248, 0.08);
-}
-
+.navbar,
+.navbar-sidebar,
 .theme-doc-sidebar-container,
 .table-of-contents,
 .pagination-nav,
 .theme-doc-markdown,
-.card,
-.navbar-sidebar {
-  backdrop-filter: blur(10px);
+.card {
+  backdrop-filter: none;
+  box-shadow: none;
 }
 
-.theme-doc-markdown {
-  background: rgba(248, 248, 248, 0.52);
-  border: 1px solid rgba(35, 31, 32, 0.05);
-  border-radius: 1rem;
-  box-shadow: var(--ifm-global-shadow-lw);
-  padding: 1.5rem;
+.navbar {
+  background: var(--vaquum-paper);
+  border-bottom: 1px solid var(--vaquum-rule);
+  height: 56px;
 }
 
-html[data-theme='dark'] .theme-doc-markdown {
-  background: rgba(35, 31, 32, 0.38);
-  border-color: rgba(248, 248, 248, 0.06);
-}
-
-.theme-doc-markdown header + * {
-  margin-top: 1rem;
-}
-
-.theme-doc-markdown h1,
-.theme-doc-markdown h2,
-.theme-doc-markdown h3,
-.theme-doc-markdown h4,
-.hero__title,
-.navbar__title {
+.navbar__title,
+.navbar__link,
+.menu__link,
+.table-of-contents__link,
+.breadcrumbs__link,
+.breadcrumbs__item,
+.pagination-nav__label,
+.pagination-nav__sublabel {
+  font-family: var(--vaquum-sans);
   letter-spacing: 0;
   text-transform: none;
 }
 
-.theme-doc-markdown h1 {
-  font-size: clamp(2.4rem, 4vw, 3.6rem);
-  line-height: 0.95;
+.navbar__title {
+  color: var(--vaquum-ink-deep);
+  font-size: 17px;
+  font-weight: 600;
 }
 
-.theme-doc-markdown h2 {
-  font-size: clamp(1.8rem, 3vw, 2.4rem);
-  margin-top: 2.75rem;
+.navbar__link {
+  color: var(--vaquum-ink);
+  font-size: 13px;
+  font-weight: 400;
 }
 
-.theme-doc-markdown h3 {
-  font-size: clamp(1.35rem, 2vw, 1.7rem);
-  margin-top: 2rem;
+.navbar__link:hover,
+.navbar__link--active {
+  color: var(--vaquum-accent);
 }
 
-.theme-doc-markdown a {
-  text-decoration-thickness: 0.08em;
-  text-underline-offset: 0.14em;
+.navbar__toggle,
+.clean-btn,
+.navbar__search-input {
+  border-radius: 0;
 }
 
-.theme-doc-markdown img {
-  border-radius: 0.75rem;
+.theme-doc-sidebar-container {
+  background: var(--vaquum-paper);
+  border-right: 1px solid var(--vaquum-rule);
 }
 
-.theme-code-block,
-pre,
-code,
-kbd {
-  font-family: var(--ifm-font-family-monospace);
+.menu {
+  font-size: 13px;
+  line-height: 1.55;
+  padding: 16px;
 }
 
-pre {
-  border: 1px solid rgba(35, 31, 32, 0.08);
-  box-shadow: var(--ifm-global-shadow-lw);
+.menu__link {
+  border-radius: 0;
+  color: var(--vaquum-ink-soft);
+  font-size: 13px;
+  font-weight: 400;
+  line-height: 1.55;
 }
 
-html[data-theme='dark'] pre {
-  border-color: rgba(248, 248, 248, 0.08);
-}
-
-table {
-  background: rgba(248, 248, 248, 0.7);
-  border-radius: 0.75rem;
-  overflow: hidden;
-}
-
-html[data-theme='dark'] table {
-  background: rgba(35, 31, 32, 0.42);
-}
-
-.pagination-nav__link {
-  border-radius: 0.9rem;
-  border: 1px solid rgba(35, 31, 32, 0.07);
-}
-
-html[data-theme='dark'] .pagination-nav__link {
-  border-color: rgba(248, 248, 248, 0.08);
+.menu__link:hover,
+.menu__link--active {
+  background: var(--vaquum-paper-2);
+  color: var(--vaquum-ink-deep);
 }
 
 .menu__link--active,
@@ -195,27 +185,49 @@ html[data-theme='dark'] .pagination-nav__link {
   font-weight: 600;
 }
 
+.breadcrumbs {
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.14em;
+  line-height: 1.2;
+  text-transform: uppercase;
+}
 
-/* Vaquum design-system sample: docs/Backtest.md. */
-.theme-doc-markdown:has(.vaquum-design-system-sample) {
-  --vaquum-sample-ink-deep: #121212;
-  --vaquum-sample-ink: #231F20;
-  --vaquum-sample-ink-soft: #444444;
-  --vaquum-sample-ink-mute: #808080;
-  --vaquum-sample-rule: #D3D3D3;
-  --vaquum-sample-paper-2: #F3F3F3;
-  --vaquum-sample-paper: #F8F8F8;
-  --vaquum-sample-accent: #DC65A6;
-  --vaquum-sample-sans: 'IBM Plex Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
-  --vaquum-sample-mono: 'IBM Plex Mono', ui-monospace, 'SF Mono', Menlo, Consolas, 'Liberation Mono', monospace;
-  background: var(--vaquum-sample-paper);
+.breadcrumbs__link,
+.breadcrumbs__item--active .breadcrumbs__link {
+  background: transparent;
+  border-radius: 0;
+  color: var(--vaquum-ink-mute);
+}
+
+.breadcrumbs__link:hover {
+  color: var(--vaquum-accent);
+}
+
+.table-of-contents {
+  border-left: 1px solid var(--vaquum-rule);
+  font-size: 13px;
+  padding-left: 16px;
+}
+
+.table-of-contents__link {
+  color: var(--vaquum-ink-soft);
+  font-size: 13px;
+  line-height: 1.55;
+}
+
+.table-of-contents__link:hover,
+.table-of-contents__link--active {
+  color: var(--vaquum-accent);
+}
+
+.theme-doc-markdown {
+  background: transparent;
   border: 0;
   border-radius: 0;
   box-shadow: none;
-  backdrop-filter: none;
-  color: var(--vaquum-sample-ink);
-  font-family: var(--vaquum-sample-sans);
-  font-feature-settings: 'kern' 1, 'liga' 1, 'calt' 1;
+  color: var(--vaquum-ink);
+  font-family: var(--vaquum-sans);
   font-size: 17px;
   font-variant-numeric: lining-nums;
   letter-spacing: 0;
@@ -225,37 +237,21 @@ html[data-theme='dark'] .pagination-nav__link {
   padding: 64px 0;
 }
 
-html[data-theme='dark'] .theme-doc-markdown:has(.vaquum-design-system-sample) {
-  --vaquum-sample-ink-deep: #F8F8F8;
-  --vaquum-sample-ink: #F3F3F3;
-  --vaquum-sample-ink-soft: #D3D3D3;
-  --vaquum-sample-ink-mute: #808080;
-  --vaquum-sample-rule: #444444;
-  --vaquum-sample-paper-2: #231F20;
-  --vaquum-sample-paper: #121212;
-  --vaquum-sample-accent: #EAA3C8;
-  background: var(--vaquum-sample-paper);
-  border: 0;
-  box-shadow: none;
-  color: var(--vaquum-sample-ink);
+.theme-doc-markdown header + * {
+  margin-top: 16px;
 }
 
-.theme-doc-markdown:has(.vaquum-design-system-sample) h1,
-.theme-doc-markdown:has(.vaquum-design-system-sample) h2,
-.theme-doc-markdown:has(.vaquum-design-system-sample) h3,
-.theme-doc-markdown:has(.vaquum-design-system-sample) h4 {
-  color: var(--vaquum-sample-ink-deep);
-  font-family: var(--vaquum-sample-sans);
+.theme-doc-markdown h1,
+.theme-doc-markdown h2,
+.theme-doc-markdown h3,
+.theme-doc-markdown h4,
+.hero__title {
+  color: var(--vaquum-ink-deep);
+  font-family: var(--vaquum-sans);
 }
 
-html[data-theme='dark'] .theme-doc-markdown:has(.vaquum-design-system-sample) h1,
-html[data-theme='dark'] .theme-doc-markdown:has(.vaquum-design-system-sample) h2,
-html[data-theme='dark'] .theme-doc-markdown:has(.vaquum-design-system-sample) h3,
-html[data-theme='dark'] .theme-doc-markdown:has(.vaquum-design-system-sample) h4 {
-  color: var(--vaquum-sample-ink-deep);
-}
-
-.theme-doc-markdown:has(.vaquum-design-system-sample) h1 {
+.theme-doc-markdown h1,
+.hero__title {
   font-size: 44px;
   font-weight: 600;
   letter-spacing: -0.015em;
@@ -265,8 +261,8 @@ html[data-theme='dark'] .theme-doc-markdown:has(.vaquum-design-system-sample) h4
   text-transform: none;
 }
 
-.theme-doc-markdown:has(.vaquum-design-system-sample) h2 {
-  border-top: 1px solid var(--vaquum-sample-rule);
+.theme-doc-markdown h2 {
+  border-top: 1px solid var(--vaquum-rule);
   font-size: 13px;
   font-weight: 600;
   letter-spacing: 0.08em;
@@ -276,7 +272,8 @@ html[data-theme='dark'] .theme-doc-markdown:has(.vaquum-design-system-sample) h4
   text-transform: uppercase;
 }
 
-.theme-doc-markdown:has(.vaquum-design-system-sample) h3 {
+.theme-doc-markdown h3,
+.theme-doc-markdown h4 {
   font-size: 13px;
   font-weight: 600;
   letter-spacing: 0.08em;
@@ -285,109 +282,173 @@ html[data-theme='dark'] .theme-doc-markdown:has(.vaquum-design-system-sample) h4
   text-transform: uppercase;
 }
 
-.theme-doc-markdown:has(.vaquum-design-system-sample) p:has(+ table) {
-  color: var(--vaquum-sample-ink-soft);
-  font-size: 13px;
-  line-height: 1.55;
-  margin: 16px 0 8px;
-  max-width: 60ch;
-}
-
-.theme-doc-markdown:has(.vaquum-design-system-sample) p,
-.theme-doc-markdown:has(.vaquum-design-system-sample) li {
+.theme-doc-markdown p,
+.theme-doc-markdown li {
   font-size: 17px;
   letter-spacing: 0;
   line-height: 1.55;
   max-width: 66ch;
 }
 
-.theme-doc-markdown:has(.vaquum-design-system-sample) h1 + .vaquum-design-system-sample + p {
-  color: var(--vaquum-sample-ink-soft);
+.theme-doc-markdown h1 + p {
+  color: var(--vaquum-ink-soft);
   font-size: 19px;
   line-height: 1.5;
   margin-bottom: 16px;
   max-width: 52ch;
 }
 
-.theme-doc-markdown:has(.vaquum-design-system-sample) a {
-  color: var(--vaquum-sample-ink);
+.theme-doc-markdown p:has(+ table) {
+  color: var(--vaquum-ink-soft);
+  font-size: 13px;
+  line-height: 1.55;
+  margin: 16px 0 8px;
+  max-width: 60ch;
+}
+
+.theme-doc-markdown a {
+  color: var(--vaquum-ink);
   font-weight: 400;
-  text-decoration-color: var(--vaquum-sample-accent);
+  text-decoration-color: var(--vaquum-accent);
   text-decoration-line: underline;
   text-decoration-thickness: 1px;
   text-underline-offset: 3px;
 }
 
-.theme-doc-markdown:has(.vaquum-design-system-sample) a:hover {
-  color: var(--vaquum-sample-accent);
+.theme-doc-markdown a:hover {
+  color: var(--vaquum-accent);
 }
 
-.theme-doc-markdown:has(.vaquum-design-system-sample) strong {
+.theme-doc-markdown strong {
+  color: var(--vaquum-ink-deep);
   font-weight: 600;
 }
 
-.theme-doc-markdown:has(.vaquum-design-system-sample) em {
+.theme-doc-markdown em {
   font-style: normal;
   font-weight: 600;
 }
 
-.theme-doc-markdown:has(.vaquum-design-system-sample) ul,
-.theme-doc-markdown:has(.vaquum-design-system-sample) ol {
+.theme-doc-markdown ul,
+.theme-doc-markdown ol {
   margin: 16px 0 24px;
   max-width: 66ch;
   padding-left: 0;
 }
 
-.theme-doc-markdown:has(.vaquum-design-system-sample) ul {
+.theme-doc-markdown ul {
   list-style: none;
 }
 
-.theme-doc-markdown:has(.vaquum-design-system-sample) ul li {
+.theme-doc-markdown ul li {
   padding-left: 1.2em;
   position: relative;
 }
 
-.theme-doc-markdown:has(.vaquum-design-system-sample) ul li::before {
-  color: var(--vaquum-sample-ink-mute);
+.theme-doc-markdown ul li::before {
+  color: var(--vaquum-ink-mute);
   content: '·';
   left: 0;
   position: absolute;
 }
 
-.theme-doc-markdown:has(.vaquum-design-system-sample) code,
-.theme-doc-markdown:has(.vaquum-design-system-sample) pre {
-  font-family: var(--vaquum-sample-mono);
-  font-size: 14.5px;
-  font-variant-numeric: tabular-nums slashed-zero;
-  letter-spacing: 0;
-  line-height: 1.65;
+.theme-doc-markdown ol {
+  list-style-position: outside;
+  padding-left: 2ch;
 }
 
-.theme-doc-markdown:has(.vaquum-design-system-sample) :not(pre) > code {
-  background: var(--vaquum-sample-paper-2);
+.theme-doc-markdown img {
+  border: 1px solid var(--vaquum-rule);
+  border-radius: 0;
+}
+
+.theme-code-block,
+.theme-code-block pre,
+pre,
+code,
+kbd {
+  font-family: var(--vaquum-mono);
+  font-variant-numeric: tabular-nums slashed-zero;
+  letter-spacing: 0;
+}
+
+.theme-doc-markdown :not(pre) > code,
+.theme-doc-markdown kbd {
+  background: var(--vaquum-paper-2);
   border: 0;
   border-radius: 0;
-  color: var(--vaquum-sample-ink);
+  color: var(--vaquum-ink);
+  font-size: 14.5px;
+  line-height: 1.65;
   padding: 0 2px;
 }
 
-.theme-doc-markdown:has(.vaquum-design-system-sample) pre {
-  background: var(--vaquum-sample-paper-2);
+.theme-code-block,
+.theme-doc-markdown pre {
+  background: var(--vaquum-paper-2);
   border: 0;
-  border-left: 3px solid var(--vaquum-sample-accent);
+  border-left: 3px solid var(--vaquum-accent);
   border-radius: 0;
   box-shadow: none;
   margin: 16px 0 24px;
   max-width: 80ch;
-  padding: 16px;
 }
 
-.theme-doc-markdown:has(.vaquum-design-system-sample) table {
+.theme-code-block pre,
+.theme-doc-markdown pre {
+  color: var(--vaquum-ink);
+  font-size: 14.5px;
+  line-height: 1.65;
+}
+
+.theme-code-block button,
+.theme-code-block .clean-btn {
+  border-radius: 0;
+}
+
+.theme-code-block .token.comment,
+.theme-code-block .token.prolog,
+.theme-code-block .token.doctype,
+.theme-code-block .token.cdata {
+  color: var(--vaquum-ink-mute);
+}
+
+.theme-code-block .token.punctuation,
+.theme-code-block .token.operator {
+  color: var(--vaquum-ink-soft);
+}
+
+.theme-code-block .token.keyword,
+.theme-code-block .token.selector,
+.theme-code-block .token.atrule {
+  color: var(--vaquum-accent);
+}
+
+.theme-code-block .token.string,
+.theme-code-block .token.attr-value {
+  color: var(--vaquum-coral);
+}
+
+.theme-code-block .token.number,
+.theme-code-block .token.boolean,
+.theme-code-block .token.constant {
+  color: var(--vaquum-cyan);
+}
+
+.theme-code-block .token.function,
+.theme-code-block .token.class-name,
+.theme-code-block .token.property,
+.theme-code-block .token.attr-name,
+.theme-code-block .token.tag {
+  color: var(--vaquum-ink-deep);
+}
+
+.theme-doc-markdown table {
   background: transparent;
   border-collapse: collapse;
   border-radius: 0;
   box-shadow: none;
-  color: var(--vaquum-sample-ink);
+  color: var(--vaquum-ink);
   display: table;
   font-size: 13px;
   line-height: 1.55;
@@ -396,70 +457,167 @@ html[data-theme='dark'] .theme-doc-markdown:has(.vaquum-design-system-sample) h4
   width: 100%;
 }
 
-.theme-doc-markdown:has(.vaquum-design-system-sample) th,
-.theme-doc-markdown:has(.vaquum-design-system-sample) td {
+.theme-doc-markdown th,
+.theme-doc-markdown td {
   background: transparent;
   border: 0;
+  color: var(--vaquum-ink-soft);
   padding: 8px 16px 8px 0;
   text-align: left;
   vertical-align: top;
 }
 
-.theme-doc-markdown:has(.vaquum-design-system-sample) tr,
-.theme-doc-markdown:has(.vaquum-design-system-sample) tr:nth-child(2n) {
+.theme-doc-markdown tr,
+.theme-doc-markdown tr:nth-child(2n) {
   background: transparent;
 }
 
-.theme-doc-markdown:has(.vaquum-design-system-sample) th code,
-.theme-doc-markdown:has(.vaquum-design-system-sample) td code {
+.theme-doc-markdown th {
+  color: var(--vaquum-ink-deep);
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  line-height: 1.2;
+  text-transform: uppercase;
+}
+
+.theme-doc-markdown thead {
+  border-bottom: 1px solid var(--vaquum-rule);
+  border-top: 1px solid var(--vaquum-ink);
+}
+
+.theme-doc-markdown tbody tr {
+  border-bottom: 1px solid var(--vaquum-paper-2);
+}
+
+.theme-doc-markdown tbody tr:last-child {
+  border-bottom: 1px solid var(--vaquum-ink);
+}
+
+.theme-doc-markdown th code,
+.theme-doc-markdown td code {
   background: transparent;
   font-size: inherit;
   line-height: inherit;
   padding: 0;
 }
 
-.theme-doc-markdown:has(.vaquum-design-system-sample) th {
-  font-size: 13px;
-  letter-spacing: 0.08em;
+.theme-doc-markdown blockquote {
+  border-left: 3px solid var(--vaquum-rule);
+  color: var(--vaquum-ink);
+  font-size: 17px;
+  line-height: 1.55;
+  margin: 16px 0 24px;
+  padding-left: 2ch;
+}
+
+.theme-doc-markdown hr {
+  border: 0;
+  border-top: 1px solid var(--vaquum-rule);
+  margin: 64px 0;
+}
+
+.pagination-nav {
+  border-top: 1px solid var(--vaquum-rule);
+  gap: 16px;
+  margin-top: 64px;
+  padding-top: 16px;
+}
+
+.pagination-nav__link {
+  background: transparent;
+  border: 1px solid var(--vaquum-rule);
+  border-radius: 0;
+  box-shadow: none;
+}
+
+.pagination-nav__link:hover {
+  border-color: var(--vaquum-accent);
+}
+
+.pagination-nav__sublabel {
+  color: var(--vaquum-ink-mute);
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.14em;
   line-height: 1.2;
   text-transform: uppercase;
 }
 
-.theme-doc-markdown:has(.vaquum-design-system-sample) thead {
-  border-bottom: 1px solid var(--vaquum-sample-rule);
-  border-top: 1px solid var(--vaquum-sample-ink);
+.pagination-nav__label {
+  color: var(--vaquum-ink);
+  font-size: 13px;
+  font-weight: 400;
+  line-height: 1.55;
 }
 
-.theme-doc-markdown:has(.vaquum-design-system-sample) tbody tr {
-  border-bottom: 1px solid var(--vaquum-sample-paper-2);
+
+[class*='generatedIndexPage'] .col {
+  margin-bottom: 16px;
 }
 
-.theme-doc-markdown:has(.vaquum-design-system-sample) tbody tr:last-child {
-  border-bottom: 1px solid var(--vaquum-sample-ink);
+[class*='generatedIndexPage'] [class*='cardContainer'],
+[class*='cardContainer'],
+.card {
+  background: transparent !important;
+  border: 1px solid var(--vaquum-rule) !important;
+  border-radius: 0 !important;
+  box-shadow: none !important;
+  color: var(--vaquum-ink);
 }
 
-.theme-doc-markdown:has(.vaquum-design-system-sample) th {
-  color: var(--vaquum-sample-ink-deep);
+[class*='generatedIndexPage'] [class*='cardContainer']:hover,
+[class*='cardContainer']:hover,
+.card:hover {
+  border-color: var(--vaquum-accent) !important;
+  box-shadow: none !important;
+}
+
+[class*='cardContainer'] h2,
+.card h2 {
+  border-top: 0 !important;
+  font-size: 17px !important;
   font-weight: 600;
+  letter-spacing: 0;
+  line-height: 1.55;
+  margin: 0 0 16px;
+  padding-top: 0 !important;
+  text-transform: none;
 }
 
-.theme-doc-markdown:has(.vaquum-design-system-sample) td {
-  color: var(--vaquum-sample-ink-soft);
+[class*='cardContainer'] p,
+.card p {
+  color: var(--vaquum-ink-soft);
+  font-size: 13px !important;
+  line-height: 1.55;
 }
 
-html[data-theme='dark'] .theme-doc-markdown:has(.vaquum-design-system-sample) td {
-  color: var(--vaquum-sample-ink-soft);
+.footer {
+  background: var(--vaquum-paper);
+  border-top: 1px solid var(--vaquum-rule);
+  color: var(--vaquum-ink-soft);
 }
 
-.theme-doc-markdown:has(.vaquum-design-system-sample) hr {
-  border: 0;
-  border-top: 1px solid var(--vaquum-sample-rule);
-  margin: 64px 0;
+.footer__title,
+.footer__link-item,
+.footer__copyright {
+  color: var(--vaquum-ink-soft);
+  font-size: 13px;
+  line-height: 1.55;
+}
+
+.footer__link-item:hover {
+  color: var(--vaquum-accent);
 }
 
 @media (max-width: 996px) {
-  .theme-doc-markdown:has(.vaquum-design-system-sample) {
+  .theme-doc-markdown {
     max-width: none;
     padding: 24px 16px 64px;
+  }
+
+  .table-of-contents {
+    border-left: 0;
+    padding-left: 0;
   }
 }

--- a/docs-site/src/css/custom.css
+++ b/docs-site/src/css/custom.css
@@ -194,3 +194,216 @@ html[data-theme='dark'] .pagination-nav__link {
 .table-of-contents__link--active {
   font-weight: 600;
 }
+
+
+/* Vaquum design-system sample: docs/Backtest.md. */
+.theme-doc-markdown:has(.vaquum-design-system-sample) {
+  --vaquum-sample-ink-deep: #121212;
+  --vaquum-sample-ink: #231F20;
+  --vaquum-sample-ink-soft: #444444;
+  --vaquum-sample-ink-mute: #808080;
+  --vaquum-sample-rule: #D3D3D3;
+  --vaquum-sample-paper-2: #F3F3F3;
+  --vaquum-sample-paper: #F8F8F8;
+  --vaquum-sample-accent: #DC65A6;
+  --vaquum-sample-sans: 'IBM Plex Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+  --vaquum-sample-mono: 'IBM Plex Mono', ui-monospace, 'SF Mono', Menlo, Consolas, 'Liberation Mono', monospace;
+  background: var(--vaquum-sample-paper);
+  border: 0;
+  border-radius: 0;
+  box-shadow: none;
+  backdrop-filter: none;
+  color: var(--vaquum-sample-ink);
+  font-family: var(--vaquum-sample-sans);
+  font-size: 17px;
+  font-variant-numeric: lining-nums;
+  letter-spacing: 0;
+  line-height: 1.55;
+  margin: 0 auto;
+  max-width: 680px;
+  padding: 64px 0;
+}
+
+.theme-doc-markdown:has(.vaquum-design-system-sample) h1,
+.theme-doc-markdown:has(.vaquum-design-system-sample) h2,
+.theme-doc-markdown:has(.vaquum-design-system-sample) h3,
+.theme-doc-markdown:has(.vaquum-design-system-sample) h4 {
+  color: var(--vaquum-sample-ink-deep);
+  font-family: var(--vaquum-sample-sans);
+}
+
+.theme-doc-markdown:has(.vaquum-design-system-sample) h1 {
+  font-size: 44px;
+  font-weight: 600;
+  letter-spacing: -0.015em;
+  line-height: 1.1;
+  margin: 0 0 16px;
+  max-width: 28ch;
+  text-transform: none;
+}
+
+.theme-doc-markdown:has(.vaquum-design-system-sample) h2 {
+  border-top: 1px solid var(--vaquum-sample-rule);
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  line-height: 1.2;
+  margin: 64px 0 16px;
+  padding-top: 16px;
+  text-transform: uppercase;
+}
+
+.theme-doc-markdown:has(.vaquum-design-system-sample) h3 {
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  line-height: 1.2;
+  margin: 24px 0 16px;
+  text-transform: uppercase;
+}
+
+.theme-doc-markdown:has(.vaquum-design-system-sample) p,
+.theme-doc-markdown:has(.vaquum-design-system-sample) li {
+  font-size: 17px;
+  letter-spacing: 0;
+  line-height: 1.55;
+  max-width: 66ch;
+}
+
+.theme-doc-markdown:has(.vaquum-design-system-sample) h1 + .vaquum-design-system-sample + p {
+  color: var(--vaquum-sample-ink-soft);
+  font-size: 19px;
+  line-height: 1.5;
+  margin-bottom: 16px;
+  max-width: 52ch;
+}
+
+.theme-doc-markdown:has(.vaquum-design-system-sample) a {
+  color: var(--vaquum-sample-ink);
+  font-weight: 400;
+  text-decoration-color: var(--vaquum-sample-accent);
+  text-decoration-line: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 3px;
+}
+
+.theme-doc-markdown:has(.vaquum-design-system-sample) a:hover {
+  color: var(--vaquum-sample-accent);
+}
+
+.theme-doc-markdown:has(.vaquum-design-system-sample) strong {
+  font-weight: 600;
+}
+
+.theme-doc-markdown:has(.vaquum-design-system-sample) em {
+  font-style: normal;
+  font-weight: 600;
+}
+
+.theme-doc-markdown:has(.vaquum-design-system-sample) ul,
+.theme-doc-markdown:has(.vaquum-design-system-sample) ol {
+  margin: 16px 0 24px;
+  max-width: 66ch;
+  padding-left: 0;
+}
+
+.theme-doc-markdown:has(.vaquum-design-system-sample) ul {
+  list-style: none;
+}
+
+.theme-doc-markdown:has(.vaquum-design-system-sample) ul li {
+  padding-left: 1.2em;
+  position: relative;
+}
+
+.theme-doc-markdown:has(.vaquum-design-system-sample) ul li::before {
+  color: var(--vaquum-sample-ink-mute);
+  content: '·';
+  left: 0;
+  position: absolute;
+}
+
+.theme-doc-markdown:has(.vaquum-design-system-sample) code,
+.theme-doc-markdown:has(.vaquum-design-system-sample) pre {
+  font-family: var(--vaquum-sample-mono);
+  font-size: 14.5px;
+  font-variant-numeric: tabular-nums slashed-zero;
+  letter-spacing: 0;
+  line-height: 1.65;
+}
+
+.theme-doc-markdown:has(.vaquum-design-system-sample) :not(pre) > code {
+  background: var(--vaquum-sample-paper-2);
+  border: 0;
+  border-radius: 0;
+  color: var(--vaquum-sample-ink);
+  padding: 0 2px;
+}
+
+.theme-doc-markdown:has(.vaquum-design-system-sample) pre {
+  background: var(--vaquum-sample-paper-2);
+  border: 0;
+  border-left: 3px solid var(--vaquum-sample-accent);
+  border-radius: 0;
+  box-shadow: none;
+  margin: 16px 0 24px;
+  max-width: 80ch;
+  padding: 16px;
+}
+
+.theme-doc-markdown:has(.vaquum-design-system-sample) table {
+  background: transparent;
+  border-collapse: collapse;
+  border-radius: 0;
+  box-shadow: none;
+  color: var(--vaquum-sample-ink);
+  display: table;
+  font-size: 13px;
+  line-height: 1.55;
+  margin: 16px 0 24px;
+  overflow: visible;
+  width: 100%;
+}
+
+.theme-doc-markdown:has(.vaquum-design-system-sample) th,
+.theme-doc-markdown:has(.vaquum-design-system-sample) td {
+  border: 0;
+  padding: 8px 16px 8px 0;
+  text-align: left;
+  vertical-align: top;
+}
+
+.theme-doc-markdown:has(.vaquum-design-system-sample) thead {
+  border-bottom: 1px solid var(--vaquum-sample-rule);
+  border-top: 1px solid var(--vaquum-sample-ink);
+}
+
+.theme-doc-markdown:has(.vaquum-design-system-sample) tbody tr {
+  border-bottom: 1px solid var(--vaquum-sample-paper-2);
+}
+
+.theme-doc-markdown:has(.vaquum-design-system-sample) tbody tr:last-child {
+  border-bottom: 1px solid var(--vaquum-sample-ink);
+}
+
+.theme-doc-markdown:has(.vaquum-design-system-sample) th {
+  color: var(--vaquum-sample-ink-deep);
+  font-weight: 600;
+}
+
+.theme-doc-markdown:has(.vaquum-design-system-sample) td {
+  color: var(--vaquum-sample-ink-soft);
+}
+
+.theme-doc-markdown:has(.vaquum-design-system-sample) hr {
+  border: 0;
+  border-top: 1px solid var(--vaquum-sample-rule);
+  margin: 64px 0;
+}
+
+@media (max-width: 996px) {
+  .theme-doc-markdown:has(.vaquum-design-system-sample) {
+    max-width: none;
+    padding: 24px 16px 64px;
+  }
+}

--- a/docs-site/src/css/custom.css
+++ b/docs-site/src/css/custom.css
@@ -225,12 +225,34 @@ html[data-theme='dark'] .pagination-nav__link {
   padding: 64px 0;
 }
 
+html[data-theme='dark'] .theme-doc-markdown:has(.vaquum-design-system-sample) {
+  --vaquum-sample-ink-deep: #F8F8F8;
+  --vaquum-sample-ink: #F3F3F3;
+  --vaquum-sample-ink-soft: #D3D3D3;
+  --vaquum-sample-ink-mute: #808080;
+  --vaquum-sample-rule: #444444;
+  --vaquum-sample-paper-2: #231F20;
+  --vaquum-sample-paper: #121212;
+  --vaquum-sample-accent: #EAA3C8;
+  background: var(--vaquum-sample-paper);
+  border: 0;
+  box-shadow: none;
+  color: var(--vaquum-sample-ink);
+}
+
 .theme-doc-markdown:has(.vaquum-design-system-sample) h1,
 .theme-doc-markdown:has(.vaquum-design-system-sample) h2,
 .theme-doc-markdown:has(.vaquum-design-system-sample) h3,
 .theme-doc-markdown:has(.vaquum-design-system-sample) h4 {
   color: var(--vaquum-sample-ink-deep);
   font-family: var(--vaquum-sample-sans);
+}
+
+html[data-theme='dark'] .theme-doc-markdown:has(.vaquum-design-system-sample) h1,
+html[data-theme='dark'] .theme-doc-markdown:has(.vaquum-design-system-sample) h2,
+html[data-theme='dark'] .theme-doc-markdown:has(.vaquum-design-system-sample) h3,
+html[data-theme='dark'] .theme-doc-markdown:has(.vaquum-design-system-sample) h4 {
+  color: var(--vaquum-sample-ink-deep);
 }
 
 .theme-doc-markdown:has(.vaquum-design-system-sample) h1 {
@@ -422,6 +444,10 @@ html[data-theme='dark'] .pagination-nav__link {
 }
 
 .theme-doc-markdown:has(.vaquum-design-system-sample) td {
+  color: var(--vaquum-sample-ink-soft);
+}
+
+html[data-theme='dark'] .theme-doc-markdown:has(.vaquum-design-system-sample) td {
   color: var(--vaquum-sample-ink-soft);
 }
 

--- a/docs-site/src/css/custom.css
+++ b/docs-site/src/css/custom.css
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500;600&family=Rajdhani:wght@500;600;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600&family=IBM+Plex+Mono:wght@400;500&display=swap');
 
 :root {
   --vaquum-cyan: #c4e8f4;
@@ -36,8 +36,8 @@
   --ifm-code-font-size: 94%;
   --ifm-font-family-base: "IBM Plex Sans", "Segoe UI", sans-serif;
   --ifm-font-family-monospace: "IBM Plex Mono", "SFMono-Regular", monospace;
-  --ifm-heading-font-family: "Rajdhani", "IBM Plex Sans", sans-serif;
-  --ifm-heading-font-weight: 700;
+  --ifm-heading-font-family: "IBM Plex Sans", "Segoe UI", sans-serif;
+  --ifm-heading-font-weight: 600;
   --ifm-line-height-base: 1.65;
   --ifm-menu-color: var(--vaquum-gray-700);
   --ifm-menu-color-active: var(--vaquum-black);
@@ -127,8 +127,8 @@ html[data-theme='dark'] .theme-doc-markdown {
 .theme-doc-markdown h4,
 .hero__title,
 .navbar__title {
-  letter-spacing: 0.01em;
-  text-transform: uppercase;
+  letter-spacing: 0;
+  text-transform: none;
 }
 
 .theme-doc-markdown h1 {
@@ -215,6 +215,7 @@ html[data-theme='dark'] .pagination-nav__link {
   backdrop-filter: none;
   color: var(--vaquum-sample-ink);
   font-family: var(--vaquum-sample-sans);
+  font-feature-settings: 'kern' 1, 'liga' 1, 'calt' 1;
   font-size: 17px;
   font-variant-numeric: lining-nums;
   letter-spacing: 0;
@@ -260,6 +261,14 @@ html[data-theme='dark'] .pagination-nav__link {
   line-height: 1.2;
   margin: 24px 0 16px;
   text-transform: uppercase;
+}
+
+.theme-doc-markdown:has(.vaquum-design-system-sample) p:has(+ table) {
+  color: var(--vaquum-sample-ink-soft);
+  font-size: 13px;
+  line-height: 1.55;
+  margin: 16px 0 8px;
+  max-width: 60ch;
 }
 
 .theme-doc-markdown:has(.vaquum-design-system-sample) p,
@@ -367,10 +376,31 @@ html[data-theme='dark'] .pagination-nav__link {
 
 .theme-doc-markdown:has(.vaquum-design-system-sample) th,
 .theme-doc-markdown:has(.vaquum-design-system-sample) td {
+  background: transparent;
   border: 0;
   padding: 8px 16px 8px 0;
   text-align: left;
   vertical-align: top;
+}
+
+.theme-doc-markdown:has(.vaquum-design-system-sample) tr,
+.theme-doc-markdown:has(.vaquum-design-system-sample) tr:nth-child(2n) {
+  background: transparent;
+}
+
+.theme-doc-markdown:has(.vaquum-design-system-sample) th code,
+.theme-doc-markdown:has(.vaquum-design-system-sample) td code {
+  background: transparent;
+  font-size: inherit;
+  line-height: inherit;
+  padding: 0;
+}
+
+.theme-doc-markdown:has(.vaquum-design-system-sample) th {
+  font-size: 13px;
+  letter-spacing: 0.08em;
+  line-height: 1.2;
+  text-transform: uppercase;
 }
 
 .theme-doc-markdown:has(.vaquum-design-system-sample) thead {

--- a/docs/Backtest.md
+++ b/docs/Backtest.md
@@ -1,138 +1,130 @@
 # Backtest
 
-Backtest is Limen's trading-economics layer. It takes prediction outputs and asks the next question after benchmark:
+<span className="vaquum-design-system-sample" aria-hidden="true"></span>
 
-The layer maps a binary signal into long-only returns after fees and slippage.
+Backtest is Limen's trading-economics ledger. It converts binary prediction output into long-flat per-bar returns after declared fill costs, then reports one row of intensive metrics per evaluated round.
 
-Limen exposes a vectorized snapshot backtest, used throughout the `Log` layer.
+The layer answers one question: did the predictive structure retain economic value under the declared execution contract?
 
-## Where backtest lives
+## Entry points
 
-Backtest outputs are exposed through:
+Table 1. Backtest is exposed through three paths.
 
-- `uel.experiment_backtest_results`
-- `uel._log.experiment_backtest_results()`
-- `limen.backtest.backtest_snapshot`
+| path | use |
+|---|---|
+| `uel.experiment_backtest_results` | Experiment-wide table with one row per round. |
+| `uel._log.experiment_backtest_results()` | Log-layer method that builds the experiment-wide table. |
+| `limen.backtest.backtest_snapshot` | Package function for one per-round prediction table. |
 
-## Snapshot Backtest
+## Snapshot contract
 
-`backtest_snapshot()` is the default backtest path used by `Log.experiment_backtest_results()`.
-
-It consumes the per-round table returned by:
+`backtest_snapshot()` is the ledger path used by `Log.experiment_backtest_results()`. It consumes the per-round table returned by `permutation_prediction_performance()` and returns one summary row.
 
 ```python
 uel._log.permutation_prediction_performance(round_id=0)
 ```
 
-and returns one summary row.
+Table 2. The default strategy is a fixed long-flat contract.
 
-### Current assumptions
+| dimension | rule |
+|---|---|
+| Signal | Direct snapshot predictions must be binary `0` or `1`; invalid and missing values raise. |
+| Position | `prediction == 1` means in market; `prediction == 0` means flat. The default path is long-only. |
+| Execution lag | Completed-bar pipelines execute prediction row `t` on the next execution row by default with `execution_lag_bars=1`. |
+| Same-row execution | `execution_lag_bars=0` executes on the same tradable row; it does not restore the old raw-row denominator behavior. |
+| Price inputs | `open`, `close`, and `price_change` must be numeric. Missing price rows are non-tradable gaps. |
+| Price identity | `price_change` must equal `close - open` when all three fields are present. |
+| Entry return | Entry-bar gross return is `price_change / open`. |
+| Continuation return | Continuation-bar gross return is `close_t / close_{t-1} - 1`. |
+| Fill cost | Fee and slippage are applied multiplicatively on entry and exit fills. |
+| Position size | `notional_rate` is a deployed-capital fraction in `(0, 1]`. It scales per-bar `edge`, `pnl`, and `cost`. |
+| Population | Every bar in the window is counted. A flat bar contributes a real `0`. |
+| Units | Return and cost outputs are basis-point scaled. |
 
-The current snapshot backtest has a fixed long-flat contract:
+This contract makes each round comparable because every output column is computed over the same population: all bars in the evaluation window.
 
-- long-only
-- direct snapshot predictions must already be binary `0/1`
-- invalid or missing direct snapshot predictions raise instead of being coerced
-- `prediction == 1` means "in market"; `prediction == 0` means flat
-- completed-bar pipelines execute prediction row `t` on the immediate next execution row by default (`execution_lag_bars=1`)
-- `execution_lag_bars=0` gives same-row execution of tradable rows, not the old raw-row denominator behavior
-- price columns must be numeric; missing price rows are treated as non-tradable gaps
-- entry-bar return is based on `price_change / open`
-- `price_change` must match `close - open` when all three fields are present
-- continuation-bar return is based on `close_t / close_{t-1} - 1`
-- fee and slippage costs are applied multiplicatively on entry and exit fills
-- position size is a tunable fraction of capital (`notional_rate`, default `1.0` = all-in) that scales the per-bar `edge`, `pnl`, and `cost` and sets the average deployed notional
-- every column is computed per bar over all bars in the window (a flat bar counts as a real `0`)
-- distribution columns carry p5/p50/p95; the rest are single intensive (run-length-invariant) scalars
-- return and cost outputs are basis-point scaled
+## Economic inputs
 
-The fee and slippage rates default to `5.0` bps each per fill (`20.0` bps for one entry and one exit) and are configured on the manifest, not on the model: `manifest.set_backtest_config(fee_bps=5.0, slip_bps=5.0)`. Each value is a fixed number or a search-param name — pass a param name to sweep cost across the search (for example `set_backtest_config(fee_bps='fee')` with `fee` in `params()`), to match a venue's costs, make cost a search dimension, or stress-test how sensitive an edge is to the cost assumption. Omitting the config keeps the 5 + 5 default, so existing experiments are unchanged.
+Fees and slippage default to `5.0` bps each per fill. A one-entry, one-exit path applies four `5.0` bps adjustments: entry fee, entry slippage, exit fee, and exit slippage.
 
-`set_backtest_config` also takes `notional_rate` — the fraction of capital deployed while in position, in `(0, 1]` (default `1.0`, all-in; a 10% book is `notional_rate=0.1`). It scales `edge`, `pnl`, and `cost` together so the ledger reflects the account at that bet size (`drawdown` also moves with bet size, but path-dependently — it compounds against a running peak, so it is not a linear multiple of the full-size drawdown), leaves `wins_per_bar` and `trades_per_bar` untouched, and turns `inventory_per_bar` into the average deployed notional. Like the costs it is a fixed number or a search-param name, so one search can sweep bet size.
+Configure the economic inputs on the manifest, not on the model:
 
-In a YAML/CLI manifest the same configuration is a `backtest:` block under `sfd.manifest`, sibling to `target:` and `scaler:`. Each value is a fixed number or a `"{param}"` reference into `sfd.params`, mirroring how indicator and target params are swept:
+```python
+manifest.set_backtest_config(fee_bps=5.0, slip_bps=5.0, notional_rate=1.0)
+```
+
+Each value is either a fixed number or a search-parameter name. Pass a parameter name when cost or position size belongs in the search space.
+
+```python
+manifest.set_backtest_config(fee_bps='fee', slip_bps=5.0, notional_rate='size')
+```
+
+A YAML/CLI manifest carries the same configuration under `sfd.manifest.backtest`, sibling to `target` and `scaler`.
 
 ```yaml
 sfd:
   manifest:
     backtest:
-      fee_bps: "{fee}"        # swept across the search
-      slip_bps: 5.0           # fixed
-      notional_rate: "{size}" # swept bet size, in (0, 1]
+      fee_bps: "{fee}"
+      slip_bps: 5.0
+      notional_rate: "{size}"
   params:
     fee: [1.0, 5.0, 10.0]
     size: [0.1, 0.5, 1.0]
 ```
 
-The block is optional and applies to both `ml` and `rule_based` manifests; omitting it — or leaving it empty — keeps the defaults (5 + 5 bps, all-in). `limen validate` rejects an unknown key, a negative or non-finite cost, a `notional_rate` outside `(0, 1]`, and a `"{param}"` reference missing from `sfd.params`.
+The block is optional. When omitted or empty, the defaults remain `fee_bps=5.0`, `slip_bps=5.0`, and `notional_rate=1.0`. `limen validate` rejects unknown keys, negative costs, non-finite costs, `notional_rate` outside `(0, 1]`, and `"{param}"` references missing from `sfd.params`.
 
-This makes snapshot backtests fast and comparable across rounds, but it also means they are not trying to be a full execution simulator.
+## Output ledger
 
-### Output columns
+Snapshot backtests produce 20 columns over one population: every bar in the window.
 
-Snapshot backtests produce 20 columns over one population — every bar in the window.
+Table 3. Distribution columns report `p5`, `p50`, and `p95`.
 
-Per-bar distributions (`p5` / `p50` / `p95`):
+| prefix | columns | meaning |
+|---|---|---|
+| `edge_bps` | `edge_bps_p5`, `edge_bps_p50`, `edge_bps_p95` | Gross per-bar return. |
+| `pnl_bps` | `pnl_bps_p5`, `pnl_bps_p50`, `pnl_bps_p95` | Net per-bar return. |
+| `cost_bps` | `cost_bps_p5`, `cost_bps_p50`, `cost_bps_p95` | Per-bar gross return minus net return. |
+| `drawdown_bps` | `drawdown_bps_p5`, `drawdown_bps_p50`, `drawdown_bps_p95` | Net equity against its running peak. Values are less than or equal to `0`. |
 
-- `edge_bps_*` — gross per-bar return
-- `pnl_bps_*` — net per-bar return
-- `cost_bps_*` — per-bar cost (gross minus net)
-- `drawdown_bps_*` — net equity against its running peak (≤ 0)
+Table 4. Scalar columns are intensive metrics.
 
-Intensive scalars:
+| column | meaning |
+|---|---|
+| `wins_per_bar` | Share of all bars with positive net return. A flat bar is not a win. |
+| `pnl_per_bar_bps` | Mean net return per bar. |
+| `avg_win_bps` | Mean positive-bar net return; `NaN` when no positive bar exists. |
+| `avg_loss_bps` | Mean negative-bar net return; `NaN` when no negative bar exists. |
+| `cvar_95_pnl_bps` | Mean of the worst `5%` of per-bar net returns; `NaN` below 20 bars. |
+| `trades_per_bar` | Entry count divided by total bar count. |
+| `inventory_per_bar` | Mean deployed notional; `notional_rate` multiplied by the share of bars in market. |
+| `cost_per_bar_bps` | Mean per-bar gross return minus net return. |
 
-- `wins_per_bar` — share of all bars with positive net return (a flat bar is not a win, so it cannot exceed the in-market share — `inventory_per_bar` under the all-in model)
-- `pnl_per_bar_bps` — mean net return per bar
-- `avg_win_bps`, `avg_loss_bps` — mean of the positive / negative bars (NaN when there are none)
-- `cvar_95_pnl_bps` — mean of the worst 5% of per-bar net returns (NaN below 20 bars)
-- `trades_per_bar` — entries per bar (turnover)
-- `inventory_per_bar` — mean position held per bar; the average deployed notional (`notional_rate` × the share of bars in market)
-- `cost_per_bar_bps` — mean cost per bar
+## Strategy boundary
 
-### Pluggable strategy
+The execution model is swappable. `backtest_snapshot()` validates price columns, calls a strategy, and builds the ledger from the returned per-bar series. The shipped strategy is `long_flat_strategy` in `limen.backtest.long_flat_strategy`.
 
-The execution model — how a `0/1` signal becomes per-bar returns — is a swappable `strategy`. `backtest_snapshot()` validates the price columns, calls the strategy, and builds the ledger from what it returns; it does not itself know how positions or costs are formed.
-
-The default is `long_flat_strategy` (the long-only, hold-while-1 model described above). A strategy is any callable with this shape:
-
-```python
-from limen.backtest.long_flat_strategy import ExecutionResult
-
-def my_strategy(predictions, open_px, close_px, price_change, *,
-                execution_lag_bars, fee_bps, slip_bps) -> ExecutionResult:
-    position = predictions.astype(float).shift(execution_lag_bars, fill_value=0.0)
-    gross_return = position * price_change / open_px
-
-    entry_mask = (position == 1.0) & (position.shift(1, fill_value=0.0) == 0.0)
-    exit_mask = (position == 1.0) & (position.shift(-1, fill_value=0.0) == 0.0)
-    fee = fee_bps / 10_000.0
-    slip = slip_bps / 10_000.0
-    cost_mult = position.copy()
-    cost_mult[:] = 1.0
-    cost_mult.loc[entry_mask] *= (1.0 - fee) / (1.0 + slip)
-    cost_mult.loc[exit_mask] *= (1.0 - fee) * (1.0 - slip)
-
-    net_return = ((1.0 + gross_return) * cost_mult) - 1.0
-    return ExecutionResult(pos=position, gross=gross_return, net=net_return)
-```
-
-`ExecutionResult` carries three per-bar series over every bar in the window: `pos` (position held — `0`/`1` here, a deployed fraction once sizing exists), `gross` (per-bar return before costs), and `net` (per-bar return after costs). Every ledger column flows from that triple. Pass a strategy through the `strategy` argument:
+A strategy receives `predictions`, `open_px`, `close_px`, `price_change`, `execution_lag_bars`, `fee_bps`, and `slip_bps`. It returns `ExecutionResult(pos, gross, net)`, where each field is a per-bar series over the full window.
 
 ```python
-round0_backtest = backtest_snapshot(perf, strategy=my_strategy)
+from limen.backtest.backtest_snapshot import backtest_snapshot
+from limen.backtest.long_flat_strategy import long_flat_strategy
+
+round0_backtest = backtest_snapshot(perf, strategy=long_flat_strategy)
 ```
 
-The strategy owns its own signal contract — `long_flat_strategy` requires binary `0/1` and validates it — and applies its own costs, since only it knows where entries and exits fall.
+The strategy owns its signal contract and fill mechanics. `backtest_snapshot()` applies `notional_rate` after the strategy returns, so position sizing remains a ledger-level scale rather than a strategy argument.
 
-`backtest_snapshot` forwards only the fill-shaping kwargs (`execution_lag_bars`, `fee_bps`, `slip_bps`) to the strategy. `notional_rate` is *not* a strategy concern — it is a uniform scale on the returned triple, so `backtest_snapshot` applies it after the strategy returns, leaving the strategy contract stable as that knob (and others like it) is added.
+## Usage
 
-### Usage
+Use the experiment-wide table to compare rounds.
 
 ```python
 backtest = uel.experiment_backtest_results
 ```
 
-or for one round:
+Use the package function to inspect one permutation.
 
 ```python
 from limen.backtest.backtest_snapshot import backtest_snapshot
@@ -141,36 +133,34 @@ perf = uel._log.permutation_prediction_performance(round_id=0)
 round0_backtest = backtest_snapshot(perf)
 ```
 
-Use the experiment-wide table to compare rounds. Use the single-round snapshot for one permutation.
+## Benchmark boundary
 
-## Backtest versus benchmark
+Benchmark and backtest answer different questions.
 
-Benchmark and backtest should be read together, not treated as substitutes.
+Table 5. The layers are separate because statistical structure and trading economics can fail independently.
 
-- benchmark asks whether the signal contains predictive structure
-- backtest asks whether that structure survives a specific trading interpretation
+| layer | question | input frame |
+|---|---|---|
+| Benchmark | Does the signal contain predictive structure? | Predictions and realized labels. |
+| Backtest | Does that structure survive the declared trading interpretation? | Binary signal, price columns, costs, lag, and notional. |
 
-Examples of why the layers diverge:
+Limen keeps the layers separate in the API and the docs because benchmark quality is not a substitute for economic inspection.
 
-- a signal can have high precision but excessive market exposure
-- a signal can have low TP/FP separation yet still avoid the largest losses
-- a signal can score high statistically but lose edge after costs
+## Non-goals
 
-That is why Limen keeps the layers separate in both the API and the docs.
+Snapshot backtest is not an execution simulator.
 
-## What snapshot backtest does not try to do
+Table 6. These concerns sit outside the snapshot contract.
 
-The snapshot backtest is not:
-
-- a venue-aware execution simulator
-- a portfolio allocator
-- a short-selling engine
-- a latency-aware order model
-
-Those concerns belong downstream from Limen or in more specialized evaluation layers.
+| concern | status |
+|---|---|
+| Venue-aware execution | Out of scope. |
+| Portfolio allocation | Out of scope. |
+| Short selling | Out of scope. |
+| Latency-aware order modeling | Out of scope. |
 
 ## Read next
 
 - Continue to [Trainer](Trainer.md) for promotion of selected experiment rounds into reusable trained sensors.
-- Continue to [Log](Log.md) for the broader post-run workflow that produces the backtest inputs.
+- Continue to [Log](Log.md) for the post-run workflow that produces backtest inputs.
 - Continue to [Benchmark](Benchmark.md) for the prediction-quality layer that precedes trading-economics inspection.

--- a/docs/Backtest.md
+++ b/docs/Backtest.md
@@ -1,6 +1,5 @@
 # Backtest
 
-<span className="vaquum-design-system-sample" aria-hidden="true"></span>
 
 Backtest is Limen's trading-economics ledger. It converts binary prediction output into long-flat per-bar returns after declared fill costs, then reports one row of intensive metrics per evaluated round.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaquum_limen"
-version = "3.30.1"
+version = "3.30.2"
 description = "Limen unifies parameter search across machine learning and rule-based strategies, with built-in analytics that show not just what works, but why it works."
 readme = "README.md"
 authors = [


### PR DESCRIPTION
## Summary

- Recasts `docs/Backtest.md` as the first canonical design-system content sample.
- Applies the design-system face globally across the docs site: IBM Plex Sans/Mono, fixed editorial scale, square frames, booktabs tables, quiet shell navigation, constrained syntax colors, and light/dark palette parity.
- Removes the page-local sentinel styling path now that the treatment is global.

## Impact

- Documentation-site presentation change only.
- Does not alter runtime behavior, generated docs routing, parser contracts, or package APIs.

## Validation

- `npm run check`
- Rendered light-mode screenshots: `/tmp/limen-backtest-global-light.png`, `/tmp/limen-guides-global-light-3.png`, `/tmp/limen-indicators-global-light-2.png`
- Rendered dark-mode screenshots: `/tmp/limen-backtest-global-dark.png`, `/tmp/limen-guides-global-dark.png`
- Local sample URL: `http://localhost:3001/limen/guides/backtest`
