### PR TITLE
fix: sensor reproducibility via context carry-over and strict null detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1136,3 +1136,11 @@ Note: add all new changelog entries to the bottom of this file.
 ## v3.30.2 on 14th of June, 2026
 
 - Add a design-system-aligned docs surface: global IBM Plex typography, fixed editorial scale, quiet navigation, booktabs-style tables, square code and media frames, light/dark palette parity, and the Backtest page as the first canonical content sample.
+
+## v3.31.0 on 15th of June, 2026
+
+- Fix rolling scaler reproducibility: the causal rolling scaler cold-started at each split boundary during training, causing val and test bars to receive different scaled values than the continuous inference stream. Context Carry-Over prepends the raw tail of the preceding split before the feature transform pass and strips it after scaling, so the scaler is always warm when it reaches the actual split data. The inference path is unchanged.
+- Expose a context rows property on the causal rolling robust scaler so CCO can detect the required warm-up size automatically. Stateless scalers return zero via duck-typing and receive no CCO block.
+- Add strict mode to the ML manifest. When enabled, unexpected nulls remaining after CCO dislodgement raise an error rather than logging a warning. The experiment loop catches the error per permutation, records the failure in results, and continues to the next round.
+- Add constructor parameter support for scalers in both the manifest API and YAML. Parameters such as window size and minimum samples can be set as literals or as sweep-param references, letting them appear in results and be fully reproducible.
+- Add a data quality section to the profile output. The profiler captures null warnings during sample rounds and the CLI renders them under a dedicated header.

--- a/docs/Built-In-SFDs.md
+++ b/docs/Built-In-SFDs.md
@@ -46,6 +46,7 @@ It combines:
 - features such as `vwap` and `kline_imbalance`
 - a fitted quantile-based target
 - scaler selection from params (`logreg`, `robust`, `rank_gauss`)
+- `strict_mode=True` — unexpected mid-split nulls abort the round and record an error in `results.csv`
 - the `LogRegBinary` reference model
 - `CalibrationBuilder` with `sklearn_probability_calibrator` and `grid_threshold_optimizer`
 
@@ -68,6 +69,7 @@ It combines:
 - context from `roc`, `distance_from_high`/`distance_from_low`/`price_range_position`, `parkinson_volatility`/`volatility_ratio`, and `cyclical_time_features`
 - the train-fitted `TradelineLongBinaryTarget` (confirmed-breakout label from a line-height percentile threshold)
 - scaler selection from params (`robust`, `rank_gauss`, `logreg`) and feature ablation
+- `strict_mode=True`
 - the `LightGBMBinary` reference model with the full `LGBMClassifier` parameter surface and early stopping
 - `CalibrationBuilder` with `sklearn_probability_calibrator` and `grid_threshold_optimizer`
 - swept backtest economics (`fee_bps`, `slip_bps`)

--- a/docs/Experiment-Manifest.md
+++ b/docs/Experiment-Manifest.md
@@ -490,17 +490,30 @@ Use this when scaler choice is itself part of the search space. Pass `extra_para
 
 ### `set_strict_mode(strict_mode)`
 
-Enable strict null checking on val and test splits after Context Carry-Over (CCO) dislodgement.
+Enable strict null checking after the Context Carry-Over (CCO) pipeline.
 
 ```python
 .set_strict_mode(True)
 ```
 
-When `True`, any unexpected null found in a feature column after CCO dislodgement raises `StrictModeError`. The UEL catches this per-permutation, records the error in `results.csv` under `strict_mode_error`, and continues to the next round.
+#### Background: Context Carry-Over
 
-When `False` (default), the same condition logs a `WARNING` and training continues. In both modes the target column (which always has a trailing null from `shift:-1`) is excluded from the check.
+When `prepare_data` processes val and test splits, it prepends a raw tail of the preceding split (the CCO block) before running feature transforms and the scaler. This ensures indicator warm-up rows and rolling-scaler warm-up rows are fully warmed before the first real split row is produced — matching how the Sensor sees a continuous stream in live inference.
 
-All foundational ML SFDs have `strict_mode=True`. New SFDs should follow the same convention.
+After the CCO rows are stripped from each processed split, two null checkpoints run on feature columns only (the target column, which always has a trailing null from `shift:-1`, is excluded):
+
+- **Checkpoint A** — after leading warm-up nulls are sliced off, before the scaler. Nulls here indicate mid-split data gaps in the raw input or indicator failures.
+- **Checkpoint B** — after the scaler and after CCO rows are removed. Nulls here would indicate the scaler itself introduced them (rare).
+
+Checkpoint A also runs on the training split, where there is no CCO block.
+
+#### Strict vs non-strict
+
+`strict_mode=True` — any unexpected null raises `StrictModeError` with the split name, checkpoint label, column name, and the timestamps of the null rows. The UEL catches this per-permutation, records the error message in `results.csv` under the `strict_mode_error` column (metric columns are empty for that round), and continues to the next round.
+
+`strict_mode=False` (default) — the same detection runs, but logs a `WARNING` instead of raising. Training continues and the final `drop_nulls()` silently removes the affected rows.
+
+All foundational ML SFDs and YAML templates ship with `strict_mode=True`. New SFDs should follow the same convention — silent drops during search can mask data quality problems that only appear under specific scaler or param combinations.
 
 ## PCA Compression
 

--- a/docs/Experiment-Manifest.md
+++ b/docs/Experiment-Manifest.md
@@ -451,7 +451,7 @@ See [Targets](Targets.md) for the full reference including all built-in target c
 
 ## Scaling
 
-### `set_scaler(transform_class, param_name='_scaler')`
+### `set_scaler(transform_class, param_name='_scaler', extra_params=None)`
 
 Configure a fitted scaler that is instantiated on train and then applied across the splits.
 
@@ -463,7 +463,14 @@ from limen.scalers import LogRegScaler
 
 The fitted scaler is stored in the resulting `data_dict` under `_scaler`.
 
-### `set_scaler_from_params(param_name='scaler_type')`
+Pass `extra_params` to forward constructor arguments. String values are treated as sweep param references resolved from `round_params` at fit time; all other values are static:
+
+```python
+# window swept as a param; min_samples fixed
+.set_scaler(CausalRollingRobustScaler, extra_params={'window': 'scaler_window', 'min_samples': 25})
+```
+
+### `set_scaler_from_params(param_name='scaler_type', extra_params=None)`
 
 Select a scaler dynamically from `SCALER_REGISTRY` using a round parameter.
 
@@ -479,7 +486,21 @@ Then in `params()`:
 }
 ```
 
-Use this when scaler choice is part of the search space.
+Use this when scaler choice is itself part of the search space. Pass `extra_params` to forward constructor arguments using the same static/dynamic resolution as `set_scaler()`.
+
+### `set_strict_mode(strict_mode)`
+
+Enable strict null checking on val and test splits after Context Carry-Over (CCO) dislodgement.
+
+```python
+.set_strict_mode(True)
+```
+
+When `True`, any unexpected null found in a feature column after CCO dislodgement raises `StrictModeError`. The UEL catches this per-permutation, records the error in `results.csv` under `strict_mode_error`, and continues to the next round.
+
+When `False` (default), the same condition logs a `WARNING` and training continues. In both modes the target column (which always has a trailing null from `shift:-1`) is excluded from the check.
+
+All foundational ML SFDs have `strict_mode=True`. New SFDs should follow the same convention.
 
 ## PCA Compression
 

--- a/docs/Scalers.md
+++ b/docs/Scalers.md
@@ -127,7 +127,9 @@ Rows with fewer than `min_samples` of trailing history fall back to the median a
 
 It skips datetime and non-numeric columns automatically. It provides no inverse transform: each row's scaling factors are derived from the data itself, so the transform is not row-wise invertible from the fitted scaler alone.
 
-The fitted instance exposes `context_rows = window`. The experiment pipeline reads this property to size the Context Carry-Over (CCO) block prepended to val and test splits, ensuring the scaler sees enough preceding rows to be fully warm from the very first split row.
+The fitted instance exposes `context_rows = window`. The experiment pipeline reads this property to size the scaler warm-up portion of the Context Carry-Over (CCO) block prepended to val and test splits, ensuring the scaler sees enough preceding rows to be fully warm from the very first split row.
+
+Scalers without a `context_rows` property (such as `RobustScaler` and `StandardScaler`) contribute zero to the scaler warm-up. CCO may still run for those scalers when indicators produce leading warm-up rows — those rows are prepended as indicator context regardless of scaler type. The total CCO block is `indicator_warm_up_rows + scaler_context_rows`.
 
 ## Custom Scaler Contract
 

--- a/docs/Scalers.md
+++ b/docs/Scalers.md
@@ -127,6 +127,8 @@ Rows with fewer than `min_samples` of trailing history fall back to the median a
 
 It skips datetime and non-numeric columns automatically. It provides no inverse transform: each row's scaling factors are derived from the data itself, so the transform is not row-wise invertible from the fitted scaler alone.
 
+The fitted instance exposes `context_rows = window`. The experiment pipeline reads this property to size the Context Carry-Over (CCO) block prepended to val and test splits, ensuring the scaler sees enough preceding rows to be fully warm from the very first split row.
+
 ## Custom Scaler Contract
 
 All custom scalers should follow the same interface:

--- a/docs/Universal-Experiment-Loop.md
+++ b/docs/Universal-Experiment-Loop.md
@@ -191,7 +191,7 @@ When UEL is instantiated with a concrete `search_strategy` and an `experiment_di
 
 | File | Meaning |
 |---|---|
-| `results.csv` | streaming round log |
+| `results.csv` | streaming round log; if a round fails a `strict_mode` null check, a `strict_mode_error` column records the error message and all metric columns for that round are empty |
 | `round_data.jsonl` | round params, predictions, and alignment metadata |
 | `checkpoint.json` | checkpoint state for resumption |
 | `audit.jsonl` | feedback-controller audit trail |

--- a/limen/cli/commands/profile.py
+++ b/limen/cli/commands/profile.py
@@ -51,6 +51,7 @@ def _print_profile(prof: ProfileResult) -> None:
     click.echo('')
     _print_permutation_space(prof)
     _print_runtime_sampling(prof)
+    _print_data_quality(prof)
 
     for w in prof.warnings:
         click.secho(f'  WARN: {w}', fg='yellow')
@@ -74,6 +75,17 @@ def _print_permutation_space(prof: ProfileResult) -> None:
     )
     for name, card in sorted_params:
         click.echo(f"      {name:<24} {card} value{'s' if card != 1 else ''}")
+
+
+def _print_data_quality(prof: ProfileResult) -> None:
+
+    click.echo('')
+    click.echo('  Data quality')
+    if not prof.data_quality_warnings:
+        click.echo('    No issues detected')
+        return
+    for w in prof.data_quality_warnings:
+        click.secho(f'    WARN: {w}', fg='yellow')
 
 
 def _print_runtime_sampling(prof: ProfileResult) -> None:

--- a/limen/experiment/errors.py
+++ b/limen/experiment/errors.py
@@ -1,0 +1,3 @@
+class StrictModeError(Exception):
+
+    '''Raised when strict_mode=True and unexpected nulls are found after CCO dislodgement.'''

--- a/limen/experiment/experiment_core.py
+++ b/limen/experiment/experiment_core.py
@@ -526,6 +526,8 @@ class UniversalExperimentLoop:
                 if caught else '[]'
             )
 
+            round_succeeded = '_alignment' in data_dict
+
             if 'extras' in round_results:
                 extras = round_results.pop('extras')
                 if post_processing:
@@ -541,12 +543,12 @@ class UniversalExperimentLoop:
             current_preds = round_results.pop('_preds', None)
             if current_preds is None:
                 current_preds = []
-            if post_processing and '_alignment' in data_dict:
+            if post_processing and round_succeeded:
                 self.preds.append(current_preds)
-            if post_processing and '_alignment' in data_dict and '_scaler' in data_dict:
+            if post_processing and round_succeeded and '_scaler' in data_dict:
                 self.scalers.append(data_dict['_scaler'])
 
-            if post_processing and '_alignment' in data_dict:
+            if post_processing and round_succeeded:
                 self._alignment.append(data_dict['_alignment'])
 
             round_results['id'] = current_hash
@@ -554,7 +556,7 @@ class UniversalExperimentLoop:
                 time.time() - start_time, 2,
             )
 
-            if post_processing and '_alignment' in data_dict:
+            if post_processing and round_succeeded:
                 self.round_params.append(sfd_params)
             for key, value in round_params.items():
                 round_results[key] = value
@@ -581,7 +583,7 @@ class UniversalExperimentLoop:
                         current_round, sorted(extra_keys),
                     )
 
-            if round_data_path and '_alignment' in data_dict:
+            if round_data_path and round_succeeded:
                 self._append_round_data(
                     round_data_path, current_hash, sfd_params,
                     current_preds,

--- a/limen/experiment/experiment_core.py
+++ b/limen/experiment/experiment_core.py
@@ -228,6 +228,9 @@ class UniversalExperimentLoop:
                     f'UniversalExperimentLoop Existing results CSV has no header: {csv_path}'
                 )
 
+        data_dict: dict[str, Any] = {}
+        _pending_csv_rows: list[dict] = []
+
         for i in tqdm(range(n_permutations)):
 
             # Start counting execution_time
@@ -246,49 +249,52 @@ class UniversalExperimentLoop:
                     'current_index': i,
                 }
 
-            if prep_each_round is True or i == 0:
-                data_dict = self.prep(self.data, round_params=round_params)
-
-            # Perform the model training and evaluation
-            round_results = self.model(data=data_dict, round_params=round_params)
+            try:
+                if prep_each_round is True or i == 0:
+                    data_dict = self.prep(self.data, round_params=round_params)
+                round_results = self.model(data=data_dict, round_params=round_params)
+                round_succeeded = True
+            except StrictModeError as exc:
+                logger.error('Round %d failed strict mode check: %s', i, exc)
+                round_results = {'strict_mode_error': str(exc)}
+                round_succeeded = False
 
             # Remove the experiment details from the results
             if maintain_details_in_params is True:
                 round_params.pop('_experiment_details')
 
-            if retain_round_artifacts:
-                self._alignment.append(data_dict['_alignment'])
-
-            # Handle any extra results that are returned from the model
-            if 'extras' in round_results:
+            if round_succeeded:
                 if retain_round_artifacts:
-                    self.extras.append(round_results['extras'])
-                round_results.pop('extras')
+                    self._alignment.append(data_dict['_alignment'])
 
-            # Handle any models that are returned from the model
-            if 'models' in round_results:
-                if retain_round_artifacts:
-                    self.models.append(round_results['models'])
-                round_results.pop('models')
+                if 'extras' in round_results:
+                    if retain_round_artifacts:
+                        self.extras.append(round_results['extras'])
+                    round_results.pop('extras')
 
-            if '_preds' in round_results:
-                if retain_round_artifacts:
-                    self.preds.append(round_results['_preds'])
-                round_results.pop('_preds')
+                if 'models' in round_results:
+                    if retain_round_artifacts:
+                        self.models.append(round_results['models'])
+                    round_results.pop('models')
 
-            if '_model' in round_results:
-                if retain_round_artifacts:
-                    self.models.append(round_results['_model'])
-                round_results.pop('_model')
+                if '_preds' in round_results:
+                    if retain_round_artifacts:
+                        self.preds.append(round_results['_preds'])
+                    round_results.pop('_preds')
 
-            if retain_round_artifacts and '_scaler' in data_dict:
-                self.scalers.append(data_dict['_scaler'])
+                if '_model' in round_results:
+                    if retain_round_artifacts:
+                        self.models.append(round_results['_model'])
+                    round_results.pop('_model')
 
-            # Add the round number and execution time to the results
+                if retain_round_artifacts and '_scaler' in data_dict:
+                    self.scalers.append(data_dict['_scaler'])
+
+            round_results.setdefault('strict_mode_error', None)
             round_results['id'] = i
             round_results['execution_time'] = round(time.time() - start_time, 2)
 
-            if retain_round_artifacts:
+            if retain_round_artifacts and round_succeeded:
                 self.round_params.append(round_params)
 
             for key in round_params:
@@ -299,23 +305,43 @@ class UniversalExperimentLoop:
                 log_batches.append(pl.DataFrame(results_accumulator))
                 results_accumulator = []
 
-            # Match the MSQ path: only write a header when the CSV is new or empty.
             write_header = not csv_path.exists() or csv_path.stat().st_size == 0
+            if write_header and not round_succeeded:
+                _pending_csv_rows.append(dict(round_results))
+            else:
+                with csv_path.open('a', newline='') as f:
+                    writer = csv.writer(f)
+                    if write_header:
+                        csv_header = list(round_results.keys())
+                        writer.writerow(csv_header)
+                        for pending in _pending_csv_rows:
+                            writer.writerow([
+                                '' if (v := pending.get(col)) is None else v
+                                for col in csv_header
+                            ])
+                        _pending_csv_rows = []
+                    writer.writerow([
+                        '' if (v := round_results.get(col)) is None else v
+                        for col in csv_header
+                    ])
+                    extra_keys = set(round_results) - set(csv_header)
+                    if extra_keys:
+                        logger.warning(
+                            'Round %d result keys not in CSV header — values dropped: %s',
+                            i, sorted(extra_keys),
+                        )
+
+        if _pending_csv_rows:
             with csv_path.open('a', newline='') as f:
                 writer = csv.writer(f)
-                if write_header:
-                    csv_header = list(round_results.keys())
+                if csv_header is None:
+                    csv_header = list(_pending_csv_rows[0].keys())
                     writer.writerow(csv_header)
-                writer.writerow([
-                    '' if (v := round_results.get(col)) is None else v
-                    for col in csv_header
-                ])
-                extra_keys = set(round_results) - set(csv_header)
-                if extra_keys:
-                    logger.warning(
-                        'Round %d result keys not in CSV header — values dropped: %s',
-                        i, sorted(extra_keys),
-                    )
+                for pending in _pending_csv_rows:
+                    writer.writerow([
+                        '' if (v := pending.get(col)) is None else v
+                        for col in csv_header
+                    ])
 
         if results_accumulator:
             log_batches.append(pl.DataFrame(results_accumulator))
@@ -460,6 +486,8 @@ class UniversalExperimentLoop:
             with csv_path.open('r', newline='') as f:
                 csv_header = next(csv.reader(f), None)
 
+        _pending_csv_rows: list[dict] = []
+
         for round_params in tqdm(msq, initial=start_round, desc=experiment_name):
             current_round = round_params['_round_index']
             current_hash = round_params['_id']
@@ -569,21 +597,30 @@ class UniversalExperimentLoop:
             results_accumulator.append(round_results)
 
             write_header = not csv_path.exists() or csv_path.stat().st_size == 0
-            with csv_path.open('a', newline='') as f:
-                writer = csv.writer(f)
-                if write_header:
-                    csv_header = list(round_results.keys())
-                    writer.writerow(csv_header)
-                writer.writerow([
-                    '' if (v := round_results.get(col)) is None else v
-                    for col in csv_header
-                ])
-                extra_keys = set(round_results) - set(csv_header)
-                if extra_keys:
-                    logger.warning(
-                        'Round %d result keys not in CSV header — values dropped: %s',
-                        current_round, sorted(extra_keys),
-                    )
+            if write_header and not round_succeeded:
+                _pending_csv_rows.append(dict(round_results))
+            else:
+                with csv_path.open('a', newline='') as f:
+                    writer = csv.writer(f)
+                    if write_header:
+                        csv_header = list(round_results.keys())
+                        writer.writerow(csv_header)
+                        for pending in _pending_csv_rows:
+                            writer.writerow([
+                                '' if (v := pending.get(col)) is None else v
+                                for col in csv_header
+                            ])
+                        _pending_csv_rows = []
+                    writer.writerow([
+                        '' if (v := round_results.get(col)) is None else v
+                        for col in csv_header
+                    ])
+                    extra_keys = set(round_results) - set(csv_header)
+                    if extra_keys:
+                        logger.warning(
+                            'Round %d result keys not in CSV header — values dropped: %s',
+                            current_round, sorted(extra_keys),
+                        )
 
             if round_data_path and round_succeeded:
                 self._append_round_data(
@@ -619,6 +656,18 @@ class UniversalExperimentLoop:
 
             last_msq_state = msq.get_state()
             last_completed_round = current_round
+
+        if _pending_csv_rows:
+            with csv_path.open('a', newline='') as f:
+                writer = csv.writer(f)
+                if csv_header is None:
+                    csv_header = list(_pending_csv_rows[0].keys())
+                    writer.writerow(csv_header)
+                for pending in _pending_csv_rows:
+                    writer.writerow([
+                        '' if (v := pending.get(col)) is None else v
+                        for col in csv_header
+                    ])
 
         if not self._shutdown_requested:
             logger.info(

--- a/limen/experiment/experiment_core.py
+++ b/limen/experiment/experiment_core.py
@@ -520,6 +520,7 @@ class UniversalExperimentLoop:
 
             data_dict: dict[str, Any] = {}
 
+            round_succeeded = False
             try:
                 with warnings.catch_warnings(record=True) as caught:
                     warnings.simplefilter('always')
@@ -527,6 +528,7 @@ class UniversalExperimentLoop:
                     round_results = self.model(
                         data=data_dict, round_params=sfd_params,
                     )
+                round_succeeded = True
             except StrictModeError as exc:
                 logger.error('Round %d failed strict mode check: %s', current_round, exc)
                 round_results = {'strict_mode_error': str(exc)}
@@ -553,8 +555,6 @@ class UniversalExperimentLoop:
                 json.dumps([str(w.message) for w in caught])
                 if caught else '[]'
             )
-
-            round_succeeded = '_alignment' in data_dict
 
             if 'extras' in round_results:
                 extras = round_results.pop('extras')

--- a/limen/experiment/experiment_core.py
+++ b/limen/experiment/experiment_core.py
@@ -490,6 +490,8 @@ class UniversalExperimentLoop:
             if context_params is not None:
                 sfd_params.update(context_params)
 
+            data_dict: dict[str, Any] = {}
+
             try:
                 with warnings.catch_warnings(record=True) as caught:
                     warnings.simplefilter('always')
@@ -539,12 +541,12 @@ class UniversalExperimentLoop:
             current_preds = round_results.pop('_preds', None)
             if current_preds is None:
                 current_preds = []
-            if post_processing:
+            if post_processing and '_alignment' in data_dict:
                 self.preds.append(current_preds)
-            if post_processing and '_scaler' in data_dict:
+            if post_processing and '_alignment' in data_dict and '_scaler' in data_dict:
                 self.scalers.append(data_dict['_scaler'])
 
-            if post_processing:
+            if post_processing and '_alignment' in data_dict:
                 self._alignment.append(data_dict['_alignment'])
 
             round_results['id'] = current_hash
@@ -552,7 +554,7 @@ class UniversalExperimentLoop:
                 time.time() - start_time, 2,
             )
 
-            if post_processing:
+            if post_processing and '_alignment' in data_dict:
                 self.round_params.append(sfd_params)
             for key, value in round_params.items():
                 round_results[key] = value
@@ -579,7 +581,7 @@ class UniversalExperimentLoop:
                         current_round, sorted(extra_keys),
                     )
 
-            if round_data_path:
+            if round_data_path and '_alignment' in data_dict:
                 self._append_round_data(
                     round_data_path, current_hash, sfd_params,
                     current_preds,

--- a/limen/experiment/experiment_core.py
+++ b/limen/experiment/experiment_core.py
@@ -564,6 +564,8 @@ class UniversalExperimentLoop:
                 for key, value in context_params.items():
                     round_results[key] = value
 
+            round_results.setdefault('strict_mode_error', None)
+
             results_accumulator.append(round_results)
 
             write_header = not csv_path.exists() or csv_path.stat().st_size == 0

--- a/limen/experiment/experiment_core.py
+++ b/limen/experiment/experiment_core.py
@@ -16,6 +16,7 @@ import polars as pl
 from tqdm import tqdm
 
 from limen.experiment.checkpoint_manager import CheckpointManager
+from limen.experiment.errors import StrictModeError
 from limen.experiment.feedback_controller import FeedbackController
 from limen.experiment.msq import MSQ
 from limen.experiment.param_domain import ParamDomain
@@ -496,6 +497,9 @@ class UniversalExperimentLoop:
                     round_results = self.model(
                         data=data_dict, round_params=sfd_params,
                     )
+            except StrictModeError as exc:
+                logger.error('Round %d failed strict mode check: %s', current_round, exc)
+                round_results = {'strict_mode_error': str(exc)}
             except KeyboardInterrupt:
                 if self._shutdown_requested:
                     logger.info(

--- a/limen/experiment/manifest_core.py
+++ b/limen/experiment/manifest_core.py
@@ -948,9 +948,7 @@ class MLManifest(Manifest):
             MLManifest: Self for method chaining
         '''
 
-        _extra = dict(extra_params or {})
-        _static = {k: v for k, v in _extra.items() if not isinstance(v, str)}
-        _dynamic = {k: v for k, v in _extra.items() if isinstance(v, str)}
+        _static, _dynamic = _split_extra_params(extra_params)
 
         def _scaler_factory(data: 'pl.DataFrame',
                             scaler_type: str = '',
@@ -1096,16 +1094,16 @@ class MLManifest(Manifest):
 
         cco_indicator_rows: int = 0
         scaler_context_rows: int = 0
+        n_raw_cco: int = 0
         cco_block: pl.DataFrame | None = None
 
         for i, split in enumerate(split_data):
             is_train = i == 0
 
-            if not is_train and cco_block is not None and cco_indicator_rows + scaler_context_rows > 0:
+            if not is_train and cco_block is not None and n_raw_cco > 0:
                 raw_input = pl.concat([cco_block, split])
             else:
                 raw_input = split
-
 
             lazy = raw_input.lazy()
             lazy = _apply_feature_transforms(self, lazy, round_params)
@@ -1144,9 +1142,9 @@ class MLManifest(Manifest):
                     (getattr(v, 'context_rows', 0) for v in all_fitted_params.values()),
                     default=0,
                 )
+                n_raw_cco = cco_indicator_rows + scaler_context_rows
 
-            n_raw_cco = cco_indicator_rows + scaler_context_rows
-            cco_block = split.tail(min(n_raw_cco, len(split))) if n_raw_cco > 0 else None
+            cco_block = split.tail(n_raw_cco) if n_raw_cco > 0 else None
 
         split_data = _align_split_columns(split_data)
         split_data, all_fitted_params = _apply_pca_compression(
@@ -1339,6 +1337,13 @@ def _apply_fitted_transform(data: pl.DataFrame, fitted_transform: Any) -> pl.Dat
     return fitted_transform.transform(data)
 
 
+def _split_extra_params(extra_params: dict[str, Any] | None) -> tuple[dict[str, Any], dict[str, Any]]:
+    _extra = dict(extra_params or {})
+    _static = {k: v for k, v in _extra.items() if not isinstance(v, str)}
+    _dynamic = {k: v for k, v in _extra.items() if isinstance(v, str)}
+    return _static, _dynamic
+
+
 def make_fitted_scaler(param_name: str,
                        transform_class: Any,
                        extra_params: dict[str, Any] | None = None) -> FittedTransformEntry:
@@ -1355,9 +1360,7 @@ def make_fitted_scaler(param_name: str,
         FittedTransformEntry: Complete fitted transform configuration
     '''
 
-    _extra = dict(extra_params or {})
-    _static = {k: v for k, v in _extra.items() if not isinstance(v, str)}
-    _dynamic = {k: v for k, v in _extra.items() if isinstance(v, str)}
+    _static, _dynamic = _split_extra_params(extra_params)
 
     def _factory(data: 'pl.DataFrame',
                  _cls: Any = transform_class,

--- a/limen/experiment/manifest_core.py
+++ b/limen/experiment/manifest_core.py
@@ -949,9 +949,12 @@ class MLManifest(Manifest):
         '''
 
         _extra = dict(extra_params or {})
+        _static = {k: v for k, v in _extra.items() if not isinstance(v, str)}
+        _dynamic = {k: v for k, v in _extra.items() if isinstance(v, str)}
 
         def _scaler_factory(data: 'pl.DataFrame',
-                            scaler_type: str = '') -> Any:
+                            scaler_type: str = '',
+                            **dyn: Any) -> Any:
 
             if scaler_type not in SCALER_REGISTRY:
                 if scaler_type == param_name:
@@ -964,10 +967,10 @@ class MLManifest(Manifest):
                     f"MLManifest Unknown scaler type '{scaler_type}'. "
                     f"Available: {sorted(SCALER_REGISTRY)}"
                 )
-            return SCALER_REGISTRY[scaler_type](data, **_extra)
+            return SCALER_REGISTRY[scaler_type](data, **_static, **dyn)
 
         self.scaler = (
-            [('_scaler', _scaler_factory, {'scaler_type': param_name})],
+            [('_scaler', _scaler_factory, {'scaler_type': param_name, **_dynamic})],
             _apply_fitted_transform,
             {'fitted_transform': '_scaler'},
         )
@@ -1353,12 +1356,20 @@ def make_fitted_scaler(param_name: str,
     '''
 
     _extra = dict(extra_params or {})
-    return ([
-        (param_name, lambda data, _cls=transform_class, _p=_extra: _cls(data, **_p), {})
-    ],
-    _apply_fitted_transform, {
-        'fitted_transform': param_name
-    })
+    _static = {k: v for k, v in _extra.items() if not isinstance(v, str)}
+    _dynamic = {k: v for k, v in _extra.items() if isinstance(v, str)}
+
+    def _factory(data: 'pl.DataFrame',
+                 _cls: Any = transform_class,
+                 _p: dict[str, Any] = _static,
+                 **dyn: Any) -> Any:
+        return _cls(data, **_p, **dyn)
+
+    return (
+        [(param_name, _factory, _dynamic)],
+        _apply_fitted_transform,
+        {'fitted_transform': param_name},
+    )
 
 
 def _resolve_params(params: dict[str, Any], round_params: dict[str, Any]) -> dict[str, Any]:

--- a/limen/experiment/manifest_core.py
+++ b/limen/experiment/manifest_core.py
@@ -25,6 +25,7 @@ from limen.data.utils import split_by_dates
 from limen.data.utils import split_data_to_prep_output
 from limen.data.utils import split_data_to_rule_based_prep_output
 from limen.data.utils import split_sequential
+from limen.experiment.errors import StrictModeError
 from limen.scalers.robust_scaler import RobustScaler
 from limen.scalers.registry import SCALER_REGISTRY
 logger = logging.getLogger(__name__)
@@ -890,8 +891,12 @@ class MLManifest(Manifest):
     data_dict_extension: Callable = None
     prediction_calibration_config: CalibrationConfig | None = None
     decoder_lookback: int = 1
+    strict_mode: bool = False
 
-    def set_scaler(self, transform_class: Any, param_name: str = '_scaler') -> 'MLManifest':
+    def set_scaler(self,
+                   transform_class: Any,
+                   param_name: str = '_scaler',
+                   extra_params: dict[str, Any] | None = None) -> 'MLManifest':
 
         '''
         Set scaler transformation using make_fitted_scaler.
@@ -904,13 +909,30 @@ class MLManifest(Manifest):
             MLManifest: Self for method chaining
         '''
 
-        self.scaler = make_fitted_scaler(param_name, transform_class)
+        self.scaler = make_fitted_scaler(param_name, transform_class, dict(extra_params or {}))
 
         return self
 
 
+    def set_strict_mode(self, strict_mode: bool) -> 'MLManifest':
+
+        '''
+        Enable or disable strict mode for null detection after CCO dislodgement.
+
+        Args:
+            strict_mode (bool): If True, unexpected nulls in feature columns raise StrictModeError
+
+        Returns:
+            MLManifest: Self for method chaining
+        '''
+
+        self.strict_mode = strict_mode
+        return self
+
+
     def set_scaler_from_params(self,
-                               param_name: str = 'scaler_type') -> 'MLManifest':
+                               param_name: str = 'scaler_type',
+                               extra_params: dict[str, Any] | None = None) -> 'MLManifest':
 
         '''
         Configure scaler selection from round_params at runtime.
@@ -924,6 +946,8 @@ class MLManifest(Manifest):
         Returns:
             MLManifest: Self for method chaining
         '''
+
+        _extra = dict(extra_params or {})
 
         def _scaler_factory(data: 'pl.DataFrame',
                             scaler_type: str = '') -> Any:
@@ -939,7 +963,7 @@ class MLManifest(Manifest):
                     f"MLManifest Unknown scaler type '{scaler_type}'. "
                     f"Available: {sorted(SCALER_REGISTRY)}"
                 )
-            return SCALER_REGISTRY[scaler_type](data)
+            return SCALER_REGISTRY[scaler_type](data, **_extra)
 
         self.scaler = (
             [('_scaler', _scaler_factory, {'scaler_type': param_name})],
@@ -1066,14 +1090,26 @@ class MLManifest(Manifest):
         columns_to_drop: list[str] | None = None
         pre_transform_columns = frozenset(split_data[0].columns)
 
+        cco_indicator_rows: int = 0
+        scaler_context_rows: int = 0
+        cco_block: pl.DataFrame | None = None
+
         for i, split in enumerate(split_data):
-            lazy = split.lazy()
+            is_train = i == 0
+            n_raw_cco = cco_indicator_rows + scaler_context_rows
+
+            if not is_train and cco_block is not None and n_raw_cco > 0:
+                raw_input = pl.concat([cco_block, split])
+            else:
+                raw_input = split
+
+            lazy = raw_input.lazy()
             lazy = _apply_feature_transforms(self, lazy, round_params)
             data = lazy.collect()
 
             if self.target_class_config is not None:
                 data, all_fitted_params = _apply_class_based_target(
-                    self, data, round_params, all_fitted_params, i == 0
+                    self, data, round_params, all_fitted_params, is_train
                 )
 
             if self.ablation_config is not None:
@@ -1081,9 +1117,32 @@ class MLManifest(Manifest):
                     data, self, round_params, columns_to_drop, pre_transform_columns,
                 )
 
-            data = data.fill_nan(None).drop_nulls()
-            data, all_fitted_params = _apply_scaler(self, data, round_params, all_fitted_params, i == 0)
+            data = data.fill_nan(None)
+            n_leading = _count_leading_nulls(data)
+            data = data.slice(n_leading)
+
+            n_cco_feature_rows = max(0, len(cco_block) - n_leading) if (not is_train and cco_block is not None) else 0
+
+            _check_unexpected_nulls(self, data, i, 'A')
+
+            data, all_fitted_params = _apply_scaler(self, data, round_params, all_fitted_params, is_train)
+
+            if n_cco_feature_rows > 0:
+                data = data.slice(n_cco_feature_rows)
+
+            _check_unexpected_nulls(self, data, i, 'B')
+
             split_data[i] = data.fill_nan(None).drop_nulls()
+
+            if is_train:
+                cco_indicator_rows = n_leading
+                scaler_context_rows = max(
+                    (getattr(v, 'context_rows', 0) for v in all_fitted_params.values()),
+                    default=0,
+                )
+
+            n_raw_cco = cco_indicator_rows + scaler_context_rows
+            cco_block = split.tail(min(n_raw_cco, len(split))) if n_raw_cco > 0 else None
 
         split_data = _align_split_columns(split_data)
         split_data, all_fitted_params = _apply_pca_compression(
@@ -1276,7 +1335,9 @@ def _apply_fitted_transform(data: pl.DataFrame, fitted_transform: Any) -> pl.Dat
     return fitted_transform.transform(data)
 
 
-def make_fitted_scaler(param_name: str, transform_class: Any) -> FittedTransformEntry:
+def make_fitted_scaler(param_name: str,
+                       transform_class: Any,
+                       extra_params: dict[str, Any] | None = None) -> FittedTransformEntry:
 
     '''
     Create fitted transform entry for scaling.
@@ -1284,13 +1345,15 @@ def make_fitted_scaler(param_name: str, transform_class: Any) -> FittedTransform
     Args:
         param_name (str): Name for the fitted parameter
         transform_class: Transform class to instantiate
+        extra_params (dict | None): Additional keyword arguments passed to the transform constructor
 
     Returns:
         FittedTransformEntry: Complete fitted transform configuration
     '''
 
+    _extra = dict(extra_params or {})
     return ([
-        (param_name, lambda data: transform_class(data), {})
+        (param_name, lambda data, _cls=transform_class, _p=_extra: _cls(data, **_p), {})
     ],
     _apply_fitted_transform, {
         'fitted_transform': param_name
@@ -1412,6 +1475,33 @@ def _is_group_active(group: str, round_params: dict[str, Any]) -> bool:
         )
 
     return group in feature_groups.split('|')
+
+
+_SPLIT_NAMES = ['train', 'val', 'test']
+
+
+def _check_unexpected_nulls(manifest: 'MLManifest',
+                             data: pl.DataFrame,
+                             split_index: int,
+                             checkpoint: str) -> None:
+
+    exclude = {'datetime', manifest.target_column}
+    feature_cols = [c for c in data.columns if c not in exclude]
+    null_info = {
+        col: data.filter(pl.col(col).is_null())['datetime'].to_list()
+        for col in feature_cols
+        if data[col].is_null().any()
+    }
+    if not null_info:
+        return
+
+    split_name = _SPLIT_NAMES[split_index] if split_index < len(_SPLIT_NAMES) else str(split_index)
+    detail = '; '.join(f"{col} @ {ts}" for col, ts in null_info.items())
+    msg = f"Unexpected nulls in {split_name} split · Checkpoint {checkpoint} · {detail}"
+
+    if manifest.strict_mode:
+        raise StrictModeError(msg)
+    logger.warning(msg)
 
 
 def _count_leading_nulls(data: pl.DataFrame) -> int:

--- a/limen/experiment/manifest_core.py
+++ b/limen/experiment/manifest_core.py
@@ -1097,12 +1097,12 @@ class MLManifest(Manifest):
 
         for i, split in enumerate(split_data):
             is_train = i == 0
-            n_raw_cco = cco_indicator_rows + scaler_context_rows
 
-            if not is_train and cco_block is not None and n_raw_cco > 0:
+            if not is_train and cco_block is not None and cco_indicator_rows + scaler_context_rows > 0:
                 raw_input = pl.concat([cco_block, split])
             else:
                 raw_input = split
+
 
             lazy = raw_input.lazy()
             lazy = _apply_feature_transforms(self, lazy, round_params)
@@ -1141,8 +1141,8 @@ class MLManifest(Manifest):
                     (getattr(v, 'context_rows', 0) for v in all_fitted_params.values()),
                     default=0,
                 )
-                n_raw_cco = cco_indicator_rows + scaler_context_rows
 
+            n_raw_cco = cco_indicator_rows + scaler_context_rows
             cco_block = split.tail(min(n_raw_cco, len(split))) if n_raw_cco > 0 else None
 
         split_data = _align_split_columns(split_data)
@@ -1488,11 +1488,11 @@ def _check_unexpected_nulls(manifest: 'MLManifest',
 
     exclude = {'datetime', manifest.target_column}
     feature_cols = [c for c in data.columns if c not in exclude]
+    counts = data.select([pl.col(c).null_count().alias(c) for c in feature_cols])
     null_info = {}
     for col in feature_cols:
-        null_rows = data.filter(pl.col(col).is_null())
-        if null_rows.height > 0:
-            null_info[col] = null_rows['datetime'].to_list()
+        if counts[col][0] > 0:
+            null_info[col] = data.filter(pl.col(col).is_null())['datetime'].to_list()
     if not null_info:
         return
 

--- a/limen/experiment/manifest_core.py
+++ b/limen/experiment/manifest_core.py
@@ -1101,6 +1101,17 @@ class MLManifest(Manifest):
             is_train = i == 0
 
             if not is_train and cco_block is not None and n_raw_cco > 0:
+                if scaler_context_rows > 0 and len(cco_block) < n_raw_cco:
+                    split_name = _SPLIT_NAMES[i] if i < len(_SPLIT_NAMES) else str(i)
+                    shortfall = n_raw_cco - len(cco_block)
+                    msg = (
+                        f'under-warmed CCO: {split_name} split requires {n_raw_cco} '
+                        f'context rows but only {len(cco_block)} available '
+                        f'(shortfall {shortfall})'
+                    )
+                    if self.strict_mode:
+                        raise StrictModeError(msg)
+                    logger.warning(msg)
                 raw_input = pl.concat([cco_block, split])
             else:
                 raw_input = split

--- a/limen/experiment/manifest_core.py
+++ b/limen/experiment/manifest_core.py
@@ -904,12 +904,13 @@ class MLManifest(Manifest):
         Args:
             transform_class: Transform class to use for scaling
             param_name (str): Parameter name for fitted scaler
+            extra_params (dict | None): Additional keyword arguments passed to the transform constructor
 
         Returns:
             MLManifest: Self for method chaining
         '''
 
-        self.scaler = make_fitted_scaler(param_name, transform_class, dict(extra_params or {}))
+        self.scaler = make_fitted_scaler(param_name, transform_class, extra_params)
 
         return self
 
@@ -1140,8 +1141,8 @@ class MLManifest(Manifest):
                     (getattr(v, 'context_rows', 0) for v in all_fitted_params.values()),
                     default=0,
                 )
+                n_raw_cco = cco_indicator_rows + scaler_context_rows
 
-            n_raw_cco = cco_indicator_rows + scaler_context_rows
             cco_block = split.tail(min(n_raw_cco, len(split))) if n_raw_cco > 0 else None
 
         split_data = _align_split_columns(split_data)
@@ -1487,11 +1488,11 @@ def _check_unexpected_nulls(manifest: 'MLManifest',
 
     exclude = {'datetime', manifest.target_column}
     feature_cols = [c for c in data.columns if c not in exclude]
-    null_info = {
-        col: data.filter(pl.col(col).is_null())['datetime'].to_list()
-        for col in feature_cols
-        if data[col].is_null().any()
-    }
+    null_info = {}
+    for col in feature_cols:
+        null_rows = data.filter(pl.col(col).is_null())
+        if null_rows.height > 0:
+            null_info[col] = null_rows['datetime'].to_list()
     if not null_info:
         return
 

--- a/limen/scalers/causal_rolling_robust_scaler.py
+++ b/limen/scalers/causal_rolling_robust_scaler.py
@@ -70,6 +70,12 @@ class CausalRollingRobustScaler:
             self.iqrs[col] = iqr if iqr != 0 else 1.0
 
 
+    @property
+    def context_rows(self) -> int:
+
+        return self.window
+
+
     def transform(self, df: pl.DataFrame) -> pl.DataFrame:
 
         '''

--- a/limen/scalers/causal_rolling_robust_scaler.py
+++ b/limen/scalers/causal_rolling_robust_scaler.py
@@ -73,6 +73,8 @@ class CausalRollingRobustScaler:
     @property
     def context_rows(self) -> int:
 
+        '''Number of raw preceding rows needed to produce a fully warm scaled output.'''
+
         return self.window
 
 

--- a/limen/sfd/foundational_sfd/lightgbm_binary.py
+++ b/limen/sfd/foundational_sfd/lightgbm_binary.py
@@ -123,6 +123,7 @@ def manifest() -> Manifest:
 
         .set_scaler_from_params('scaler_type')
         .set_feature_ablation()
+        .set_strict_mode(True)
 
         .with_reference_architecture(lightgbm_binary)
 

--- a/limen/sfd/foundational_sfd/logreg_binary.py
+++ b/limen/sfd/foundational_sfd/logreg_binary.py
@@ -85,6 +85,7 @@ def manifest() -> Manifest:
 
         .set_scaler_from_params('scaler_type')
         .set_feature_ablation()
+        .set_strict_mode(True)
 
         .with_reference_architecture(logreg_binary)
 

--- a/limen/sfd/foundational_sfd/random_binary.py
+++ b/limen/sfd/foundational_sfd/random_binary.py
@@ -30,5 +30,6 @@ def manifest() -> Manifest:
             'no_of_trades'
         ])
         .with_target_label('outcome', RandomBinaryTarget)
+        .set_strict_mode(True)
         .with_reference_architecture(random_binary)
     )

--- a/limen/sfd/foundational_sfd/tabpfn_binary.py
+++ b/limen/sfd/foundational_sfd/tabpfn_binary.py
@@ -71,6 +71,7 @@ def manifest() -> Manifest:
             transform_params={'forward_periods': 'forward_periods', 'threshold': 'threshold_pct', 'shift': -1},
         )
 
+        .set_strict_mode(True)
         .with_reference_architecture(tabpfn_binary)
 
         .with_calibration()

--- a/limen/sfd/foundational_sfd/xgboost_regressor.py
+++ b/limen/sfd/foundational_sfd/xgboost_regressor.py
@@ -77,5 +77,6 @@ def manifest() -> Manifest:
             'stoch_k',
         ], lag=1)
         .with_target_label('next_return', NextReturnTarget)
+        .set_strict_mode(True)
         .with_reference_architecture(xgboost_regressor)
     )

--- a/limen/yaml/compiler.py
+++ b/limen/yaml/compiler.py
@@ -86,6 +86,7 @@ def _build_ml_manifest(m: dict[str, Any]) -> MLManifest:
     _apply_pca_compression(manifest, m)
     _apply_calibration(manifest, m)
     _apply_ml_extras(manifest, m)
+    _apply_strict_mode(manifest, m)
     manifest.with_reference_architecture(resolve(m['reference_architecture']))
     return manifest
 
@@ -197,10 +198,17 @@ def _apply_scaler(manifest: MLManifest, m: dict[str, Any]) -> None:
     scaler = m.get('scaler')
     if scaler is None:
         return
+    extra_params = dict(scaler.get('params') or {})
     if 'from_params' in scaler:
-        manifest.set_scaler_from_params(param_name=scaler['from_params'])
+        manifest.set_scaler_from_params(param_name=scaler['from_params'], extra_params=extra_params)
     else:
-        manifest.set_scaler(resolve(scaler['class']))
+        manifest.set_scaler(resolve(scaler['class']), extra_params=extra_params)
+
+
+def _apply_strict_mode(manifest: MLManifest, m: dict[str, Any]) -> None:
+
+    if m.get('strict_mode'):
+        manifest.set_strict_mode(True)
 
 
 def _apply_target(manifest: MLManifest, m: dict[str, Any]) -> None:

--- a/limen/yaml/profiler.py
+++ b/limen/yaml/profiler.py
@@ -165,8 +165,9 @@ def profile(compiled_sfd: 'CompiledSFD') -> ProfileResult:
     result.sample_permutations_attempted = len(permutations)
 
     elapsed_times: list[float] = []
-    saved_strict_mode = getattr(manifest, 'strict_mode', False)
-    if hasattr(manifest, 'strict_mode'):
+    has_strict_mode = hasattr(manifest, 'strict_mode')
+    if has_strict_mode:
+        saved_strict_mode = manifest.strict_mode
         manifest.strict_mode = False
 
     log_capture = _LogCapture()
@@ -186,7 +187,7 @@ def profile(compiled_sfd: 'CompiledSFD') -> ProfileResult:
                     result.errors.append(_classify_error(exc))
     finally:
         manifest_logger.removeHandler(log_capture)
-        if hasattr(manifest, 'strict_mode'):
+        if has_strict_mode:
             manifest.strict_mode = saved_strict_mode
 
     seen: set[str] = set()

--- a/limen/yaml/profiler.py
+++ b/limen/yaml/profiler.py
@@ -1,3 +1,4 @@
+import logging
 import math
 import random
 import re
@@ -36,6 +37,22 @@ class ProfileResult:
     sample_time_seconds_per_permutation: float | None = None
     warnings: list[str] = field(default_factory=list)
     errors: list[str] = field(default_factory=list)
+    data_quality_warnings: list[str] = field(default_factory=list)
+
+
+_MANIFEST_CORE_LOGGER = 'limen.experiment.manifest_core'
+
+
+class _LogCapture(logging.Handler):
+
+    def __init__(self) -> None:
+
+        super().__init__(level=logging.WARNING)
+        self.records: list[str] = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+
+        self.records.append(record.getMessage())
 
 
 def _complexity_rating(total: int) -> str:
@@ -148,17 +165,35 @@ def profile(compiled_sfd: 'CompiledSFD') -> ProfileResult:
     result.sample_permutations_attempted = len(permutations)
 
     elapsed_times: list[float] = []
+    saved_strict_mode = getattr(manifest, 'strict_mode', False)
+    if hasattr(manifest, 'strict_mode'):
+        manifest.strict_mode = False
 
-    with warnings.catch_warnings():
-        warnings.simplefilter('ignore')
-        for round_params in permutations:
-            try:
-                t0 = time.perf_counter()
-                data_dict = manifest.prepare_data(raw_data, round_params)
-                manifest.run_model(data_dict, round_params)
-                elapsed_times.append(time.perf_counter() - t0)
-            except (ValueError, RuntimeError, MemoryError, TypeError, ArithmeticError) as exc:
-                result.errors.append(_classify_error(exc))
+    log_capture = _LogCapture()
+    manifest_logger = logging.getLogger(_MANIFEST_CORE_LOGGER)
+    manifest_logger.addHandler(log_capture)
+
+    try:
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore')
+            for round_params in permutations:
+                try:
+                    t0 = time.perf_counter()
+                    data_dict = manifest.prepare_data(raw_data, round_params)
+                    manifest.run_model(data_dict, round_params)
+                    elapsed_times.append(time.perf_counter() - t0)
+                except (ValueError, RuntimeError, MemoryError, TypeError, ArithmeticError) as exc:
+                    result.errors.append(_classify_error(exc))
+    finally:
+        manifest_logger.removeHandler(log_capture)
+        if hasattr(manifest, 'strict_mode'):
+            manifest.strict_mode = saved_strict_mode
+
+    seen: set[str] = set()
+    for msg in log_capture.records:
+        if 'Unexpected nulls' in msg and msg not in seen:
+            seen.add(msg)
+            result.data_quality_warnings.append(msg)
 
     result.sample_permutations_completed = len(elapsed_times)
 

--- a/limen/yaml/schema.py
+++ b/limen/yaml/schema.py
@@ -28,6 +28,7 @@ ML_MANIFEST_OPTIONAL = {
     'params_override',
     'metrics_params',
     'decoder_lookback',
+    'strict_mode',
 }
 
 RULE_BASED_MANIFEST_REQUIRED = {'strategy'}

--- a/limen/yaml/templates/lightgbm_binary.yaml
+++ b/limen/yaml/templates/lightgbm_binary.yaml
@@ -89,6 +89,8 @@ sfd:
       drop_count_key: feature_drop_count
       seed_key: feature_drop_seed
 
+    strict_mode: true
+
     reference_architecture: limen.sfd.reference_architecture.lightgbm_binary
 
     calibration:

--- a/limen/yaml/templates/logreg_binary.yaml
+++ b/limen/yaml/templates/logreg_binary.yaml
@@ -68,6 +68,8 @@ sfd:
       drop_count_key: feature_drop_count
       seed_key: feature_drop_seed
 
+    strict_mode: true
+
     reference_architecture: limen.sfd.reference_architecture.logreg_binary
 
     calibration:

--- a/limen/yaml/templates/tabpfn_binary.yaml
+++ b/limen/yaml/templates/tabpfn_binary.yaml
@@ -77,6 +77,8 @@ sfd:
       drop_count_key: feature_drop_count
       seed_key: feature_drop_seed
 
+    strict_mode: true
+
     reference_architecture: limen.sfd.reference_architecture.tabpfn_binary
 
     calibration:

--- a/limen/yaml/templates/xgboost_regressor.yaml
+++ b/limen/yaml/templates/xgboost_regressor.yaml
@@ -81,6 +81,8 @@ sfd:
       drop_count_key: feature_drop_count
       seed_key: feature_drop_seed
 
+    strict_mode: true
+
     reference_architecture: limen.sfd.reference_architecture.xgboost_regressor
 
   params:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaquum_limen"
-version = "3.30.2"
+version = "3.31.0"
 description = "Limen unifies parameter search across machine learning and rule-based strategies, with built-in analytics that show not just what works, but why it works."
 readme = "README.md"
 authors = [

--- a/tests/run.py
+++ b/tests/run.py
@@ -553,6 +553,10 @@ from tests.test_manifest_cco import test_cco_val_matches_continuous
 from tests.test_manifest_cco import test_cco_row_count_recovery
 from tests.test_manifest_cco import test_no_cco_for_stateless_scaler
 from tests.test_manifest_cco import test_strict_mode_raises_on_gap
+from tests.test_manifest_cco import test_non_strict_mode_warns_on_gap
+from tests.test_manifest_cco import test_cco_under_warm_strict_mode_raises
+from tests.test_manifest_cco import test_cco_under_warm_non_strict_warns
+from tests.test_manifest_cco import test_uel_first_round_strict_mode_error_does_not_corrupt_csv_header
 from tests.test_manifest_cco import test_scaler_params_yaml_window
 from tests.test_manifest_cco import test_scaler_params_default_when_omitted
 from tests.test_manifest_cco import test_scaler_params_class_form_with_dynamic_window
@@ -1855,6 +1859,10 @@ tests = [
     test_cco_row_count_recovery,
     test_no_cco_for_stateless_scaler,
     test_strict_mode_raises_on_gap,
+    test_non_strict_mode_warns_on_gap,
+    test_cco_under_warm_strict_mode_raises,
+    test_cco_under_warm_non_strict_warns,
+    test_uel_first_round_strict_mode_error_does_not_corrupt_csv_header,
     test_scaler_params_yaml_window,
     test_scaler_params_default_when_omitted,
     test_scaler_params_class_form_with_dynamic_window,

--- a/tests/run.py
+++ b/tests/run.py
@@ -555,6 +555,9 @@ from tests.test_manifest_cco import test_no_cco_for_stateless_scaler
 from tests.test_manifest_cco import test_strict_mode_raises_on_gap
 from tests.test_manifest_cco import test_scaler_params_yaml_window
 from tests.test_manifest_cco import test_scaler_params_default_when_omitted
+from tests.test_manifest_cco import test_scaler_params_class_form_with_dynamic_window
+from tests.test_manifest_cco import test_scaler_params_from_params_with_dynamic_window
+from tests.test_manifest_cco import test_scaler_params_mixed_static_and_dynamic
 from tests.test_manifest_cco import test_uel_continues_after_strict_mode_error
 from tests.test_inline_metrics import test_inline_and_post_experiment_metrics
 from tests.test_inline_metrics import test_logreg_inline_and_post_confusion_metrics_match
@@ -1854,6 +1857,9 @@ tests = [
     test_strict_mode_raises_on_gap,
     test_scaler_params_yaml_window,
     test_scaler_params_default_when_omitted,
+    test_scaler_params_class_form_with_dynamic_window,
+    test_scaler_params_from_params_with_dynamic_window,
+    test_scaler_params_mixed_static_and_dynamic,
     test_uel_continues_after_strict_mode_error,
     test_fractional_diff_manifest_integration,
     test_trainer_requires_yaml_reference,

--- a/tests/run.py
+++ b/tests/run.py
@@ -555,6 +555,7 @@ from tests.test_manifest_cco import test_no_cco_for_stateless_scaler
 from tests.test_manifest_cco import test_strict_mode_raises_on_gap
 from tests.test_manifest_cco import test_scaler_params_yaml_window
 from tests.test_manifest_cco import test_scaler_params_default_when_omitted
+from tests.test_manifest_cco import test_uel_continues_after_strict_mode_error
 from tests.test_inline_metrics import test_inline_and_post_experiment_metrics
 from tests.test_inline_metrics import test_logreg_inline_and_post_confusion_metrics_match
 from tests.test_inline_metrics import test_xgboost_inline_and_post_backtest_metrics_match
@@ -1853,6 +1854,7 @@ tests = [
     test_strict_mode_raises_on_gap,
     test_scaler_params_yaml_window,
     test_scaler_params_default_when_omitted,
+    test_uel_continues_after_strict_mode_error,
     test_fractional_diff_manifest_integration,
     test_trainer_requires_yaml_reference,
     test_trainer_rejects_non_dict_yaml_reference,

--- a/tests/run.py
+++ b/tests/run.py
@@ -882,6 +882,7 @@ from tests.test_trainer import test_trainer_yaml_deterministic_validation
 from tests.test_trainer import test_trainer_yaml_sensor_inference
 from tests.test_trainer import test_trainer_yaml_feature_ablation
 from tests.test_trainer import test_sensor_reproduces_training_metrics_on_val_test
+from tests.test_trainer import test_sensor_reproduces_training_metrics_with_rolling_scaler
 from tests.test_sensor import test_count_leading_nulls_no_nulls
 from tests.test_sensor import test_count_leading_nulls_leading_nulls
 from tests.test_sensor import test_count_leading_nulls_all_null
@@ -1868,6 +1869,7 @@ tests = [
     test_trainer_yaml_sensor_inference,
     test_trainer_yaml_feature_ablation,
     test_sensor_reproduces_training_metrics_on_val_test,
+    test_sensor_reproduces_training_metrics_with_rolling_scaler,
     test_count_leading_nulls_no_nulls,
     test_count_leading_nulls_leading_nulls,
     test_count_leading_nulls_all_null,

--- a/tests/run.py
+++ b/tests/run.py
@@ -546,6 +546,15 @@ from tests.test_manifest_prepare_data import test_pca_compression_requires_confi
 from tests.test_manifest_prepare_data import test_pca_compression_reports_scaler_param_mismatch
 from tests.test_manifest_prepare_data import test_pca_compression_rejects_invalid_k
 from tests.test_manifest_prepare_data import test_pca_compression_rejects_nonnumeric_features
+from tests.test_manifest_cco import test_context_rows_property
+from tests.test_manifest_cco import test_context_rows_default_window
+from tests.test_manifest_cco import test_cco_no_contamination
+from tests.test_manifest_cco import test_cco_val_matches_continuous
+from tests.test_manifest_cco import test_cco_row_count_recovery
+from tests.test_manifest_cco import test_no_cco_for_stateless_scaler
+from tests.test_manifest_cco import test_strict_mode_raises_on_gap
+from tests.test_manifest_cco import test_scaler_params_yaml_window
+from tests.test_manifest_cco import test_scaler_params_default_when_omitted
 from tests.test_inline_metrics import test_inline_and_post_experiment_metrics
 from tests.test_inline_metrics import test_logreg_inline_and_post_confusion_metrics_match
 from tests.test_inline_metrics import test_xgboost_inline_and_post_backtest_metrics_match
@@ -872,6 +881,7 @@ from tests.test_trainer import test_trainer_yaml_reconstruction_error_tampered_l
 from tests.test_trainer import test_trainer_yaml_deterministic_validation
 from tests.test_trainer import test_trainer_yaml_sensor_inference
 from tests.test_trainer import test_trainer_yaml_feature_ablation
+from tests.test_trainer import test_sensor_reproduces_training_metrics_on_val_test
 from tests.test_sensor import test_count_leading_nulls_no_nulls
 from tests.test_sensor import test_count_leading_nulls_leading_nulls
 from tests.test_sensor import test_count_leading_nulls_all_null
@@ -1833,6 +1843,15 @@ tests = [
     test_pca_compression_reports_scaler_param_mismatch,
     test_pca_compression_rejects_invalid_k,
     test_pca_compression_rejects_nonnumeric_features,
+    test_context_rows_property,
+    test_context_rows_default_window,
+    test_cco_no_contamination,
+    test_cco_val_matches_continuous,
+    test_cco_row_count_recovery,
+    test_no_cco_for_stateless_scaler,
+    test_strict_mode_raises_on_gap,
+    test_scaler_params_yaml_window,
+    test_scaler_params_default_when_omitted,
     test_fractional_diff_manifest_integration,
     test_trainer_requires_yaml_reference,
     test_trainer_rejects_non_dict_yaml_reference,
@@ -1848,6 +1867,7 @@ tests = [
     test_trainer_yaml_deterministic_validation,
     test_trainer_yaml_sensor_inference,
     test_trainer_yaml_feature_ablation,
+    test_sensor_reproduces_training_metrics_on_val_test,
     test_count_leading_nulls_no_nulls,
     test_count_leading_nulls_leading_nulls,
     test_count_leading_nulls_all_null,

--- a/tests/test_foundational_sfd.py
+++ b/tests/test_foundational_sfd.py
@@ -67,6 +67,8 @@ def test_foundational_sfd():
                     assert 'is_stable' in log.columns, 'is_stable missing from log'
                     assert uel.experiment_confusion_metrics is None, 'experiment_confusion_metrics should be None for rule-based'
                     assert uel.experiment_backtest_results is None, 'experiment_backtest_results should be None for rule-based'
+                else:
+                    assert sfd_module.manifest().strict_mode is True, f'{sfd_module.__name__} manifest must have strict_mode=True'
 
             logger.info('    ✅ %s: PASSED', sfd_module.__name__)
 

--- a/tests/test_manifest_cco.py
+++ b/tests/test_manifest_cco.py
@@ -1,0 +1,264 @@
+import logging
+import math
+from datetime import date
+from datetime import datetime
+from datetime import timedelta
+
+import polars as pl
+import pytest
+
+from limen.experiment import MLManifest
+from limen.experiment.errors import StrictModeError
+from limen.indicators import roc
+from limen.scalers.causal_rolling_robust_scaler import CausalRollingRobustScaler
+from limen.scalers.robust_scaler import RobustScaler
+from limen.targets import QuantileBinaryTarget
+from limen.yaml.compiler import build_manifest
+from limen.yaml.parser import parse
+
+
+_WINDOW = 20
+_MIN_SAMPLES = 5
+_ROC_PERIOD = 1
+
+# 300 hourly bars: 2025-01-01 00:00 to 2025-01-13 11:00
+# train: [2025-01-01, 2025-01-09) = 192 bars
+# val:   [2025-01-09, 2025-01-11) = 48 bars
+# test:  [2025-01-11, 2025-01-13) = 48 bars
+_N = 300
+_TRAIN_START = date(2025, 1, 1)
+_TRAIN_END = date(2025, 1, 9)
+_VAL_START = date(2025, 1, 9)
+_VAL_END = date(2025, 1, 11)
+_TEST_START = date(2025, 1, 11)
+_TEST_END = date(2025, 1, 13)
+_VAL_HOURS = 48
+_TEST_HOURS = 48
+
+
+def _make_raw_data(n: int = _N) -> pl.DataFrame:
+    timestamps = [datetime(2025, 1, 1) + timedelta(hours=i) for i in range(n)]
+    close = [100.0 + 0.05 * i + math.sin(i / 8.0) for i in range(n)]
+    return pl.DataFrame({
+        'datetime': timestamps,
+        'open': [v - 0.1 for v in close],
+        'high': [v + 0.2 for v in close],
+        'low': [v - 0.2 for v in close],
+        'close': close,
+        'volume': [1000.0 + i for i in range(n)],
+    })
+
+
+def _make_manifest(use_rolling_scaler: bool = True, strict_mode: bool = False) -> MLManifest:
+    m = (
+        MLManifest()
+        .set_split_dates(_TRAIN_START, _TRAIN_END, _VAL_START, _VAL_END, _TEST_START, _TEST_END)
+        .add_indicator(roc, period=_ROC_PERIOD, group='momentum')
+        .with_target_label(
+            'quantile_flag',
+            QuantileBinaryTarget,
+            fit_params={'source_column': 'roc_1', 'quantile': 0.5},
+            transform_params={'shift': -1},
+        )
+    )
+    if use_rolling_scaler:
+        m.set_scaler(CausalRollingRobustScaler, extra_params={'window': _WINDOW, 'min_samples': _MIN_SAMPLES})
+    else:
+        m.set_scaler(RobustScaler)
+    if strict_mode:
+        m.set_strict_mode(True)
+    return m
+
+
+def _prepare(manifest: MLManifest, raw: pl.DataFrame) -> dict:
+    return manifest.prepare_data(raw, round_params={})
+
+
+def test_context_rows_property() -> None:
+    train = pl.DataFrame({'x': [float(i) for i in range(50)]})
+    scaler = CausalRollingRobustScaler(train, window=500, min_samples=10)
+    assert scaler.context_rows == 500
+
+
+def test_context_rows_default_window() -> None:
+    train = pl.DataFrame({'x': [float(i) for i in range(100)]})
+    scaler = CausalRollingRobustScaler(train)
+    assert scaler.context_rows == 1000
+
+
+def test_cco_no_contamination() -> None:
+    raw = _make_raw_data()
+    data_dict = _prepare(_make_manifest(), raw)
+
+    # datetime is stripped from x_val/x_test; verify via alignment and row-count bounds
+    assert len(data_dict['x_val']) <= _VAL_HOURS, 'val has more rows than val window — contamination'
+    assert len(data_dict['x_test']) <= _TEST_HOURS, 'test has more rows than test window — contamination'
+
+    alignment = data_dict['_alignment']
+    first_test_dt = alignment['first_test_datetime']
+    last_test_dt = alignment['last_test_datetime']
+    first_test_date = first_test_dt.date() if hasattr(first_test_dt, 'date') else first_test_dt
+    last_test_date = last_test_dt.date() if hasattr(last_test_dt, 'date') else last_test_dt
+    assert first_test_date >= _TEST_START, f'first test row {first_test_date} is before test_start'
+    assert last_test_date < _TEST_END, f'last test row {last_test_date} is on or after test_end'
+
+
+def test_cco_val_matches_continuous() -> None:
+    raw = _make_raw_data()
+    manifest = _make_manifest()
+    data_dict = _prepare(manifest, raw)
+
+    # sensor_input_prep applies indicators + scaler continuously on the full raw series
+    fitted_params = data_dict['_fitted_params']
+    sensor_data, _ = manifest.sensor_input_prep(raw, fitted_params, {})
+
+    # filter sensor output to val timestamps; this is the ground-truth continuous output
+    val_dt_start = datetime(_VAL_START.year, _VAL_START.month, _VAL_START.day)
+    val_dt_end = datetime(_VAL_END.year, _VAL_END.month, _VAL_END.day)
+    val_continuous = (
+        sensor_data
+        .filter((pl.col('datetime') >= val_dt_start) & (pl.col('datetime') < val_dt_end))
+        .drop('datetime')
+    )
+
+    feature_cols = data_dict['x_val'].columns
+    val_cco = data_dict['x_val']  # 47 rows (last target row dropped)
+
+    # compare first 47 rows (sensor includes all 48 val rows; x_val drops last due to target shift)
+    assert len(val_cco) == len(val_continuous) - 1
+    for col in feature_cols:
+        cco_vals = val_cco[col].to_list()
+        cont_vals = val_continuous[col].to_list()[:len(val_cco)]
+        for i, (a, b) in enumerate(zip(cco_vals, cont_vals)):
+            assert abs(a - b) < 1e-9, f"val col={col} row={i}: CCO={a} continuous={b}"
+
+
+def test_cco_row_count_recovery() -> None:
+    raw = _make_raw_data()
+
+    # with rolling scaler: CCO recovers indicator warm-up rows (1 for roc period=1)
+    data_dict_cco = _prepare(_make_manifest(use_rolling_scaler=True), raw)
+
+    # with stateless scaler: no CCO context rows beyond indicator warm-up
+    data_dict_stateless = _prepare(_make_manifest(use_rolling_scaler=False), raw)
+
+    # CCO should recover at least as many rows as stateless (warm-up rows are not dropped)
+    assert len(data_dict_cco['x_val']) >= len(data_dict_stateless['x_val'])
+    assert len(data_dict_cco['x_test']) >= len(data_dict_stateless['x_test'])
+
+
+def test_no_cco_for_stateless_scaler() -> None:
+    raw = _make_raw_data()
+    data_dict = _prepare(_make_manifest(use_rolling_scaler=False), raw)
+
+    # stateless scaler has context_rows=0; scaler values are globally fitted so no CCO needed
+    # verify alignment is still correct and row counts are within window bounds
+    assert len(data_dict['x_val']) <= _VAL_HOURS
+    assert len(data_dict['x_test']) <= _TEST_HOURS
+
+    alignment = data_dict['_alignment']
+    first_test_dt = alignment['first_test_datetime']
+    first_test_date = first_test_dt.date() if hasattr(first_test_dt, 'date') else first_test_dt
+    assert first_test_date >= _TEST_START
+
+
+def test_strict_mode_raises_on_gap() -> None:
+    raw = _make_raw_data()
+
+    rows = raw.to_dicts()
+    rows[200]['close'] = None
+    raw_with_gap = pl.DataFrame(rows)
+
+    manifest = _make_manifest(strict_mode=True)
+    with pytest.raises(StrictModeError, match='Unexpected nulls'):
+        _prepare(manifest, raw_with_gap)
+
+
+def test_non_strict_mode_warns_on_gap(caplog: pytest.LogCaptureFixture) -> None:
+    raw = _make_raw_data()
+
+    rows = raw.to_dicts()
+    rows[200]['close'] = None
+    raw_with_gap = pl.DataFrame(rows)
+
+    manifest = _make_manifest(strict_mode=False)
+    with caplog.at_level(logging.WARNING, logger='limen.experiment.manifest_core'):
+        data_dict = _prepare(manifest, raw_with_gap)
+
+    assert any('Unexpected nulls' in r.message for r in caplog.records)
+    assert 'x_val' in data_dict
+
+
+def test_scaler_params_yaml_window() -> None:
+    from textwrap import dedent
+
+    yaml_text = dedent('''\
+        schema_version: "1.0"
+        metadata:
+          name: test_scaler_params
+          mode: development
+        sfd:
+          manifest:
+            type: ml
+            data_source:
+              method: limen.data.HistoricalData.get_spot_klines
+              params:
+                kline_size: 3600
+            split_dates:
+              train_start: "2025-01-01"
+              train_end: "2025-01-09"
+              val_start: "2025-01-09"
+              val_end: "2025-01-11"
+              test_start: "2025-01-11"
+              test_end: "2025-01-13"
+            indicators:
+              - func: limen.indicators.roc
+                params:
+                  period: 1
+                  group: momentum
+            target:
+              name: quantile_flag
+              class: limen.targets.QuantileBinaryTarget
+              fit_params:
+                source_column: roc_1
+                quantile: 0.5
+              transform_params:
+                shift: -1
+            scaler:
+              class: limen.scalers.CausalRollingRobustScaler
+              params:
+                window: 50
+                min_samples: 10
+            reference_architecture: limen.sfd.reference_architecture.logreg_binary
+          params:
+            C: [1.0]
+            random_state: [42]
+        uel:
+          n_permutations: 1
+          search_strategy:
+            type: grid
+          output_format: csv
+    ''')
+
+    yaml_dict, parse_errors = parse(yaml_text)
+    assert not parse_errors, parse_errors
+
+    manifest = build_manifest(yaml_dict)
+    raw = _make_raw_data()
+    data_dict = manifest.prepare_data(raw, round_params={'C': 1.0, 'random_state': 42})
+
+    fitted_scaler = data_dict['_fitted_params'].get('_scaler')
+    assert fitted_scaler is not None
+    assert fitted_scaler.window == 50
+    assert fitted_scaler.context_rows == 50
+
+
+def test_scaler_params_default_when_omitted() -> None:
+    manifest = _make_manifest()
+    raw = _make_raw_data()
+    data_dict = manifest.prepare_data(raw, round_params={})
+
+    fitted_scaler = data_dict['_fitted_params'].get('_scaler')
+    assert fitted_scaler is not None
+    assert fitted_scaler.window == _WINDOW
+    assert fitted_scaler.context_rows == _WINDOW

--- a/tests/test_manifest_cco.py
+++ b/tests/test_manifest_cco.py
@@ -397,7 +397,7 @@ def test_uel_continues_after_strict_mode_error() -> None:
 
     def patched_prep(data: pl.DataFrame, round_params: dict | None = None) -> dict:
         call_count[0] += 1
-        if call_count[0] == 1:
+        if call_count[0] == 2:
             raise StrictModeError('Unexpected nulls in val split · Checkpoint A · roc_1 @ [2025-01-09T08:00]')
         return original_prep(data, round_params)
 
@@ -417,7 +417,12 @@ def test_uel_continues_after_strict_mode_error() -> None:
     assert len(uel.round_params) == 2, 'only successful rounds in round_params'
     assert len(uel.preds) == 2, 'only successful rounds in preds'
     assert len(uel._alignment) == 2, 'only successful rounds in alignment'
+    # strict_mode_error must be a column in every row (null for success, string for failure)
     assert 'strict_mode_error' in uel.experiment_log.columns, 'strict_mode_error column must exist'
     error_rows = uel.experiment_log.filter(pl.col('strict_mode_error').is_not_null())
+    ok_rows = uel.experiment_log.filter(pl.col('strict_mode_error').is_null())
     assert error_rows.shape[0] == 1, 'exactly one round must have strict_mode_error'
+    assert ok_rows.shape[0] == 2, 'successful rounds must have null strict_mode_error'
     assert 'Unexpected nulls' in error_rows['strict_mode_error'][0]
+    # successful rounds must have metric columns populated (not dropped due to header mismatch)
+    assert 'id' in ok_rows.columns and ok_rows['id'].null_count() == 0

--- a/tests/test_manifest_cco.py
+++ b/tests/test_manifest_cco.py
@@ -3,12 +3,18 @@ import math
 from datetime import date
 from datetime import datetime
 from datetime import timedelta
+from pathlib import Path
+from tempfile import TemporaryDirectory
 
 import polars as pl
 import pytest
 
+import limen.sfd.foundational_sfd.random_binary as _random_binary_sfd
 from limen.experiment import MLManifest
 from limen.experiment.errors import StrictModeError
+from limen.experiment.experiment_core import UniversalExperimentLoop
+from limen.experiment.param_domain import ParamDomain
+from limen.experiment.param_search import RandomStrategy
 from limen.indicators import roc
 from limen.scalers.causal_rolling_robust_scaler import CausalRollingRobustScaler
 from limen.scalers.robust_scaler import RobustScaler
@@ -262,3 +268,39 @@ def test_scaler_params_default_when_omitted() -> None:
     assert fitted_scaler is not None
     assert fitted_scaler.window == _WINDOW
     assert fitted_scaler.context_rows == _WINDOW
+
+
+def test_uel_continues_after_strict_mode_error() -> None:
+    domain = ParamDomain(_random_binary_sfd.params())
+    strategy = RandomStrategy(domain, seed=42)
+    uel = UniversalExperimentLoop(sfd=_random_binary_sfd, search_strategy=strategy, test_mode=True)
+
+    call_count = [0]
+    original_prep = uel.prep
+
+    def patched_prep(data: pl.DataFrame, round_params: dict | None = None) -> dict:
+        call_count[0] += 1
+        if call_count[0] == 1:
+            raise StrictModeError('Unexpected nulls in val split · Checkpoint A · roc_1 @ [2025-01-09T08:00]')
+        return original_prep(data, round_params)
+
+    uel.prep = patched_prep
+
+    with TemporaryDirectory() as tmpdir:
+        uel._run_with_msq(
+            experiment_name=str(Path(tmpdir) / 'test'),
+            n_permutations=3,
+            context_params=None,
+            resume=False,
+            post_processing=True,
+        )
+
+    assert uel.experiment_log is not None
+    assert uel.experiment_log.shape[0] == 3, 'all 3 rounds must appear in experiment log'
+    assert len(uel.round_params) == 2, 'only successful rounds in round_params'
+    assert len(uel.preds) == 2, 'only successful rounds in preds'
+    assert len(uel._alignment) == 2, 'only successful rounds in alignment'
+    assert 'strict_mode_error' in uel.experiment_log.columns, 'strict_mode_error column must exist'
+    error_rows = uel.experiment_log.filter(pl.col('strict_mode_error').is_not_null())
+    assert error_rows.shape[0] == 1, 'exactly one round must have strict_mode_error'
+    assert 'Unexpected nulls' in error_rows['strict_mode_error'][0]

--- a/tests/test_manifest_cco.py
+++ b/tests/test_manifest_cco.py
@@ -27,10 +27,6 @@ _WINDOW = 20
 _MIN_SAMPLES = 5
 _ROC_PERIOD = 1
 
-# 300 hourly bars: 2025-01-01 00:00 to 2025-01-13 11:00
-# train: [2025-01-01, 2025-01-09) = 192 bars
-# val:   [2025-01-09, 2025-01-11) = 48 bars
-# test:  [2025-01-11, 2025-01-13) = 48 bars
 _N = 300
 _TRAIN_START = date(2025, 1, 1)
 _TRAIN_END = date(2025, 1, 9)
@@ -114,11 +110,9 @@ def test_cco_val_matches_continuous() -> None:
     manifest = _make_manifest()
     data_dict = _prepare(manifest, raw)
 
-    # sensor_input_prep applies indicators + scaler continuously on the full raw series
     fitted_params = data_dict['_fitted_params']
     sensor_data, _ = manifest.sensor_input_prep(raw, fitted_params, {})
 
-    # filter sensor output to val timestamps; this is the ground-truth continuous output
     val_dt_start = datetime(_VAL_START.year, _VAL_START.month, _VAL_START.day)
     val_dt_end = datetime(_VAL_END.year, _VAL_END.month, _VAL_END.day)
     val_continuous = (
@@ -128,7 +122,7 @@ def test_cco_val_matches_continuous() -> None:
     )
 
     feature_cols = data_dict['x_val'].columns
-    val_cco = data_dict['x_val']  # 47 rows (last target row dropped)
+    val_cco = data_dict['x_val']
 
     # compare first 47 rows (sensor includes all 48 val rows; x_val drops last due to target shift)
     assert len(val_cco) == len(val_continuous) - 1
@@ -142,13 +136,9 @@ def test_cco_val_matches_continuous() -> None:
 def test_cco_row_count_recovery() -> None:
     raw = _make_raw_data()
 
-    # with rolling scaler: CCO recovers indicator warm-up rows (1 for roc period=1)
     data_dict_cco = _prepare(_make_manifest(use_rolling_scaler=True), raw)
-
-    # with stateless scaler: no CCO context rows beyond indicator warm-up
     data_dict_stateless = _prepare(_make_manifest(use_rolling_scaler=False), raw)
 
-    # CCO should recover at least as many rows as stateless (warm-up rows are not dropped)
     assert len(data_dict_cco['x_val']) >= len(data_dict_stateless['x_val'])
     assert len(data_dict_cco['x_test']) >= len(data_dict_stateless['x_test'])
 
@@ -158,7 +148,6 @@ def test_no_cco_for_stateless_scaler() -> None:
     data_dict = _prepare(_make_manifest(use_rolling_scaler=False), raw)
 
     # stateless scaler has context_rows=0; scaler values are globally fitted so no CCO needed
-    # verify alignment is still correct and row counts are within window bounds
     assert len(data_dict['x_val']) <= _VAL_HOURS
     assert len(data_dict['x_test']) <= _TEST_HOURS
 
@@ -417,7 +406,6 @@ def test_uel_continues_after_strict_mode_error() -> None:
     assert len(uel.round_params) == 2, 'only successful rounds in round_params'
     assert len(uel.preds) == 2, 'only successful rounds in preds'
     assert len(uel._alignment) == 2, 'only successful rounds in alignment'
-    # strict_mode_error must be a column in every row (null for success, string for failure)
     assert 'strict_mode_error' in uel.experiment_log.columns, 'strict_mode_error column must exist'
     error_rows = uel.experiment_log.filter(pl.col('strict_mode_error').is_not_null())
     ok_rows = uel.experiment_log.filter(pl.col('strict_mode_error').is_null())

--- a/tests/test_manifest_cco.py
+++ b/tests/test_manifest_cco.py
@@ -135,7 +135,7 @@ def test_cco_val_matches_continuous() -> None:
     for col in feature_cols:
         cco_vals = val_cco[col].to_list()
         cont_vals = val_continuous[col].to_list()[:len(val_cco)]
-        for i, (a, b) in enumerate(zip(cco_vals, cont_vals)):
+        for i, (a, b) in enumerate(zip(cco_vals, cont_vals, strict=False)):
             assert abs(a - b) < 1e-9, f"val col={col} row={i}: CCO={a} continuous={b}"
 
 

--- a/tests/test_manifest_cco.py
+++ b/tests/test_manifest_cco.py
@@ -1,3 +1,5 @@
+import csv as _csv
+import io
 import logging
 import math
 from datetime import date
@@ -169,7 +171,7 @@ def test_strict_mode_raises_on_gap() -> None:
         _prepare(manifest, raw_with_gap)
 
 
-def test_non_strict_mode_warns_on_gap(caplog: pytest.LogCaptureFixture) -> None:
+def test_non_strict_mode_warns_on_gap() -> None:
     raw = _make_raw_data()
 
     rows = raw.to_dicts()
@@ -177,10 +179,17 @@ def test_non_strict_mode_warns_on_gap(caplog: pytest.LogCaptureFixture) -> None:
     raw_with_gap = pl.DataFrame(rows)
 
     manifest = _make_manifest(strict_mode=False)
-    with caplog.at_level(logging.WARNING, logger='limen.experiment.manifest_core'):
+    buf = io.StringIO()
+    handler = logging.StreamHandler(buf)
+    handler.setLevel(logging.WARNING)
+    logger = logging.getLogger('limen.experiment.manifest_core')
+    logger.addHandler(handler)
+    try:
         data_dict = _prepare(manifest, raw_with_gap)
+    finally:
+        logger.removeHandler(handler)
 
-    assert any('Unexpected nulls' in r.message for r in caplog.records)
+    assert 'Unexpected nulls' in buf.getvalue()
     assert 'x_val' in data_dict
 
 
@@ -414,3 +423,110 @@ def test_uel_continues_after_strict_mode_error() -> None:
     assert 'Unexpected nulls' in error_rows['strict_mode_error'][0]
     # successful rounds must have metric columns populated (not dropped due to header mismatch)
     assert 'id' in ok_rows.columns and ok_rows['id'].null_count() == 0
+
+
+_UNDER_WARM_WINDOW = 25
+_SHORT_N = 80
+_SHORT_TRAIN_START = date(2025, 1, 1)
+_SHORT_TRAIN_END = date(2025, 1, 2)    # 24 train rows < n_raw_cco=26 → under-warming
+_SHORT_VAL_START = date(2025, 1, 2)
+_SHORT_VAL_END = date(2025, 1, 3)
+_SHORT_TEST_START = date(2025, 1, 3)
+_SHORT_TEST_END = date(2025, 1, 4)
+
+
+def _make_short_raw_data() -> pl.DataFrame:
+    timestamps = [datetime(2025, 1, 1) + timedelta(hours=i) for i in range(_SHORT_N)]
+    close = [100.0 + 0.05 * i for i in range(_SHORT_N)]
+    return pl.DataFrame({
+        'datetime': timestamps,
+        'open': [v - 0.1 for v in close],
+        'high': [v + 0.2 for v in close],
+        'low': [v - 0.2 for v in close],
+        'close': close,
+        'volume': [1000.0 + float(i) for i in range(_SHORT_N)],
+    })
+
+
+def _make_under_warm_manifest(strict_mode: bool = False) -> MLManifest:
+    m = (
+        MLManifest()
+        .set_split_dates(
+            _SHORT_TRAIN_START, _SHORT_TRAIN_END,
+            _SHORT_VAL_START, _SHORT_VAL_END,
+            _SHORT_TEST_START, _SHORT_TEST_END,
+        )
+        .add_indicator(roc, period=1, group='momentum')
+        .with_target_label(
+            'quantile_flag',
+            QuantileBinaryTarget,
+            fit_params={'source_column': 'roc_1', 'quantile': 0.5},
+            transform_params={'shift': -1},
+        )
+        .set_scaler(CausalRollingRobustScaler, extra_params={'window': _UNDER_WARM_WINDOW, 'min_samples': 3})
+    )
+    if strict_mode:
+        m.set_strict_mode(True)
+    return m
+
+
+def test_cco_under_warm_strict_mode_raises() -> None:
+    raw = _make_short_raw_data()
+    manifest = _make_under_warm_manifest(strict_mode=True)
+    with pytest.raises(StrictModeError, match='under-warmed CCO'):
+        manifest.prepare_data(raw, round_params={})
+
+
+def test_cco_under_warm_non_strict_warns() -> None:
+    raw = _make_short_raw_data()
+    manifest = _make_under_warm_manifest(strict_mode=False)
+    buf = io.StringIO()
+    handler = logging.StreamHandler(buf)
+    handler.setLevel(logging.WARNING)
+    logger = logging.getLogger('limen.experiment.manifest_core')
+    logger.addHandler(handler)
+    try:
+        data_dict = manifest.prepare_data(raw, round_params={})
+    finally:
+        logger.removeHandler(handler)
+    assert 'under-warmed CCO' in buf.getvalue()
+    assert 'x_val' in data_dict
+
+
+def test_uel_first_round_strict_mode_error_does_not_corrupt_csv_header() -> None:
+    domain = ParamDomain(_random_binary_sfd.params())
+    strategy = RandomStrategy(domain, seed=42)
+    uel = UniversalExperimentLoop(sfd=_random_binary_sfd, search_strategy=strategy, test_mode=True)
+
+    call_count = [0]
+    original_prep = uel.prep
+
+    def patched_prep(data: pl.DataFrame, round_params: dict | None = None) -> dict:
+        call_count[0] += 1
+        if call_count[0] == 1:
+            raise StrictModeError('Unexpected nulls in val split · Checkpoint A · roc_1 @ [2025-01-01T00:00]')
+        return original_prep(data, round_params)
+
+    uel.prep = patched_prep
+
+    with TemporaryDirectory() as tmpdir:
+        exp_name = str(Path(tmpdir) / 'test_header')
+        uel._run_with_msq(
+            experiment_name=exp_name,
+            n_permutations=3,
+            context_params=None,
+            resume=False,
+            post_processing=True,
+        )
+        csv_path = Path(f'{exp_name}.csv')
+        assert csv_path.exists(), 'CSV must be written'
+        with csv_path.open('r', newline='') as f:
+            reader = _csv.reader(f)
+            header = next(reader)
+            rows = list(reader)
+
+    assert 'accuracy' in header, f'accuracy missing from CSV header — first-round failure corrupted the schema: {header}'
+    assert len(rows) == 3, f'expected 3 rows in CSV, got {len(rows)}'
+    acc_idx = header.index('accuracy')
+    filled = [r[acc_idx] for r in rows if r[acc_idx] != '']
+    assert len(filled) == 2, 'exactly 2 successful rounds should have accuracy values in CSV'

--- a/tests/test_manifest_cco.py
+++ b/tests/test_manifest_cco.py
@@ -270,6 +270,123 @@ def test_scaler_params_default_when_omitted() -> None:
     assert fitted_scaler.context_rows == _WINDOW
 
 
+def _make_dynamic_scaler_yaml(scaler_block: str,
+                               extra_params_block: str = '',
+                               scaler_window: int = 60) -> str:
+    from textwrap import dedent
+    return dedent(f'''\
+        schema_version: "1.0"
+        metadata:
+          name: test_dynamic_scaler
+          mode: development
+        sfd:
+          manifest:
+            type: ml
+            data_source:
+              method: limen.data.HistoricalData.get_spot_klines
+              params:
+                kline_size: 3600
+            split_dates:
+              train_start: "2025-01-01"
+              train_end: "2025-01-09"
+              val_start: "2025-01-09"
+              val_end: "2025-01-11"
+              test_start: "2025-01-11"
+              test_end: "2025-01-13"
+            indicators:
+              - func: limen.indicators.roc
+                params:
+                  period: 1
+                  group: momentum
+            target:
+              name: quantile_flag
+              class: limen.targets.QuantileBinaryTarget
+              fit_params:
+                source_column: roc_1
+                quantile: 0.5
+              transform_params:
+                shift: -1
+            {scaler_block}
+            reference_architecture: limen.sfd.reference_architecture.logreg_binary
+          params:
+            C: [1.0]
+            random_state: [42]
+            scaler_window: [{scaler_window}]
+            {extra_params_block}
+        uel:
+          n_permutations: 1
+          search_strategy:
+            type: grid
+          output_format: csv
+    ''')
+
+
+def test_scaler_params_class_form_with_dynamic_window() -> None:
+    scaler_block = '''\
+scaler:
+              class: limen.scalers.CausalRollingRobustScaler
+              params:
+                window: scaler_window'''
+
+    yaml_dict, parse_errors = parse(_make_dynamic_scaler_yaml(scaler_block, scaler_window=60))
+    assert not parse_errors, parse_errors
+
+    manifest = build_manifest(yaml_dict)
+    raw = _make_raw_data()
+    data_dict = manifest.prepare_data(raw, round_params={'C': 1.0, 'random_state': 42, 'scaler_window': 60})
+
+    fitted_scaler = data_dict['_fitted_params'].get('_scaler')
+    assert fitted_scaler is not None
+    assert fitted_scaler.window == 60, f'expected window=60, got {fitted_scaler.window}'
+    assert fitted_scaler.context_rows == 60
+
+
+def test_scaler_params_from_params_with_dynamic_window() -> None:
+    scaler_block = '''\
+scaler:
+              from_params: scaler_type
+              params:
+                window: scaler_window'''
+    extra_params_block = 'scaler_type: [causal_rolling_robust]'
+
+    yaml_dict, parse_errors = parse(_make_dynamic_scaler_yaml(scaler_block, extra_params_block, scaler_window=60))
+    assert not parse_errors, parse_errors
+
+    manifest = build_manifest(yaml_dict)
+    raw = _make_raw_data()
+    data_dict = manifest.prepare_data(
+        raw,
+        round_params={'C': 1.0, 'random_state': 42, 'scaler_window': 60, 'scaler_type': 'causal_rolling_robust'},
+    )
+
+    fitted_scaler = data_dict['_fitted_params'].get('_scaler')
+    assert fitted_scaler is not None
+    assert fitted_scaler.window == 60, f'expected window=60, got {fitted_scaler.window}'
+    assert fitted_scaler.context_rows == 60
+
+
+def test_scaler_params_mixed_static_and_dynamic() -> None:
+    # window is a sweep param reference (dynamic); min_samples is a literal (static)
+    scaler_block = '''\
+scaler:
+              class: limen.scalers.CausalRollingRobustScaler
+              params:
+                window: scaler_window
+                min_samples: 3'''
+
+    yaml_dict, parse_errors = parse(_make_dynamic_scaler_yaml(scaler_block, scaler_window=30))
+    assert not parse_errors, parse_errors
+
+    manifest = build_manifest(yaml_dict)
+    raw = _make_raw_data()
+    data_dict = manifest.prepare_data(raw, round_params={'C': 1.0, 'random_state': 42, 'scaler_window': 30})
+
+    fitted_scaler = data_dict['_fitted_params'].get('_scaler')
+    assert fitted_scaler is not None
+    assert fitted_scaler.window == 30, f'expected window=30 (dynamic), got {fitted_scaler.window}'
+    assert fitted_scaler.min_samples == 3, f'expected min_samples=3 (static), got {fitted_scaler.min_samples}'
+
+
 def test_uel_continues_after_strict_mode_error() -> None:
     domain = ParamDomain(_random_binary_sfd.params())
     strategy = RandomStrategy(domain, seed=42)

--- a/tests/test_run_registration.py
+++ b/tests/test_run_registration.py
@@ -14,7 +14,6 @@ PYTEST_ONLY_TESTS = {
         'test_get_arrow_file_row_count_limit_zero_copy',
         'test_get_arrow_file_view_outlives_call',
     },
-    'test_manifest_cco': {'test_non_strict_mode_warns_on_gap'},
     'test_tabpfn': {'test_tabpfn'},
 }
 

--- a/tests/test_run_registration.py
+++ b/tests/test_run_registration.py
@@ -14,6 +14,7 @@ PYTEST_ONLY_TESTS = {
         'test_get_arrow_file_row_count_limit_zero_copy',
         'test_get_arrow_file_view_outlives_call',
     },
+    'test_manifest_cco': {'test_non_strict_mode_warns_on_gap'},
     'test_tabpfn': {'test_tabpfn'},
 }
 

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -163,6 +163,57 @@ _E2E_ABLATION_YAML = dedent('''\
 ''')
 
 
+_E2E_REPRO_ROLLING_YAML = dedent('''\
+    schema_version: "1.0"
+    metadata:
+      name: test_repro_rolling
+      mode: development
+    sfd:
+      manifest:
+        type: ml
+        data_source:
+          method: limen.data.HistoricalData.get_spot_klines
+          params:
+            kline_size: 3600
+        split_dates:
+          train_start: "2025-01-01"
+          train_end: "2025-01-15"
+          val_start: "2025-01-15"
+          val_end: "2025-01-18"
+          test_start: "2025-01-18"
+          test_end: "2025-01-22"
+          val_predict_guard: false
+          test_predict_guard: false
+        indicators:
+          - func: limen.indicators.roc
+            params:
+              period: 1
+              group: momentum
+        target:
+          name: quantile_flag
+          class: limen.targets.QuantileBinaryTarget
+          fit_params:
+            source_column: roc_1
+            quantile: 0.5
+          transform_params:
+            shift: -1
+        scaler:
+          class: limen.scalers.CausalRollingRobustScaler
+          params:
+            window: 20
+            min_samples: 5
+        reference_architecture: limen.sfd.reference_architecture.logreg_binary
+      params:
+        C: [1.0]
+        random_state: [42]
+    uel:
+      n_permutations: 1
+      search_strategy:
+        type: grid
+      output_format: csv
+''')
+
+
 _E2E_REPRO_YAML = dedent('''\
     schema_version: "1.0"
     metadata:
@@ -543,4 +594,62 @@ def test_sensor_reproduces_training_metrics_on_val_test() -> None:
         # results.csv stores metrics rounded to 3 decimal places
         assert round(sensor_accuracy, 3) == training_accuracy, (
             f'sensor accuracy {sensor_accuracy} does not match training accuracy {training_accuracy}'
+        )
+
+
+def test_sensor_reproduces_training_metrics_with_rolling_scaler() -> None:
+    with TemporaryDirectory() as tmpdir:
+        exp_dir = Path(tmpdir) / 'exp'
+        exp_dir.mkdir()
+        round_ids = _run_e2e_experiment(exp_dir, _E2E_REPRO_ROLLING_YAML)
+        assert len(round_ids) == 1
+
+        training_accuracy = (
+            pl.read_csv(exp_dir / 'results.csv')
+            .filter(pl.col('id') == str(round_ids[0]))['accuracy'][0]
+        )
+
+        trainer, sensors = _train_e2e(exp_dir, round_ids)
+        sensor = sensors[0]
+
+        # Feed the full raw series so CausalRollingRobustScaler is warm across val+test —
+        # the same continuous stream that sensor_input_prep uses during training.
+        # Training-window bars come back with reason='inside-training-window'.
+        val_start = datetime(2025, 1, 15)
+        test_start = datetime(2025, 1, 18)
+        test_end = datetime(2025, 1, 22)
+        bar_preds = sensor.predict_all(trainer._data)
+
+        def _valid(p: object, lo: datetime, hi: datetime) -> bool:
+            return p.datetime is not None and p.reason is None and lo <= p.datetime < hi
+
+        val_preds = sorted([p for p in bar_preds if _valid(p, val_start, test_start)],
+                           key=lambda p: p.datetime)
+        test_preds = sorted([p for p in bar_preds if _valid(p, test_start, test_end)],
+                            key=lambda p: p.datetime)
+
+        data_dict = trainer._manifest.prepare_data(trainer._data, sensor.round_params)
+        y_val = data_dict['y_val'].to_list()
+        y_test = data_dict['y_test'].to_list()
+
+        # Row-count: CCO must have recovered all val+test rows (no cold-scaler nulls masked).
+        # Without CCO, min_samples-1=4 cold rows get reason='warm-up-rows' and are excluded,
+        # so the val count would fall below len(y_val).
+        assert len(val_preds) >= len(y_val), (
+            f'CCO failed on val: expected >= {len(y_val)} predictions '
+            f'(cold-scaler rows masked), got {len(val_preds)}'
+        )
+        assert len(test_preds) >= len(y_test), (
+            f'CCO failed on test: expected >= {len(y_test)} predictions '
+            f'(cold-scaler rows masked), got {len(test_preds)}'
+        )
+
+        # Accuracy: test-split predictions must match training (results.csv stores test accuracy)
+        test_preds = test_preds[:len(y_test)]
+        n_correct = sum(1 for p, y in zip(test_preds, y_test) if p.prediction == y)
+        sensor_accuracy = n_correct / len(y_test)
+
+        assert round(sensor_accuracy, 3) == training_accuracy, (
+            f'rolling scaler sensor accuracy {sensor_accuracy} '
+            f'does not match training accuracy {training_accuracy}'
         )

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -632,16 +632,16 @@ def test_sensor_reproduces_training_metrics_with_rolling_scaler() -> None:
         y_val = data_dict['y_val'].to_list()
         y_test = data_dict['y_test'].to_list()
 
-        # Row-count: CCO must have recovered all val+test rows (no cold-scaler nulls masked).
-        # Without CCO, min_samples-1=4 cold rows get reason='warm-up-rows' and are excluded,
-        # so the val count would fall below len(y_val).
-        assert len(val_preds) >= len(y_val), (
-            f'CCO failed on val: expected >= {len(y_val)} predictions '
-            f'(cold-scaler rows masked), got {len(val_preds)}'
+        # Row-count: sensor predicts every bar in the window including the last (no target due
+        # to shift:-1), so the count is len(y_*)+1. Without CCO, min_samples-1=4 cold rows
+        # get reason='warm-up-rows' and are excluded, dropping the count below len(y_val)+1.
+        assert len(val_preds) == len(y_val) + 1, (
+            f'CCO failed on val: expected {len(y_val) + 1} predictions '
+            f'(cold-scaler rows would be masked), got {len(val_preds)}'
         )
-        assert len(test_preds) >= len(y_test), (
-            f'CCO failed on test: expected >= {len(y_test)} predictions '
-            f'(cold-scaler rows masked), got {len(test_preds)}'
+        assert len(test_preds) == len(y_test) + 1, (
+            f'CCO failed on test: expected {len(y_test) + 1} predictions '
+            f'(cold-scaler rows would be masked), got {len(test_preds)}'
         )
 
         # Accuracy: test-split predictions must match training (results.csv stores test accuracy)

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -163,6 +163,52 @@ _E2E_ABLATION_YAML = dedent('''\
 ''')
 
 
+_E2E_REPRO_YAML = dedent('''\
+    schema_version: "1.0"
+    metadata:
+      name: test_repro
+      mode: development
+    sfd:
+      manifest:
+        type: ml
+        data_source:
+          method: limen.data.HistoricalData.get_spot_klines
+          params:
+            kline_size: 3600
+        split_dates:
+          train_start: "2025-01-01"
+          train_end: "2025-01-15"
+          val_start: "2025-01-15"
+          val_end: "2025-01-18"
+          test_start: "2025-01-18"
+          test_end: "2025-01-22"
+          val_predict_guard: false
+          test_predict_guard: false
+        indicators:
+          - func: limen.indicators.roc
+            params:
+              period: 1
+              group: momentum
+        target:
+          name: quantile_flag
+          class: limen.targets.QuantileBinaryTarget
+          fit_params:
+            source_column: roc_1
+            quantile: 0.5
+          transform_params:
+            shift: -1
+        reference_architecture: limen.sfd.reference_architecture.logreg_binary
+      params:
+        C: [1.0]
+        random_state: [42]
+    uel:
+      n_permutations: 1
+      search_strategy:
+        type: grid
+      output_format: csv
+''')
+
+
 def _make_e2e_data(kline_size: int = 3600,
                    n_rows: int | None = None,
                    start_date_limit: object = None,
@@ -454,3 +500,47 @@ def test_trainer_yaml_feature_ablation() -> None:
         dropped = sensor.round_params.get('_dropped_features')
         assert isinstance(dropped, list)
         assert len(dropped) == 1
+
+
+def test_sensor_reproduces_training_metrics_on_val_test() -> None:
+    with TemporaryDirectory() as tmpdir:
+        exp_dir = Path(tmpdir) / 'exp'
+        exp_dir.mkdir()
+        round_ids = _run_e2e_experiment(exp_dir, _E2E_REPRO_YAML)
+        assert len(round_ids) == 1
+
+        training_accuracy = (
+            pl.read_csv(exp_dir / 'results.csv')
+            .filter(pl.col('id') == str(round_ids[0]))['accuracy'][0]
+        )
+
+        trainer, sensors = _train_e2e(exp_dir, round_ids)
+        sensor = sensors[0]
+
+        bar_preds = sensor.predict_all(trainer._data)
+
+        test_start = datetime(2025, 1, 18)
+        test_end = datetime(2025, 1, 22)
+        test_preds = sorted(
+            [p for p in bar_preds if p.datetime is not None and p.reason is None
+             and test_start <= p.datetime < test_end],
+            key=lambda p: p.datetime,
+        )
+
+        data_dict = trainer._manifest.prepare_data(trainer._data, sensor.round_params)
+        y_test = data_dict['y_test'].to_list()
+
+        # sensor predicts for all test bars including the last one (no target); y_test drops it
+        test_preds = test_preds[:len(y_test)]
+
+        assert len(test_preds) == len(y_test), (
+            f'expected {len(y_test)} test predictions, got {len(test_preds)}'
+        )
+
+        n_correct = sum(1 for p, y in zip(test_preds, y_test) if p.prediction == y)
+        sensor_accuracy = n_correct / len(y_test)
+
+        # results.csv stores metrics rounded to 3 decimal places
+        assert round(sensor_accuracy, 3) == training_accuracy, (
+            f'sensor accuracy {sensor_accuracy} does not match training accuracy {training_accuracy}'
+        )

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -11,6 +11,8 @@ import polars as pl
 import pytest
 
 from limen.cli.commands.run import run_experiment
+from limen.cohort import Cohort
+from limen.cohort.sfc.top_n import select as select_top_n
 from limen.data import historical_data
 from limen.experiment.trainer import ReconstructionError
 from limen.experiment.trainer import Trainer
@@ -200,14 +202,16 @@ _E2E_REPRO_ROLLING_YAML = dedent('''\
         scaler:
           class: limen.scalers.CausalRollingRobustScaler
           params:
-            window: 20
+            window: scaler_window
             min_samples: 5
+        strict_mode: true
         reference_architecture: limen.sfd.reference_architecture.logreg_binary
       params:
         C: [1.0]
         random_state: [42]
+        scaler_window: [20, 50]
     uel:
-      n_permutations: 1
+      n_permutations: 2
       search_strategy:
         type: grid
       output_format: csv
@@ -602,54 +606,98 @@ def test_sensor_reproduces_training_metrics_with_rolling_scaler() -> None:
         exp_dir = Path(tmpdir) / 'exp'
         exp_dir.mkdir()
         round_ids = _run_e2e_experiment(exp_dir, _E2E_REPRO_ROLLING_YAML)
-        assert len(round_ids) == 1
+        assert len(round_ids) == 2
 
-        training_accuracy = (
-            pl.read_csv(exp_dir / 'results.csv')
-            .filter(pl.col('id') == str(round_ids[0]))['accuracy'][0]
+        results = pl.read_csv(exp_dir / 'results.csv')
+
+        assert 'scaler_window' in results.columns
+        assert set(results['scaler_window'].to_list()) == {20, 50}
+
+        # strict_mode=true: clean synthetic data must never trigger StrictModeError
+        assert 'strict_mode_error' in results.columns
+        assert results['strict_mode_error'].null_count() == len(round_ids), (
+            'clean data must produce no strict_mode_error on any round'
         )
 
-        trainer, sensors = _train_e2e(exp_dir, round_ids)
-        sensor = sensors[0]
+        assert results['accuracy'].null_count() == 0
+        assert results['auc'].null_count() == 0
 
-        # Feed the full raw series so CausalRollingRobustScaler is warm across val+test —
-        # the same continuous stream that sensor_input_prep uses during training.
-        # Training-window bars come back with reason='inside-training-window'.
+        cohort = Cohort(
+            experiment_log_path=str(exp_dir),
+            selector=select_top_n,
+            selector_params={'column': 'accuracy', 'n': 2},
+        )
+        assert len(cohort.permutation_ids) == 2
+
+        trainer, sensors = _train_e2e(exp_dir, round_ids)
+        assert len(sensors) == 2
+
+        assert {s.round_params['scaler_window'] for s in sensors} == {20, 50}
+
         val_start = datetime(2025, 1, 15)
         test_start = datetime(2025, 1, 18)
         test_end = datetime(2025, 1, 22)
-        bar_preds = sensor.predict_all(trainer._data)
 
-        def _valid(p: object, lo: datetime, hi: datetime) -> bool:
+        def _valid(p: BarPrediction, lo: datetime, hi: datetime) -> bool:
             return p.datetime is not None and p.reason is None and lo <= p.datetime < hi
 
-        val_preds = sorted([p for p in bar_preds if _valid(p, val_start, test_start)],
-                           key=lambda p: p.datetime)
-        test_preds = sorted([p for p in bar_preds if _valid(p, test_start, test_end)],
-                            key=lambda p: p.datetime)
+        for sensor in sensors:
+            w = sensor.round_params['scaler_window']
 
-        data_dict = trainer._manifest.prepare_data(trainer._data, sensor.round_params)
-        y_val = data_dict['y_val'].to_list()
-        y_test = data_dict['y_test'].to_list()
+            # Feed the full raw series — same continuous stream the scaler saw during training.
+            # Training-window bars come back with reason='inside-training-window'.
+            bar_preds = sensor.predict_all(trainer._data)
 
-        # Row-count: sensor predicts every bar in the window including the last (no target due
-        # to shift:-1), so the count is len(y_*)+1. Without CCO, min_samples-1=4 cold rows
-        # get reason='warm-up-rows' and are excluded, dropping the count below len(y_val)+1.
-        assert len(val_preds) == len(y_val) + 1, (
-            f'CCO failed on val: expected {len(y_val) + 1} predictions '
-            f'(cold-scaler rows would be masked), got {len(val_preds)}'
-        )
-        assert len(test_preds) == len(y_test) + 1, (
-            f'CCO failed on test: expected {len(y_test) + 1} predictions '
-            f'(cold-scaler rows would be masked), got {len(test_preds)}'
-        )
+            val_preds = sorted(
+                [p for p in bar_preds if _valid(p, val_start, test_start)],
+                key=lambda p: p.datetime,
+            )
+            test_preds = sorted(
+                [p for p in bar_preds if _valid(p, test_start, test_end)],
+                key=lambda p: p.datetime,
+            )
 
-        # Accuracy: test-split predictions must match training (results.csv stores test accuracy)
-        test_preds = test_preds[:len(y_test)]
-        n_correct = sum(1 for p, y in zip(test_preds, y_test, strict=False) if p.prediction == y)
-        sensor_accuracy = n_correct / len(y_test)
+            data_dict = trainer._manifest.prepare_data(trainer._data, sensor.round_params)
+            y_val = data_dict['y_val'].to_list()
+            y_test = data_dict['y_test'].to_list()
 
-        assert round(sensor_accuracy, 3) == training_accuracy, (
-            f'rolling scaler sensor accuracy {sensor_accuracy} '
-            f'does not match training accuracy {training_accuracy}'
-        )
+            # CCO must recover all val and test rows regardless of window size.
+            # Without CCO, the first (min_samples - 1) = 4 val rows would be
+            # excluded as cold-scaler warm-up, giving len(val_preds) < len(y_val) + 1.
+            assert len(val_preds) == len(y_val) + 1, (
+                f'CCO failed on val (window={w}): '
+                f'expected {len(y_val) + 1}, got {len(val_preds)}'
+            )
+            assert len(test_preds) == len(y_test) + 1, (
+                f'CCO failed on test (window={w}): '
+                f'expected {len(y_test) + 1}, got {len(test_preds)}'
+            )
+
+            n_correct = sum(
+                1 for p, y in zip(test_preds[:len(y_test)], y_test, strict=False)
+                if p.prediction == y
+            )
+            sensor_accuracy = n_correct / len(y_test)
+            training_accuracy = (
+                results.filter(pl.col('id') == str(sensor.permutation_id))['accuracy'][0]
+            )
+            assert round(sensor_accuracy, 3) == training_accuracy, (
+                f'sensor (window={w}) accuracy {sensor_accuracy:.4f} '
+                f'!= training {training_accuracy}'
+            )
+
+        cohort.set_members(sensors)
+
+        cohort_all = cohort.predict_all(trainer._data)
+        assert len(cohort_all) == len(trainer._data)
+        valid_cohort = [p for p in cohort_all if p.reason is None]
+        assert len(valid_cohort) > 0
+        assert all(p.prediction in (0, 1) for p in valid_cohort)
+        assert all(p.probability is not None and 0.0 <= p.probability <= 1.0 for p in valid_cohort)
+
+        cohort_last = cohort.predict(trainer._data)
+        assert isinstance(cohort_last, BarPrediction)
+        assert cohort_last.prediction in (0, 1)
+        assert cohort_last.probability is not None and 0.0 <= cohort_last.probability <= 1.0
+        last_valid_cohort = next(p for p in reversed(cohort_all) if p.reason is None)
+        assert cohort_last.prediction == last_valid_cohort.prediction

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -588,7 +588,7 @@ def test_sensor_reproduces_training_metrics_on_val_test() -> None:
             f'expected {len(y_test)} test predictions, got {len(test_preds)}'
         )
 
-        n_correct = sum(1 for p, y in zip(test_preds, y_test) if p.prediction == y)
+        n_correct = sum(1 for p, y in zip(test_preds, y_test, strict=False) if p.prediction == y)
         sensor_accuracy = n_correct / len(y_test)
 
         # results.csv stores metrics rounded to 3 decimal places
@@ -646,7 +646,7 @@ def test_sensor_reproduces_training_metrics_with_rolling_scaler() -> None:
 
         # Accuracy: test-split predictions must match training (results.csv stores test accuracy)
         test_preds = test_preds[:len(y_test)]
-        n_correct = sum(1 for p, y in zip(test_preds, y_test) if p.prediction == y)
+        n_correct = sum(1 for p, y in zip(test_preds, y_test, strict=False) if p.prediction == y)
         sensor_accuracy = n_correct / len(y_test)
 
         assert round(sensor_accuracy, 3) == training_accuracy, (

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -622,6 +622,18 @@ def test_sensor_reproduces_training_metrics_with_rolling_scaler() -> None:
         assert results['accuracy'].null_count() == 0
         assert results['auc'].null_count() == 0
 
+        for row in results.iter_rows(named=True):
+            assert row['scaler_window'] in {20, 50}, f'scaler_window={row["scaler_window"]} is a jumbled value'
+            assert isinstance(row['accuracy'], float) and 0.0 <= row['accuracy'] <= 1.0, (
+                f'accuracy={row["accuracy"]} outside [0,1] — possible column jumble'
+            )
+            assert isinstance(row['auc'], float) and 0.0 <= row['auc'] <= 1.0, (
+                f'auc={row["auc"]} outside [0,1] — possible column jumble'
+            )
+            assert row['C'] == 1.0, f'C={row["C"]} does not match the only swept value'
+            assert row['random_state'] == 42, f'random_state={row["random_state"]} does not match the only swept value'
+            assert row['strict_mode_error'] is None, f'strict_mode_error unexpectedly set: {row["strict_mode_error"]}'
+
         cohort = Cohort(
             experiment_log_path=str(exp_dir),
             selector=select_top_n,

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -650,28 +650,34 @@ def test_sensor_reproduces_training_metrics_with_rolling_scaler() -> None:
         test_start = datetime(2025, 1, 18)
         test_end = datetime(2025, 1, 22)
 
-        def _valid(p: BarPrediction, lo: datetime, hi: datetime) -> bool:
-            return p.datetime is not None and p.reason is None and lo <= p.datetime < hi
+        raw = trainer._data
+        train_raw = raw.filter(pl.col('datetime') < val_start)
+        val_raw = raw.filter((pl.col('datetime') >= val_start) & (pl.col('datetime') < test_start))
+        test_raw = raw.filter((pl.col('datetime') >= test_start) & (pl.col('datetime') < test_end))
 
         for sensor in sensors:
             w = sensor.round_params['scaler_window']
 
-            # Feed the full raw series — same continuous stream the scaler saw during training.
-            # Training-window bars come back with reason='inside-training-window'.
-            bar_preds = sensor.predict_all(trainer._data)
-
-            val_preds = sorted(
-                [p for p in bar_preds if _valid(p, val_start, test_start)],
-                key=lambda p: p.datetime,
-            )
-            test_preds = sorted(
-                [p for p in bar_preds if _valid(p, test_start, test_end)],
-                key=lambda p: p.datetime,
-            )
-
             data_dict = trainer._manifest.prepare_data(trainer._data, sensor.round_params)
             y_val = data_dict['y_val'].to_list()
             y_test = data_dict['y_test'].to_list()
+
+            # Feed cco+split per split: sensor's rolling computation operates on the same-shaped
+            # array as prepare_data, giving FP-identical scaled features.
+            # N_raw_cco covers the scaler warm-up window plus a small buffer for indicator lookback.
+            N_raw_cco = w + 10
+            val_preds_raw = sensor.predict_all(pl.concat([train_raw.tail(N_raw_cco), val_raw]))
+            test_preds_raw = sensor.predict_all(pl.concat([val_raw.tail(N_raw_cco), test_raw]))
+
+            # CCO bars are excluded by the datetime filter; no reason filter needed.
+            val_preds = sorted(
+                [p for p in val_preds_raw if p.datetime is not None and val_start <= p.datetime < test_start],
+                key=lambda p: p.datetime,
+            )
+            test_preds = sorted(
+                [p for p in test_preds_raw if p.datetime is not None and test_start <= p.datetime < test_end],
+                key=lambda p: p.datetime,
+            )
 
             # CCO must recover all val and test rows regardless of window size.
             # Without CCO, the first (min_samples - 1) = 4 val rows would be

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -664,8 +664,8 @@ def test_sensor_reproduces_training_metrics_with_rolling_scaler() -> None:
 
             # Feed cco+split per split: sensor's rolling computation operates on the same-shaped
             # array as prepare_data, giving FP-identical scaled features.
-            # N_raw_cco covers the scaler warm-up window plus a small buffer for indicator lookback.
-            N_raw_cco = w + 10
+            # n_raw_cco = cco_indicator_rows + scaler_context_rows; roc(period=1) gives 1 leading null.
+            N_raw_cco = w + 1
             val_preds_raw = sensor.predict_all(pl.concat([train_raw.tail(N_raw_cco), val_raw]))
             test_preds_raw = sensor.predict_all(pl.concat([val_raw.tail(N_raw_cco), test_raw]))
 

--- a/tests/test_yaml.py
+++ b/tests/test_yaml.py
@@ -277,6 +277,9 @@ def test_logreg_yaml_template_exposes_full_architecture_surface() -> None:
 
     assert model_params <= set(yaml_dict['sfd']['params'])
 
+    sfd = CompiledSFD(yaml_dict)
+    assert sfd.manifest().strict_mode is True
+
 
 def test_validate_passes_valid_rule_based_yaml() -> None:
     yaml_dict, _ = parse(_MINIMAL_RULE_BASED_YAML)
@@ -1260,6 +1263,7 @@ def test_tabpfn_binary_template_is_valid_and_arch_surface_complete() -> None:
 
     sfd = CompiledSFD(yaml_dict)
     assert isinstance(sfd.manifest(), MLManifest)
+    assert sfd.manifest().strict_mode is True
 
     arch = resolve(yaml_dict['sfd']['manifest']['reference_architecture'])
     model_params = set(inspect.signature(arch).parameters) - {'data', 'prediction_calibration_config'}
@@ -1278,6 +1282,7 @@ def test_xgboost_regressor_template_is_valid_and_arch_surface_complete() -> None
 
     sfd = CompiledSFD(yaml_dict)
     assert isinstance(sfd.manifest(), MLManifest)
+    assert sfd.manifest().strict_mode is True
 
     arch = resolve(yaml_dict['sfd']['manifest']['reference_architecture'])
     model_params = set(inspect.signature(arch).parameters) - {'data', 'prediction_calibration_config'}
@@ -1310,6 +1315,7 @@ def test_lightgbm_binary_template_is_valid_and_arch_surface_complete() -> None:
 
     sfd = CompiledSFD(yaml_dict)
     assert isinstance(sfd.manifest(), MLManifest)
+    assert sfd.manifest().strict_mode is True
 
     arch = resolve(yaml_dict['sfd']['manifest']['reference_architecture'])
     model_params = set(inspect.signature(arch).parameters) - {'data', 'prediction_calibration_config'}


### PR DESCRIPTION
**NOTE:** The author must always **first review the PR themselves**, before requesting review from others, that means carefully having reviewed the full diff in GitHub.

## What does this PR change?

- Fix rolling scaler reproducibility: the causal rolling scaler cold-started at each split boundary during training, causing val and test bars to receive different scaled values than the continuous inference stream. Context Carry-Over prepends the raw tail of the preceding split before the feature transform pass and strips it after scaling, so the scaler is always warm when it reaches the actual split data. The inference path is unchanged.
- Expose a context rows property on the causal rolling robust scaler so CCO can detect the required warm-up size automatically. Stateless scalers return zero via duck-typing and receive no CCO block.
- Add strict mode to the ML manifest. When enabled, unexpected nulls remaining after CCO dislodgement raise an error rather than logging a warning. The experiment loop catches the error per permutation, records the failure in results, and continues to the next round.
- Add constructor parameter support for scalers in both the manifest API and YAML. Parameters such as window size and minimum samples can be set as literals or as sweep-param references, letting them appear in results and be fully reproducible.
- Add a data quality section to the profile output. The profiler captures null warnings during sample rounds and the CLI renders them under a dedicated header.

Closes #598
Closes  #599 

## Checklist

- [x] I have reviewed full diff in “Files changed”
- [x] I left no unnecessary files in the changes
- [x] I ran `python tests/run.py` locally without errors (where applicable)
- [x] I updated `/docs` (if behavior/API/config/user/etc changed)
- [x] I added and/or updated docstrings as per [Writing Docstrings](https://github.com/Vaquum/Limen/blob/main/docs/Developer/Writing-Docstrings.md) (for any changed public functions/classes)
- [x] I updated CHANGELOG.md (unless only docs or other non-code aspect was changed)
- [x] I updated pyproject.toml (unless only docs or other non-code aspect was changed)
- [x] I added and/or updated tests (if behavior changed or new code paths added)
- [x] I validated changes manually
- [x] I validated changes with LLM
- [x] I removed any extraneous examples/comments
- [x] I linked issue to auto-close on merge (e.g., “Fixes #123”) when applicable
- [x] If this PR delivers a PRD’s **last** remaining slice, I also linked the parent PRD to close with it (e.g., “Closes #120”), so the PRD closes on merge instead of by hand
