### PR TITLE
docs: make Limen docs YAML CLI first

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ In the wider Vaquum architecture, Origo sits upstream as the data layer. Nexus, 
 
 ## First Experiment
 
-The first runnable path is a small parameter sweep on the bundled BTC/USDT kline dataset with the built-in logistic-regression decoder.
+The first runnable path is a YAML manifest executed through the `limen` CLI.
 
 1. Install the package:
 
@@ -61,36 +61,41 @@ The first runnable path is a small parameter sweep on the bundled BTC/USDT kline
 pip install vaquum_limen
 ```
 
-2. Load data and run a first experiment:
+2. Scaffold a starter manifest:
 
-```python
-import limen
-
-historical = limen.HistoricalData()
-data = historical.get_spot_klines(kline_size=7200, row_count_limit=2000)
-
-uel = limen.UniversalExperimentLoop(data=data, sfd=limen.sfd.logreg_binary)
-
-uel.run(
-    experiment_name="logreg-first",
-    n_permutations=25,
-    prep_each_round=True,
-)
+```bash
+limen init logreg-first.yaml --template logreg_binary
 ```
 
-3. Inspect the core outputs:
+3. Validate, profile, and dry-run the manifest:
 
-- `uel.experiment_log` for the parameter sweep results
-- `uel.experiment_confusion_metrics` for confusion analytics
-- `uel.experiment_backtest_results` for backtest results
+```bash
+limen validate logreg-first.yaml
+limen profile logreg-first.yaml
+limen run --dry-run logreg-first.yaml
+```
 
-That path runs against public BTC/USDT data without relying on repo-local fixture files. The UEL documentation covers run directories, checkpoints, resumability, and stored round artefacts.
+4. Run it:
+
+```bash
+limen run logreg-first.yaml
+```
+
+5. Inspect the result directory printed by the CLI:
+
+- copied YAML manifest
+- `metadata.json`
+- `results.csv`
+- `round_data.jsonl`
+
+That path runs the manifest-backed engine without Python orchestration code. The Python API remains available for custom SFDs, custom prep/model logic, and direct UEL integration.
 
 ## Learn more
 
 - Start with the full docs hub in [docs/README.md](docs/README.md)
-- Define research units in [docs/Single-File-Decoder.md](docs/Single-File-Decoder.md), [docs/Built-In-SFDs.md](docs/Built-In-SFDs.md), and [docs/Experiment-Manifest.md](docs/Experiment-Manifest.md)
-- Run experiments in [docs/Universal-Experiment-Loop.md](docs/Universal-Experiment-Loop.md) and extend the artifact-backed path through [docs/Advanced-Search.md](docs/Advanced-Search.md) and [docs/Reducers-And-Feedback.md](docs/Reducers-And-Feedback.md)
+- Start with the YAML/CLI path in [docs/Command-Line-Interface.md](docs/Command-Line-Interface.md) and [docs/Experiment-Manifest.md](docs/Experiment-Manifest.md)
+- Use [docs/Universal-Experiment-Loop.md](docs/Universal-Experiment-Loop.md) for the engine beneath CLI and direct Python integration
+- Define extension research units in [docs/Single-File-Decoder.md](docs/Single-File-Decoder.md) and [docs/Built-In-SFDs.md](docs/Built-In-SFDs.md)
 - Analyze results in [docs/Log.md](docs/Log.md), [docs/Benchmark.md](docs/Benchmark.md), and [docs/Backtest.md](docs/Backtest.md)
 - Understand the model layer in [docs/Reference-Architecture.md](docs/Reference-Architecture.md) and the helper layer in [docs/Utilities.md](docs/Utilities.md)
 - Promote finished runs into reusable outputs with [docs/Trainer.md](docs/Trainer.md) and [docs/Cohort.md](docs/Cohort.md)

--- a/docs/Advanced-Search.md
+++ b/docs/Advanced-Search.md
@@ -1,6 +1,6 @@
 # Advanced Search
 
-Advanced search is Limen's artifact-backed experiment path. It adds a mutable parameter domain, a search strategy abstraction, checkpointing, resumability, and mid-run feedback on top of the normal Universal Experiment Loop.
+Advanced search is Limen's artifact-backed extension path. It adds a mutable parameter domain, a search strategy abstraction, checkpointing, resumability, and mid-run feedback on top of the same UEL engine used by `limen run`.
 
 This page covers:
 
@@ -9,7 +9,7 @@ This page covers:
 - mid-run interventions that can mutate the remaining search space
 - promotion-ready runs for [Trainer](Trainer.md)
 
-For a first experiment, stay on the standard UEL path. Advanced search is real and supported, but it is the extension-oriented layer of Limen.
+For a first experiment, stay on the YAML/CLI path. Advanced search is real and supported, but it is the extension-oriented layer of Limen.
 
 ## The core pieces
 
@@ -166,9 +166,9 @@ For resume to work cleanly, keep these stable:
 - the same parameter content
 - the same configured reducer stack
 
-## What advanced search adds beyond standard UEL
+## What advanced search adds beyond the normal run path
 
-Compared to the standard path, advanced search adds:
+Compared to a normal YAML CLI run or direct standard UEL sweep, advanced search adds:
 
 - mutable pruning and focus during a run
 - stored round-level predictions and alignment data
@@ -185,5 +185,6 @@ What it does not change:
 ## Read next
 
 - Continue to [Reducers And Feedback](Reducers-And-Feedback.md) for the intervention system that acts on the mutable search queue.
-- Continue to [Universal Experiment Loop](Universal-Experiment-Loop.md) for the broader run contract around standard and advanced execution.
+- Continue to [Command Line Interface](Command-Line-Interface.md) for the normal YAML run loop.
+- Continue to [Universal Experiment Loop](Universal-Experiment-Loop.md) for the broader engine contract around standard and advanced execution.
 - Continue to [Trainer](Trainer.md) for promotion of finished advanced runs into reusable sensors.

--- a/docs/Built-In-SFDs.md
+++ b/docs/Built-In-SFDs.md
@@ -1,6 +1,6 @@
 # Built-in SFDs
 
-Limen ships foundational SFDs under `limen.sfd.foundational_sfd`. These packaged decoders run without a custom experiment module.
+Limen ships foundational SFDs under `limen.sfd.foundational_sfd` and matching YAML templates under `limen/yaml/templates`. Ordinary runs should start from the YAML template and CLI; the Python modules are the packaged decoder layer beneath that path.
 
 They show the packaged Limen experiment shape because each one combines:
 
@@ -110,23 +110,17 @@ That optional status matters at import time and in local documentation examples.
 
 ## Running one immediately
 
-A built-in SFD can run with only `sfd=`:
+A built-in YAML template can run directly through the CLI:
 
-```python
-import limen
-
-uel = limen.UniversalExperimentLoop(
-    sfd=limen.sfd.logreg_binary,
-)
-
-uel.run(
-    experiment_name='built-in-logreg',
-    n_permutations=5,
-    prep_each_round=True,
-)
+```bash
+limen init built-in-logreg.yaml --template logreg_binary
+limen validate built-in-logreg.yaml
+limen profile built-in-logreg.yaml
+limen run --dry-run built-in-logreg.yaml
+limen run built-in-logreg.yaml
 ```
 
-When `data=` is omitted, the manifest fetches data using `fetch_data()`. Passing `test_mode=True` to UEL uses the test data source instead.
+Direct Python use is still available when you need to integrate with UEL or custom code. When `data=` is omitted on a manifest-driven SFD, the manifest fetches data using `fetch_data()`.
 
 ## How to choose
 
@@ -138,5 +132,6 @@ When `data=` is omitted, the manifest fetches data using `fetch_data()`. Passing
 ## Read next
 
 - Continue to [Single-File Decoder](Single-File-Decoder.md) for the general SFD contract.
+- Continue to [Command Line Interface](Command-Line-Interface.md) for the YAML run loop.
 - Continue to [Reference Architecture](Reference-Architecture.md) for the class-based model layer underneath these built-in decoders.
 - Continue to [Experiment Manifest](Experiment-Manifest.md) to adapt one of these into a custom SFD.

--- a/docs/Cohort.md
+++ b/docs/Cohort.md
@@ -17,21 +17,21 @@
 
 A Cohort requires:
 
-1. a completed UEL experiment directory
+1. a completed YAML CLI result directory
 2. valid experiment artefacts (`metadata.json`, `round_data.jsonl`)
 3. selected permutation IDs, or a selector that chooses them
 4. trained members from `Trainer.train(permutation_ids)`
 
 Read these pages first:
 
-- [Universal Experiment Loop](Universal-Experiment-Loop.md)
+- [Command Line Interface](Command-Line-Interface.md)
 - [Trainer](Trainer.md)
 
 ## Where Cohort fits in the pipeline
 
 Pipeline path:
 
-1. run experiment search with UEL
+1. run experiment search with `limen run`
 2. identify permutations to promote, manually or with a selector
 3. reconstruct/train those permutations with Trainer
 4. create Cohort from experiment source + permutation IDs or selector

--- a/docs/Command-Line-Interface.md
+++ b/docs/Command-Line-Interface.md
@@ -6,6 +6,18 @@ The Limen CLI is the supported shell surface for YAML-first experiment work. It 
 
 The CLI owns project and manifest operations around declarative YAML experiments. It does not replace the Python API for custom SFD authoring, custom feature code, or direct `UniversalExperimentLoop` integration.
 
+## First YAML Run
+
+```bash
+limen init logreg-first.yaml --template logreg_binary
+limen validate logreg-first.yaml
+limen profile logreg-first.yaml
+limen run --dry-run logreg-first.yaml
+limen run logreg-first.yaml
+```
+
+This is the preferred user journey: create or edit YAML, validate it, profile the search space, compile it without execution, then run it through the UEL engine.
+
 ## Commands
 
 | Command | Purpose | Main output |
@@ -53,6 +65,17 @@ Options:
 | --- | --- |
 | `--dry-run` | validate and compile only; no permutations execute |
 | `--resume <results_dir>` | resume from a checkpoint directory; cannot be combined with a YAML file |
+
+The normal result directory contains:
+
+| File | Meaning |
+| --- | --- |
+| copied YAML manifest | the source manifest copied beside the run outputs; committed manifest URI runs use `manifest.yaml` |
+| `metadata.json` | experiment metadata, including `yaml_reference` for Trainer and resume flows |
+| `results.csv` | streaming round log |
+| `round_data.jsonl` | round params, predictions, and alignment metadata |
+| `checkpoint.json` | checkpoint state when checkpointing has run |
+| `audit.jsonl` | feedback-cycle audit trail when feedback has run |
 
 ### `limen commit <yaml_file>`
 

--- a/docs/Developer/Documentation-System.md
+++ b/docs/Developer/Documentation-System.md
@@ -78,11 +78,12 @@ Every major public page should reinforce the same core Limen story:
 
 1. Limen turns Bitcoin market data into searchable signals, backtested outcomes, and decoder cohorts.
 2. Data enters through native Limen data access or external OHLC-style data.
-3. An experiment is defined through an SFD, manifest-driven by default.
-4. Universal Experiment Loop executes a parameter search across the chosen search space.
-5. Log, benchmark-style analytics, and backtest outputs show what happened and why.
-6. Trainer and Cohort turn finished experiment outputs into reusable downstream artefacts.
-7. Trade decisioning and execution happen outside Limen, downstream in other Vaquum systems.
+3. An experiment is defined first as a YAML manifest.
+4. The CLI validates, profiles, dry-runs, and runs that manifest.
+5. Universal Experiment Loop is the engine beneath CLI execution and the direct API for Python extensions.
+6. Log, benchmark-style analytics, and backtest outputs show what happened and why.
+7. Trainer and Cohort turn finished experiment outputs into reusable downstream artefacts.
+8. Trade decisioning and execution happen outside Limen, downstream in other Vaquum systems.
 
 If a page does not help a reader understand its place in that story, it should route clearly to the pages that do.
 
@@ -104,6 +105,7 @@ All Limen documentation should use the same register:
 - Keep theory only where it directly improves practical understanding.
 - Explain current surface area honestly; do not imply future behavior as present behavior.
 - Prefer examples that show inputs, outputs, and artefacts.
+- Lead operator-facing workflow docs with YAML manifest and CLI execution before Python internals.
 - Do not use unexplained internal jargon.
 - Do not duplicate large sections of content across pages.
 - End pages with explicit reading routes or next steps when they affect task completion.

--- a/docs/Experiment-Manifest.md
+++ b/docs/Experiment-Manifest.md
@@ -1,29 +1,97 @@
 # Experiment Manifest
 
-The Experiment Manifest is Limen's declarative pipeline builder. Instead of hand-written `prep()` orchestration, the manifest describes how data is fetched, split, transformed, targeted, scaled, and handed to a model.
+The Experiment Manifest is Limen's declarative experiment definition. The canonical operator form is YAML: define the manifest, validate it, profile it, run it through CLI, then inspect the generated artifacts.
 
-This is the default path for Limen work because it provides:
+Use YAML manifests for Limen's opinionated pipeline. Use Python builders, custom `prep()`, and custom `model()` only when the workflow cannot fit the declarative operator path.
+
+The default path provides:
 
 - split-first execution
 - train-only fitting for targets and scalers
 - automatic data fetching
 - cleaner collaboration surfaces
-- reproducible experiment definitions
+- reproducible experiment definitions and artifact-backed runs
 
-Use a manifest for Limen's opinionated pipeline. Use custom `prep()` and `model()` functions only when the workflow cannot fit the declarative pipeline.
+## YAML First Run
+
+```bash
+limen init logreg-first.yaml --template logreg_binary
+limen validate logreg-first.yaml
+limen profile logreg-first.yaml
+limen run --dry-run logreg-first.yaml
+limen run logreg-first.yaml
+```
+
+The run writes a result directory containing the copied YAML manifest, `metadata.json`, `results.csv`, and `round_data.jsonl`.
+
+## YAML Shape
+
+This minimal shape shows the same pieces as the Python builder API:
+
+```yaml
+schema_version: "1.0"
+
+metadata:
+  name: logreg-first
+  limen_version: "3.6.0"
+  mode: development
+
+sfd:
+  manifest:
+    type: ml
+    data_source:
+      method: limen.data.HistoricalData.get_spot_klines
+      params:
+        kline_size: 3600
+    split_dates:
+      train_start: "2024-01-01"
+      train_end: "2024-09-30"
+      val_start: "2024-10-01"
+      val_end: "2024-11-30"
+      test_start: "2024-12-01"
+      test_end: "2024-12-31"
+    indicators:
+      - func: limen.indicators.roc
+        params:
+          period: "{roc_period}"
+    target:
+      name: quantile_flag
+      class: limen.targets.QuantileBinaryTarget
+      fit_params:
+        source_column: "roc_{roc_period}"
+        quantile: "{q}"
+      transform_params:
+        shift: "{shift}"
+    scaler:
+      from_params: scaler_type
+    reference_architecture: limen.sfd.reference_architecture.logreg_binary
+  params:
+    roc_period: [1, 4, 12]
+    q: [0.35, 0.40, 0.45]
+    shift: [-1, -2, -3]
+    scaler_type: [logreg]
+    C: [0.1, 1.0, 5.0]
+
+uel:
+  n_permutations: 25
+  search_strategy:
+    type: random
+  prep_each_round: true
+  output_format: csv
+```
 
 ## Manifest Types
 
-There are two manifest subclasses:
+There are two manifest subclasses under the YAML and Python surfaces:
 
 - **`MLManifest`** — for ML pipelines. Supports indicators, features, targets, scalers, ablation, and calibration.
 - **`RuleBasedManifest`** — for rule-based pipelines. Supports indicators and features, plus `with_strategy()` for predicate-driven entry signals. Does not support scalers or ablation.
 
 Both subclasses share a common base (`Manifest`) that owns data fetching, splitting, and model execution. The `manifest()` function in every foundational SFD returns the base `Manifest` type as a uniform interface, while internally constructing the correct subclass. `Manifest` itself is not meant to be instantiated directly — its `prepare_data()` raises `NotImplementedError`.
 
-## Golden Path Example
+## Python Builder Equivalent
 
-This is a complete manifest-driven SFD in the style Limen uses today.
+The Python builder API is the equivalent surface for foundational SFD authors and custom integrations.
 
 ```python
 from limen.data import HistoricalData
@@ -76,7 +144,7 @@ def manifest() -> Manifest:
     )
 ```
 
-Run it through UEL like this:
+Run the Python-built SFD through UEL only when direct engine integration is required:
 
 ```python
 import limen
@@ -90,6 +158,8 @@ uel.run(
     prep_each_round=True,
 )
 ```
+
+For ordinary runs, keep the manifest in YAML and use `limen run`.
 
 ## How A Manifest Executes
 

--- a/docs/Log.md
+++ b/docs/Log.md
@@ -2,22 +2,28 @@
 
 `Log` is Limen's post-run analysis layer. It sits on top of a finished experiment and turns raw round results into round-level prediction tables, benchmark-style summaries, backtest summaries, and parameter-correlation views.
 
-`UniversalExperimentLoop` creates `uel._log` automatically at the end of a successful run and exposes the primary derived tables directly on the `uel` object.
+For YAML CLI runs, start from the generated result directory and `results.csv`. For direct Python UEL runs, pass `post_processing=True` when you need `uel._log`, confusion metrics, and backtest summaries on the live object.
 
 ## Two ways to use `Log`
 
 ### UEL-backed `Log`
 
-This is the normal path.
+This is the direct Python analysis path.
 
 ```python
+import limen
 from limen.data import HistoricalData
 
 historical = HistoricalData()
 data = historical.get_spot_klines(kline_size=7200, row_count_limit=2000)
 
 uel = limen.UniversalExperimentLoop(data=data, sfd=limen.sfd.logreg_binary)
-uel.run(experiment_name='logreg-first', n_permutations=4, prep_each_round=True)
+uel.run(
+    experiment_name='logreg-first',
+    n_permutations=4,
+    prep_each_round=True,
+    post_processing=True,
+)
 
 log = uel._log
 ```

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,7 @@ This page routes Limen docs by task.
 
 ## Limen in one page
 
-Limen is a Bitcoin alpha research engine for turning market data into experiments, logged analytics, backtests, and decoder cohorts. It keeps the research loop inside one Python system: data preparation, indicators, features, targets, scaling, parameter search, and post-run evaluation.
+Limen is a Bitcoin alpha research engine for turning market data into experiments, logged analytics, backtests, and decoder cohorts. Its default operator path is a YAML manifest run through the CLI; Python APIs remain the extension layer for custom decoder and engine work.
 
 Limen does not perform downstream trade decisioning or execution. In the wider Vaquum architecture, Origo sits upstream as the data layer, while Nexus, Praxis, and Veritas sit downstream for decisioning, execution, and oversight.
 
@@ -13,20 +13,20 @@ Limen does not perform downstream trade decisioning or execution. In the wider V
 ### New to Limen
 
 1. Read the [product home page](../README.md)
-2. Learn how data enters Limen in [Historical Data](Historical-Data.md)
-3. Learn how experiments are packaged in [Single-File Decoder](Single-File-Decoder.md)
-4. Review the shipped patterns in [Built-In SFDs](Built-In-SFDs.md)
-5. Learn the standard declarative path in [Experiment Manifest](Experiment-Manifest.md)
-6. Run experiments in [Universal Experiment Loop](Universal-Experiment-Loop.md)
-7. Review outcomes in [Log](Log.md)
+2. Run the YAML workflow in [Command Line Interface](Command-Line-Interface.md)
+3. Learn the manifest contract in [Experiment Manifest](Experiment-Manifest.md)
+4. Learn how data enters Limen in [Historical Data](Historical-Data.md)
+5. Review outcomes in [Log](Log.md), [Benchmark](Benchmark.md), and [Backtest](Backtest.md)
+6. Continue to [Universal Experiment Loop](Universal-Experiment-Loop.md) for the engine beneath CLI
+7. Use [Single-File Decoder](Single-File-Decoder.md) and [Built-In SFDs](Built-In-SFDs.md) for Python extension work
 
 ### Author experiments
 
-1. Start with [Single-File Decoder](Single-File-Decoder.md)
-2. Review the shipped patterns in [Built-In SFDs](Built-In-SFDs.md)
-3. Continue to [Experiment Manifest](Experiment-Manifest.md)
-4. Use [Indicators](Indicators.md), [Features](Features.md), [Targets](Targets.md), [Transforms](Transforms.md), [Scalers](Scalers.md), [Calibration](Calibration.md), and [Reference Architecture](Reference-Architecture.md) as the reference layer
-5. Run the search in [Universal Experiment Loop](Universal-Experiment-Loop.md)
+1. Start with [Experiment Manifest](Experiment-Manifest.md)
+2. Run manifests through [Command Line Interface](Command-Line-Interface.md)
+3. Review the shipped decoder patterns in [Built-In SFDs](Built-In-SFDs.md)
+4. Use [Single-File Decoder](Single-File-Decoder.md) for custom Python experiment modules
+5. Use [Indicators](Indicators.md), [Features](Features.md), [Targets](Targets.md), [Transforms](Transforms.md), [Scalers](Scalers.md), [Calibration](Calibration.md), and [Reference Architecture](Reference-Architecture.md) as the reference layer
 6. Adaptive search continues in [Advanced Search](Advanced-Search.md) and [Reducers And Feedback](Reducers-And-Feedback.md)
 7. Inspect results in [Log](Log.md), [Benchmark](Benchmark.md), and [Backtest](Backtest.md)
 
@@ -41,9 +41,9 @@ Limen does not perform downstream trade decisioning or execution. In the wider V
 ### Extend Limen
 
 1. Start with [Reference Architecture](Reference-Architecture.md) and [Built-In SFDs](Built-In-SFDs.md)
-2. Continue to [Advanced Search](Advanced-Search.md) for `SearchStrategy`, `ParamDomain`, `MSQ`, and checkpoints
-3. Continue to [Reducers And Feedback](Reducers-And-Feedback.md) for adaptive interventions
-4. Use [Command Line Interface](Command-Line-Interface.md) when the extension is YAML-first or shell-driven
+2. Continue to [Universal Experiment Loop](Universal-Experiment-Loop.md) for direct engine integration
+3. Continue to [Advanced Search](Advanced-Search.md) for `SearchStrategy`, `ParamDomain`, `MSQ`, and checkpoints
+4. Continue to [Reducers And Feedback](Reducers-And-Feedback.md) for adaptive interventions
 5. Use [Utilities](Utilities.md) for the helper layer rather than the main workflow
 
 ### Contribute or maintain
@@ -60,8 +60,8 @@ Limen does not perform downstream trade decisioning or execution. In the wider V
 1. Data enters through [Historical Data](Historical-Data.md) or compatible external OHLC data.
 2. Data can be reshaped with [Data Bars](Data-Bars.md) when threshold bars are the right research surface.
 3. Indicators, features, transforms, and scalers define the research surface. Targets define supervised labels; calibration adjusts probabilities and thresholds after model output.
-4. An experiment is packaged in an [SFD](Single-File-Decoder.md), starts from [Built-In SFDs](Built-In-SFDs.md) when a packaged decoder fits, and is expressed through an [Experiment Manifest](Experiment-Manifest.md) by default.
-5. [Universal Experiment Loop](Universal-Experiment-Loop.md) executes the search, with [Advanced Search](Advanced-Search.md) and [Reducers And Feedback](Reducers-And-Feedback.md) extending the artifact-backed path.
+4. An experiment is expressed as an [Experiment Manifest](Experiment-Manifest.md) and run through the [Command Line Interface](Command-Line-Interface.md) by default.
+5. [Universal Experiment Loop](Universal-Experiment-Loop.md) is the engine beneath CLI execution; [Single-File Decoder](Single-File-Decoder.md), [Built-In SFDs](Built-In-SFDs.md), [Advanced Search](Advanced-Search.md), and [Reducers And Feedback](Reducers-And-Feedback.md) are the Python extension layer.
 6. [Log](Log.md), [Benchmark](Benchmark.md), and [Backtest](Backtest.md) explain what happened and why.
 7. [Trainer](Trainer.md) turns selected rounds into reusable sensors.
 8. [Cohort](Cohort.md) defines selector-driven ensemble inference for multi-member decoder aggregation.
@@ -70,8 +70,8 @@ Limen does not perform downstream trade decisioning or execution. In the wider V
 ## Docs map
 
 - `Overview`: [Product Home](../README.md), [this docs hub](README.md)
-- `Guides`: [Historical Data](Historical-Data.md), [Data Bars](Data-Bars.md), [Single-File Decoder](Single-File-Decoder.md), [Built-In SFDs](Built-In-SFDs.md), [Experiment Manifest](Experiment-Manifest.md), [Universal Experiment Loop](Universal-Experiment-Loop.md), [Advanced Search](Advanced-Search.md), [Reducers And Feedback](Reducers-And-Feedback.md), [Log](Log.md), [Benchmark](Benchmark.md), [Backtest](Backtest.md), [Trainer](Trainer.md), [Cohort](Cohort.md), [Conserved Flux Renormalization](Conserved-Flux-Renormalization.md)
-- `Reference`: [Indicators](Indicators.md), [Features](Features.md), [Targets](Targets.md), [Transforms](Transforms.md), [Scalers](Scalers.md), [Calibration](Calibration.md), [Standard Metrics Library](Standard-Metrics-Library.md), [Reference Architecture](Reference-Architecture.md), [Utilities](Utilities.md), [Command Line Interface](Command-Line-Interface.md)
+- `Guides`: [Command Line Interface](Command-Line-Interface.md), [Experiment Manifest](Experiment-Manifest.md), [Historical Data](Historical-Data.md), [Data Bars](Data-Bars.md), [Single-File Decoder](Single-File-Decoder.md), [Built-In SFDs](Built-In-SFDs.md), [Universal Experiment Loop](Universal-Experiment-Loop.md), [Advanced Search](Advanced-Search.md), [Reducers And Feedback](Reducers-And-Feedback.md), [Log](Log.md), [Benchmark](Benchmark.md), [Backtest](Backtest.md), [Trainer](Trainer.md), [Cohort](Cohort.md), [Conserved Flux Renormalization](Conserved-Flux-Renormalization.md)
+- `Reference`: [Indicators](Indicators.md), [Features](Features.md), [Targets](Targets.md), [Transforms](Transforms.md), [Scalers](Scalers.md), [Calibration](Calibration.md), [Standard Metrics Library](Standard-Metrics-Library.md), [Reference Architecture](Reference-Architecture.md), [Utilities](Utilities.md)
 - `Developer`: [Developer Guidelines](Developer/README.md), [Documentation System](Developer/Documentation-System.md), [Pruning Strategies](Developer/Pruning-Strategies.md), [Writing Docstrings](Developer/Writing-Docstrings.md), [Contributing Foundational SFDs](Developer/Contributing-Foundational-SFDs.md), [Making Release](Developer/Making-Release.md), [Semantic Versioning](Semantic-Versioning.md), [Technical Debt](TechnicalDebt.md)
 - `Packages`: package `README`s under `/limen` for `data`, `experiment`, `sfd`, `indicators`, `features`, `transforms`, `scalers`, `metrics`, `log`, `cohort`, `backtest`, `utils`, `calibration`, `cli`, `targets`, and `yaml`
 
@@ -96,7 +96,7 @@ Limen does not perform downstream trade decisioning or execution. In the wider V
 
 ## Read next
 
-- For a first real run, continue to [Historical Data](Historical-Data.md), then [Single-File Decoder](Single-File-Decoder.md), then [Universal Experiment Loop](Universal-Experiment-Loop.md)
+- For a first real run, continue to [Command Line Interface](Command-Line-Interface.md), then [Experiment Manifest](Experiment-Manifest.md)
 - For architecture and system boundaries, continue to [Trainer](Trainer.md) and [Cohort](Cohort.md)
 - For the extension layer, continue to [Built-In SFDs](Built-In-SFDs.md), [Reference Architecture](Reference-Architecture.md), and [Advanced Search](Advanced-Search.md)
 - For contributor work, continue to [Developer Guidelines](Developer/README.md)

--- a/docs/Single-File-Decoder.md
+++ b/docs/Single-File-Decoder.md
@@ -1,8 +1,8 @@
 # Single file decoder
 
-A Single File Decoder (SFD) is the unit of experiment definition in Limen. It is a Python module that packages the parameter space together with either a declarative manifest or fully custom preparation and model functions.
+A Single File Decoder (SFD) is the Python experiment unit beneath Limen's YAML and CLI path. It packages a parameter space together with either a declarative manifest or fully custom preparation and model functions.
 
-`UniversalExperimentLoop` turns an SFD module into a parameter sweep.
+`limen run` compiles YAML into a manifest-backed SFD and passes it to `UniversalExperimentLoop`. Direct SFD authoring is the extension path for custom decoders and model code.
 
 ## Choose the SFD style
 
@@ -89,12 +89,12 @@ This style is how Limen's foundational SFDs are built.
 
 - declarative data fetching
 - split-first prep with train-only fitting
-- automatic prep/model wiring inside `UniversalExperimentLoop`
+- automatic prep/model wiring inside the CLI-backed UEL engine
 - reproducible collaboration surface
 
 ### Runtime rules for manifest-driven SFDs
 
-- `UniversalExperimentLoop.run(prep_each_round=True)` is required
+- `limen run` sets `prep_each_round` from YAML; direct `UniversalExperimentLoop.run(prep_each_round=True)` is required
 - `prep` and `model` cannot be overridden in `run()`
 - when `data=` is omitted, Limen fetches data from the manifest
 
@@ -206,8 +206,9 @@ Use [Built-In SFDs](Built-In-SFDs.md) for the current shipped catalog and [Refer
 
 ## Read next
 
-- Continue to [Built-In SFDs](Built-In-SFDs.md) for the shipped foundational decoder catalog.
+- Continue to [Command Line Interface](Command-Line-Interface.md) for the normal YAML run path.
 - Continue to [Experiment Manifest](Experiment-Manifest.md) for the full declarative pipeline used by standard SFDs.
-- Continue to [Universal Experiment Loop](Universal-Experiment-Loop.md) to run an SFD.
+- Continue to [Built-In SFDs](Built-In-SFDs.md) for the shipped foundational decoder catalog.
+- Continue to [Universal Experiment Loop](Universal-Experiment-Loop.md) for direct Python execution.
 - Continue to [Reference Architecture](Reference-Architecture.md) for model implementation authoring beyond packaged decoders.
 - Use [Indicators](Indicators.md), [Features](Features.md), [Transforms](Transforms.md), and [Scalers](Scalers.md) as the reference layer while authoring new SFDs.

--- a/docs/Trainer.md
+++ b/docs/Trainer.md
@@ -6,7 +6,7 @@ Trainer bridges a selected experiment row and a trained model object for downstr
 
 ## What Trainer needs
 
-Trainer works only with experiments that were run through the artifact-backed UEL path and wrote an `experiment_dir`.
+Trainer works only with YAML-based artifact directories, normally created by `limen run`, that include the metadata needed to reconstruct the manifest.
 
 At minimum, the directory must contain:
 
@@ -17,8 +17,8 @@ If `results.csv` is also present, Trainer validates the retrained metrics agains
 
 ## Prerequisites
 
-- the experiment must have been created with `experiment_dir='experiments/logreg-first'`
-- the experiment must be YAML-based (created via `limen run`)
+- the experiment must have a result directory created by `limen run`
+- the experiment must be YAML-based and include `metadata.json["yaml_reference"]`
 - the SFD must be a manifest-driven ML architecture (rule-based architectures are not supported)
 
 ## Workflow
@@ -208,15 +208,15 @@ Trainer uses:
 
 ## Scope note
 
-Trainer depends on the artifact-backed UEL path, which in turn depends on a concrete `SearchStrategy`. Limen ships built-in strategies (`GridStrategy`, `RandomStrategy`) and the `SearchStrategy` abstraction for custom strategies.
+Trainer depends on the artifact-backed YAML run path, which uses UEL with a concrete `SearchStrategy`. Limen ships built-in strategies (`GridStrategy`, `RandomStrategy`) and the `SearchStrategy` abstraction for custom strategies.
 
 The operating model is:
 
-- UEL artifact-backed runs create the promotion-ready experiment directory
+- `limen run` creates the promotion-ready experiment directory
 - Trainer turns selected rounds from that directory into sensors
 
 ## Read next
 
 - Continue to [Reference Architecture](Reference-Architecture.md) for the class-based model contract that Trainer reconstructs and retrains.
 - Continue to [Cohort](Cohort.md) to bind selected sensors into an ensemble inference surface.
-- Continue to [Universal Experiment Loop](Universal-Experiment-Loop.md) for the run layer that produces `experiment_dir`.
+- Continue to [Command Line Interface](Command-Line-Interface.md) for the YAML run layer that produces result directories.

--- a/docs/Universal-Experiment-Loop.md
+++ b/docs/Universal-Experiment-Loop.md
@@ -1,28 +1,41 @@
 # Universal experiment loop
 
-The Universal Experiment Loop (UEL) is Limen's experiment runner. It takes an SFD, executes parameter combinations, streams a CSV log, and then exposes post-run analysis surfaces such as confusion metrics and backtest results.
+The Universal Experiment Loop (UEL) is Limen's execution engine. The normal operator path reaches it through `limen run`: YAML is validated, compiled into a manifest-backed SFD, executed by UEL, and written to a result directory.
 
 This page covers:
 
-- how to run a first experiment
-- what `UniversalExperimentLoop` actually stores after a run
-- when to use the standard run path versus the advanced artifact-backed path
-- which run-time rules matter for manifest-driven and custom SFDs
+- how CLI execution maps to UEL
+- what `UniversalExperimentLoop` stores after a direct Python run
+- when to use direct standard UEL versus the artifact-backed path
+- which runtime rules matter for manifest-driven and custom SFDs
 
-## Two execution modes
+## Preferred execution path
 
-UEL currently has two execution modes.
+Start with CLI unless you are extending the engine directly:
+
+```bash
+limen validate logreg-first.yaml
+limen profile logreg-first.yaml
+limen run --dry-run logreg-first.yaml
+limen run logreg-first.yaml
+```
+
+`limen run` constructs UEL with a compiled SFD, a concrete search strategy, an `experiment_dir`, and the parsed YAML stored as `yaml_reference` in `metadata.json`. The result directory contains the copied manifest, `metadata.json`, `results.csv`, and `round_data.jsonl`.
+
+## Direct Python execution modes
+
+Direct UEL integration currently has two execution modes.
 
 | Mode | Entry path | Fits | Outputs |
 |---|---|---|---|
-| standard run path | instantiate with `sfd=` and optionally `data=`, then call `run()` without a `search_strategy` | public examples and direct sweeps | in-memory UEL artifacts plus a streaming CSV at `<experiment_name>.csv`, or `<experiment_dir>/<experiment_name>.csv` when `experiment_dir` is set |
-| MSQ / artifact-backed path | instantiate with a concrete `search_strategy`, optionally `experiment_dir`, then call `run()` | advanced search flows, checkpointing, resumability, trainer workflows | `results.csv`, `round_data.jsonl`, checkpoints, audit trail, metadata, and in-memory UEL artifacts |
+| standard run path | instantiate with `sfd=` and optionally `data=`, then call `run()` without a `search_strategy` | custom local sweeps and Python examples | in-memory UEL artifacts plus a streaming CSV at `<experiment_name>.csv`, or `<experiment_dir>/<experiment_name>.csv` when `experiment_dir` is set |
+| MSQ / artifact-backed path | instantiate with a concrete `search_strategy`, optionally `experiment_dir`, then call `run()` | advanced search flows, checkpointing, resumability, trainer workflows, and the CLI YAML path | `results.csv`, `round_data.jsonl`, checkpoints, audit trail, metadata, and in-memory UEL artifacts |
 
-The standard run path is the starting point for public examples and direct sweeps. The advanced path is supported and extension-oriented through `SearchStrategy`.
+The standard run path is for direct Python work. The artifact-backed path is the durable engine path used by CLI YAML runs and advanced search.
 
-## First real run
+## Direct standard run
 
-This local example uses the file-backed spot-kline path with explicit `kline_size` and `row_count_limit`.
+This local Python example uses the file-backed spot-kline path with explicit `kline_size` and `row_count_limit`.
 
 ```python
 import limen
@@ -41,10 +54,11 @@ uel.run(
     n_permutations=4,
     prep_each_round=True,
     random_search=False,
+    post_processing=True,
 )
 ```
 
-After the run, these attributes are available:
+With `post_processing=True`, these attributes are available:
 
 ```python
 uel.experiment_log
@@ -52,7 +66,9 @@ uel.experiment_confusion_metrics
 uel.experiment_backtest_results
 ```
 
-On a live local run over that file-backed input, that produced:
+Without `post_processing=True`, standard UEL still writes `uel.experiment_log`, but `uel._log`, `uel.experiment_confusion_metrics`, and `uel.experiment_backtest_results` remain unset.
+
+On a live local run over that file-backed input with post-processing enabled, that produced:
 
 - `uel.experiment_log` with one row per round
 - `uel.experiment_confusion_metrics` with one row per round
@@ -180,9 +196,8 @@ and keeps the full run state in memory on the `uel` object.
 
 This is the path to use for:
 
-- first experiments
-- docs examples
 - direct local research loops
+- custom Python examples
 - direct parameter sweeps
 
 ### Artifact-backed path

--- a/limen/cli/README.md
+++ b/limen/cli/README.md
@@ -10,7 +10,7 @@
 
 ## What this package owns
 
-Owns command parsing and command-specific orchestration around YAML manifests.
+Owns the preferred operator path for YAML manifests: scaffold, validate, profile, dry-run, run, resume, and manage committed manifests.
 Does **not** own manifest semantics, experiment execution internals, model behavior, or docs-site build behavior.
 
 ## Key entry points
@@ -53,7 +53,9 @@ cli/
 ## Things to know
 
 - `limen profile` is static for validated CLI YAML because YAML manifests reject `test_data_source`.
+- The normal first-run loop is `limen init`, `limen validate`, `limen profile`, `limen run --dry-run`, then `limen run`.
 - `limen run` accepts both direct YAML files and committed `manifest://sha256:` URIs.
+- `limen run` writes a result directory containing the copied manifest, `metadata.json`, `results.csv`, and `round_data.jsonl`.
 - `limen commit` writes the project manifest store before attempting the git commit.
 - Command code should stay thin; YAML semantics belong in `limen.yaml` and execution semantics belong in `limen.experiment`.
 

--- a/limen/cohort/README.md
+++ b/limen/cohort/README.md
@@ -50,8 +50,9 @@ cohort/
 - Infer aggregation mode from architecture capability:
   - `probability_weighted` when probability output is supported
   - `majority_vote` fallback otherwise
-- `predict(raw_klines)` returns ndarray/tuple contract
-- `__call__(raw_klines)` returns decoder-compatible dict contract
+- `predict(raw_klines)` returns one `BarPrediction` for the last bar
+- `predict_all(raw_klines)` returns `list[BarPrediction]`
+- `__call__(raw_klines)` aliases `predict_all(raw_klines)`
 
 See [Cohort](../../docs/Cohort.md) for full contract and examples.
 

--- a/limen/yaml/README.md
+++ b/limen/yaml/README.md
@@ -10,7 +10,7 @@
 
 ## What this package owns
 
-Owns YAML schema constants, parsing, validation, object resolution, manifest compilation, profiling, and committed-manifest lookup.
+Owns the declarative manifest surface behind the preferred CLI path: YAML schema constants, parsing, validation, object resolution, manifest compilation, profiling, and committed-manifest lookup.
 Does **not** own Click command routing, UEL execution, model implementations, or feature/target business logic.
 
 ## Key entry points
@@ -51,6 +51,7 @@ yaml/
 ## Things to know
 
 - `schema_version` is currently `1.0`.
+- YAML manifests are the canonical operator-facing experiment definition; Python builders are the extension-equivalent surface.
 - YAML validation rejects `sfd.manifest.test_data_source`; runtime date limits come from `split_dates`.
 - The resolver only treats `limen.*` references as supported dotted references.
 - Store functions back `limen commit`, `limen ls`, and committed-manifest URI runs.


### PR DESCRIPTION
## Summary
- make README and docs hub lead with YAML manifest plus CLI execution
- reframe Manifest, CLI, UEL, SFD, advanced search, Trainer, and Cohort docs around the operator path
- align package READMEs and replace stale Cohort ndarray/dict wording with BarPrediction contract
- clarify direct UEL post-processing behavior for #615

## Proof
- README CLI command assertion: True
- docs hub CLI-before-SFD assertion: True
- manifest YAML-before-MLManifest assertion: True
- UEL CLI engine assertion: True
- Cohort README contract assertion: True
- `cd docs-site && npm run check`: passed

Closes #617
Closes #616
Fixes #615